### PR TITLE
fix: update link in footer with new repo name

### DIFF
--- a/src/components/PageStrcture/Footer.vue
+++ b/src/components/PageStrcture/Footer.vue
@@ -20,7 +20,7 @@ export default {
     licenseUrl: { type: String, default: 'https://gist.github.com/Lissy93/143d2ee01ccc5c052a17' },
     date: { type: String, default: `${new Date().getFullYear()}` },
     showCopyright: { type: Boolean, default: true },
-    repoUrl: { type: String, default: 'https://github.com/lissy93/panel' },
+    repoUrl: { type: String, default: 'https://github.com/lissy93/dashy' },
     text: String,
   },
 };


### PR DESCRIPTION
**Please check the type of change your PR introduces**:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

**Issue Number** (if applicable):

None

**Briefly outline your changes**:

The footer link to viewing the source code sends users to the wrong repository. This repo must've been named "panel" in a past life, but now it is "dashy". This resolves the issue.

**Before submitting, please ensure that**:
- [x] Must be backwards compatible
- [x] All lint checks and tests must pass
- [x] If a new option in the the config file is added, it needs to be added into the schema, and documented in the configuring guide
- [x] If a new dependency is required, it must be essential, and it must be thoroughly checked out for security or efficiency issues
