### PR TITLE
Enables the user to add raw HTML and inline CSS into the footer, Re: #28

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -29,7 +29,7 @@ All fields are optional, unless otherwise stated.
 **`title`** | `string` |  Required | Your dashboard title, displayed in the header and browser tab
 **`description`** | `string` | _Optional_ | Description of your dashboard, also displayed as a subtitle
 **`navLinks`** | `array` | _Optional_ | Optional list of a maximum of 6 links, which will be displayed in the navigation bar. See [`navLinks`](#pageinfonavlinks-optional)
-**`footerText`** | `string` | _Optional_ | Text to display in the footer (note that this will override the default footer content)
+**`footerText`** | `string` | _Optional_ | Text to display in the footer (note that this will override the default footer content). This can also include HTML and inline CSS
 
 #### `pageInfo.navLinks` _(optional)_
 

--- a/src/components/PageStrcture/Footer.vue
+++ b/src/components/PageStrcture/Footer.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- User Footer -->
-  <footer v-if="text && text !== ''">{{text}}</footer>
+  <footer v-if="text && text !== ''" v-html="text"></footer>
   <!-- Default Footer -->
   <footer v-else>
       Developed by <a :href="authorUrl">{{authorName}}</a>.
@@ -14,6 +14,7 @@
 export default {
   name: 'Footer',
   props: {
+    text: String,
     authorName: { type: String, default: 'Alicia Sykes' },
     authorUrl: { type: String, default: 'https://aliciasykes.com' },
     license: { type: String, default: 'MIT' },
@@ -21,7 +22,6 @@ export default {
     date: { type: String, default: `${new Date().getFullYear()}` },
     showCopyright: { type: Boolean, default: true },
     repoUrl: { type: String, default: 'https://github.com/lissy93/dashy' },
-    text: String,
   },
 };
 </script>


### PR DESCRIPTION
**Please check the type of change your PR introduces**:
- Feature

**Issue Number** (if applicable): #28

**Briefly outline your changes**: Enables user to have HTML and inline styles rendered in the footer. Uses `v-html`.
Example usage:
```yaml
pageInfo:
  title: Dashy
  footerText: '<div style="text-align: left;"><h1 style="color: blue;">HTML Footer Example</h1><ul><li>Bullet 1</li><li>Bullet 2</li></ul></div>'
```

**Before submitting, please ensure that**:
- [X] Must be backwards compatible
- [X] All lint checks and tests must pass
- [X] If a new option in the the config file is added, it needs to be added into the schema, and documented in the configuring guide
- [X] If a new dependency is required, it must be essential, and it must be thoroughly checked out for security or efficiency issues
