### PR TITLE
:bug: Re #41: Fixes small UI issue on tile-title

### DIFF
--- a/src/components/LinkItems/Item.vue
+++ b/src/components/LinkItems/Item.vue
@@ -223,6 +223,8 @@ export default {
     .tile-title {
       height: fit-content;
       min-height: 1.2rem;
+      text-align: left;
+      max-width:140px;
       span.text {
         text-align: left;
         padding-left: 10%;


### PR DESCRIPTION
#### Category
- Bugfix


#### Overview
Fixes text alignment on tile title when in small mode.
Sets text-align and max-width on the small tiles. Thanks to @m4x91

**Issue Number**: #41

**New Vars**: N/A

#### Screenshot
<img width="300" src="https://user-images.githubusercontent.com/1862727/123260446-79c19700-d4ed-11eb-9f93-f2745dba43c8.png" />


#### Code Quality Checklist _(Please complete)_
- [X] All changes are backwards compatible
- [X] All lint checks and tests are passing
- [X] There are no (new) build warnings or errors
- [X] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [X] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance

