### PR TITLE
Implements an option for user to force website favicon

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,9 @@ export default {
     Header,
     Footer,
   },
+  provide: {
+    config: conf,
+  },
   data: () => ({
     // pageInfo: this.getPageInfo(conf.pageInfo),
     showFooter: Defaults.visibleComponents.footer,

--- a/src/components/LinkItems/ItemIcon.vue
+++ b/src/components/LinkItems/ItemIcon.vue
@@ -11,6 +11,7 @@
 <script>
 import BrokenImage from '@/assets/interface-icons/broken-icon.svg';
 import ErrorHandler from '@/utils/ErrorHandler';
+import { iconOptions } from '@/utils/defaults';
 
 export default {
   name: 'Icon',
@@ -30,6 +31,7 @@ export default {
       return this.getIconPath(this.icon, this.url);
     },
   },
+  inject: ['config'],
   data() {
     return {
       broken: false,
@@ -51,11 +53,15 @@ export default {
     },
     /* Get favicon URL, for items which use the favicon as their icon */
     getFavicon(fullUrl) {
+      const userHatesGoogle = this.config.appConfig // User specified don't use Google favicon API
+        ? !!this.config.appConfig.forceRootFavicon : iconOptions.forceRootFavicon;
       const isLocalIP = /(127\.)|(192\.168\.)|(10\.)|(172\.1[6-9]\.)|(172\.2[0-9]\.)|(172\.3[0-1]\.)|(::1$)|([fF][cCdD])|(localhost)/;
-      if (isLocalIP.test(fullUrl)) { // Check if using a local IP format or localhost
+      if (isLocalIP.test(fullUrl) || userHatesGoogle) { // If using local service, or hates google
+        const favicon = this.config.appConfig // Favicon name (usually /favicon.ico)
+          ? this.config.appConfig.itemFaviconLocation : iconOptions.itemFaviconLocation;
         const urlParts = fullUrl.split('/');
         // For locally running services, use the default path for favicon
-        if (urlParts.length >= 2) return `${urlParts[0]}/${urlParts[1]}/${urlParts[2]}/favicon.ico`;
+        if (urlParts.length >= 2) return `${urlParts[0]}/${urlParts[1]}/${urlParts[2]}/${favicon}`;
       } else if (fullUrl.includes('http')) {
         // For publicly accessible sites, a more reliable method is using Google's API
         return `https://s2.googleusercontent.com/s2/favicons?domain=${fullUrl}`;

--- a/src/utils/ConfigSchema.js
+++ b/src/utils/ConfigSchema.js
@@ -89,6 +89,16 @@ module.exports = {
           type: 'string',
           description: 'Any custom CSS overides, must be minified',
         },
+        forceRootFavicon: {
+          type: 'boolean',
+          default: false,
+          description: 'When fetching favicon, always use websites icon and not Google API',
+        },
+        itemFaviconLocation: {
+          type: 'string',
+          default: '/favicon.ico',
+          description: 'The path to look for website favicons',
+        },
       },
       additionalProperties: false,
     },

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -13,6 +13,10 @@ module.exports = {
   layout: 'auto',
   theme: 'default',
   fontAwesomeKey: '0821c65656',
+  iconOptions: {
+    forceRootFavicon: false,
+    itemFaviconLocation: '/favicon.ico',
+  },
   builtInThemes: [
     'callisto',
     'thebe',


### PR DESCRIPTION

This PR introduces two new properties in the config file, under `appConfig`:
```yaml
appConfig:
  forceRootFavicon: true
  itemFaviconLocation: /favicon.ico
```

- `forceRootFavicon` - Boolean, optional, defaults to `false`. When set to `true` favicons will be fetched from a website source, no matter of their source.
- `itemFaviconLocation` - String, optional, defaults to `/favicon.ico`. Can be used to specify a custom path to an icon, e.g. `/assets/pwa-192x192.png`

---

This PR is a fix the the issue raised in #14 - When an `item`'s  `icon` is set to `favicon`, the asset will be resolved using Google API's if the URL is a remote website, or using `/favicon.ico` if it is a locally hosted service accessible via IP address. The issue is that when a local service has a domain name, the Google method will be used, resulting in a 404. Not to mention, many users will not be comfortable with requests being sent to Google. 



