### PR TITLE
[BUG-FIX] Removes duplicate Environment tag from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,20 +3,19 @@
 version: "3.8"
 services:
   dashy:
-    # Set any environmental variables
-    environment:
-      NODE_ENV: production
     # To build from source, replace 'image: lissy93/dashy' with 'build: .'
-    # build: .
-    image: lissy93/dashy
+    build: .
+    # image: lissy93/dashy
     container_name: Dashy
     # Pass in your config file below, by specifying the path on your host machine
     # volumes:
       # - /root/my-config.yml:/app/public/conf.yml
     ports:
       - 4000:80
+    # Set any environmental variables
+    environment:
+    - NODE_ENV=production
     # Specify your user ID and group ID. You can find this by running `id -u` and `id -g`
-    # environment:
     #  - UID=1000
     #  - GID=1000
     # Specify restart policy


### PR DESCRIPTION
**Please check the type of change your PR introduces**:
- [X] Bugfix

**Issue Number** (if applicable): #48

**Briefly outline your changes**: There was a duplicate identifier, `environment` in the [`docker-compose.yml`](https://github.com/Lissy93/dashy/blob/master/docker-compose.yml#L19) file, as pointed out by @EVOTk in #48. This PR applies his suggestions, removing the duplicate key.

**Before submitting, please ensure that**:
- [X] Must be backwards compatible
- [X] All lint checks and tests must pass
- [X] If a new option in the the config file is added, it needs to be added into the schema, and documented in the configuring guide
- [X] If a new dependency is required, it must be essential, and it must be thoroughly checked out for security or efficiency issues
