### PR TITLE
[BUG-FIX] Status check tooltip visibility, Re: #39

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -116,6 +116,8 @@ You can target specific elements on the UI with these variables. All are optiona
 - `--welcome-popup-text-color` - Text color for the welcome pop-up. Defaults to `--primary`
 - `--side-bar-background` - Background color of the sidebar used in the workspace view. Defaults to `--background-darker`
 - `--side-bar-color` - Color of icons and text within the sidebar. Defaults to `--primary`
+- `--status-check-tooltip-background` - Background color for status check tooltips. Defaults to `--background-darker`
+- `--status-check-tooltip-color` - Text color for the status check tooltips. Defaults to `--primary`
 
 #### Non-Color Variables
 - `--outline-color` - Used to outline focused or selected elements

--- a/src/components/LinkItems/Item.vue
+++ b/src/components/LinkItems/Item.vue
@@ -101,6 +101,7 @@ export default {
         html: false,
         placement: this.statusResponse ? 'left' : 'auto',
         delay: { show: 600, hide: 200 },
+        classes: 'item-description-tooltip',
       };
     },
     /* Used by certain themes, which display an icon with animated CSS */

--- a/src/components/LinkItems/StatusIndicator.vue
+++ b/src/components/LinkItems/StatusIndicator.vue
@@ -112,7 +112,8 @@ export default {
 
 <style lang="scss">
 .status-tooltip {
-  background: var(--background-darker) !important;
+  background: var(--status-check-tooltip-background) !important;
+  color: var(--status-check-tooltip-color) !important;
   font-size: 1rem;
   z-index: 10;
   &.tip-green { border: 1px solid var(--success); }

--- a/src/styles/color-palette.scss
+++ b/src/styles/color-palette.scss
@@ -74,4 +74,6 @@
   --side-bar-background: var(--background-darker);
   --side-bar-background-lighter: var(--background);
   --side-bar-color: var(--primary);
+  --status-check-tooltip-background: var(--background-darker);
+  --status-check-tooltip-color: var(--primary);
 }

--- a/src/styles/color-themes.scss
+++ b/src/styles/color-themes.scss
@@ -175,6 +175,8 @@ html[data-theme='material-original'] {
   --config-settings-background: #01579b;
   --config-settings-color: #fff;
   --heading-text-color: #fff;
+  --status-check-tooltip-background: #f2f2f2;
+  --status-check-tooltip-color: #01579b;
 }
 
 html[data-theme='material-dark-original'] {
@@ -208,6 +210,8 @@ html[data-theme='material-dark-original'] {
   --config-settings-color: #41e2ed;
   --scroll-bar-color: #08B0BB;
   --scroll-bar-background: #131a1f;
+  --status-check-tooltip-background: #131a1f;
+  --status-check-tooltip-color: #08B0BB;
   &::-webkit-scrollbar-thumb {
     border-left: 1px solid #131a1f;
   }
@@ -331,7 +335,7 @@ html[data-theme='material'], html[data-theme='material-dark'] {
       }
     }
   }
-  .tooltip {
+  .tooltip.item-description-tooltip {
     display: none !important;
   }
   .orientation-horizontal {
@@ -498,6 +502,8 @@ html[data-theme='material-dark'] {
   --config-settings-color: #41e2ed;
   --scroll-bar-color: #08B0BB;
   --scroll-bar-background: #131a1f;
+  --status-check-tooltip-color: #131a1f;
+
   &::-webkit-scrollbar-thumb {
     border-left: 1px solid #131a1f;
   }
@@ -527,6 +533,8 @@ html[data-theme='minimal-light'] {
   --search-container-background: #fff;
   --curve-factor: 4px;
   --curve-factor-navbar: 8px;
+  --status-check-tooltip-background: #f2f2f2;
+  --status-check-tooltip-color: #000;
 
   section.filter-container {
     background: #fff;


### PR DESCRIPTION
**Please check the type of change your PR introduces**:
- Bugfix

**Issue Number** (if applicable): #39 

**Briefly outline your changes**:
The tooltips for status indicators were not visible in some themes. Fixed it by adding custom CSS variable so that themes can target the element correctly, and also added a class name so that the Material theme did not set `display: none` to the status indicator tooltip.

**Before submitting, please ensure that**:
- [X] Must be backwards compatible
- [X] All lint checks and tests must pass
- [X] If a new option in the the config file is added, it needs to be added into the schema, and documented in the configuring guide
- [X] If a new dependency is required, it must be essential, and it must be thoroughly checked out for security or efficiency issues
