### PR TITLE
[FIX] Text overflows when language is very long

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 🩹 1.5.1 - UI Quick Fix [PR #116](https://github.com/Lissy93/dashy/pull/116)
+- Fixes #115 - Some longer languages (e.g. French) cause text to break to the next line
+
 ## 🔒 1.5.0 - Improve Robustness of Auth [PR #113](https://github.com/Lissy93/dashy/pull/113)
 - Use both username + password for generating token, so that a change in either will log the user out
 - Prevent privilege escalation by disallowing a user from modifying their user type through the UI

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Dashy",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "main": "server",
   "scripts": {

--- a/src/components/Configuration/ConfigContainer.vue
+++ b/src/components/Configuration/ConfigContainer.vue
@@ -217,7 +217,8 @@ a.config-button, button.config-button {
   text-decoration: none;
   cursor: pointer;
   margin: 0.5rem auto;
-  width: 18rem;
+  min-width: 18rem;
+  width: 100%;
   svg.button-icon {
     path {
       fill: var(--config-settings-color);
@@ -234,6 +235,13 @@ a.config-button, button.config-button {
       fill: var(--config-settings-background);
     }
   }
+}
+
+a.hyperlink-wrapper {
+  margin: 0 auto;
+  text-decoration: none;
+  min-width: 18rem;
+  width: 100%;
 }
 
 p.app-version, p.language {
@@ -296,17 +304,14 @@ div.code-container {
   }
 }
 
-a.hyperlink-wrapper {
-  margin: 0 auto;
-  text-decoration: none;
-}
-
 .main-options-container {
   display: flex;
   flex-direction: column;
-  padding-top: 2rem;
   background: var(--config-settings-background);
   height: calc(100% - 2rem);
+  width: fit-content;
+  margin: 0 auto;
+  padding: 2rem 0.5rem;
   h2 {
     margin: 0 auto 1rem auto;
     color: var(--config-settings-color);

--- a/src/components/Configuration/ConfigContainer.vue
+++ b/src/components/Configuration/ConfigContainer.vue
@@ -308,10 +308,10 @@ div.code-container {
   display: flex;
   flex-direction: column;
   background: var(--config-settings-background);
-  height: calc(100% - 2rem);
+  height: calc(100% - 4rem);
   width: fit-content;
   margin: 0 auto;
-  padding: 2rem 0.5rem;
+  padding: 2rem 1rem;
   h2 {
     margin: 0 auto 1rem auto;
     color: var(--config-settings-color);


### PR DESCRIPTION
**Category**:   Minor / UI Bugfix

**Overview**
With some languages (e.g. French) the text is considerably longer. This caused issues with text wrapping onto the next line of the config container's buttons, which didn't look very neat. This PR fixes this, by making the width of the button equal to that of the longest line of text.

**Issue Number** #115

**New Vars** N/A

**Screenshot** 
![image](https://user-images.githubusercontent.com/1862727/128243804-03730022-e882-4303-842c-5acaaf3ba59b.png)


**Code Quality Checklist** _(Please complete)_
- [X] All changes are backwards compatible
- [X] All lint checks and tests are passing
- [X] There are no (new) build warnings or errors
- [X] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [X] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [X] Bumps version, if new feature added

