### PR TITLE
Fix simple icons color fill

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "remedial": "^1.0.8",
     "rsup-progress": "^2.0.4",
     "serve-static": "^1.14.1",
+    "simple-icons": "^5.12.0",
     "v-jsoneditor": "^1.4.2",
     "v-tooltip": "^2.1.3",
     "vue": "^2.6.10",

--- a/src/components/LinkItems/ItemIcon.vue
+++ b/src/components/LinkItems/ItemIcon.vue
@@ -7,8 +7,9 @@
     <!-- Material Design Icon -->
     <span v-else-if="iconType === 'mdi'"  :class=" `mdi ${icon} ${size}`"></span>
     <!-- Simple-Icons -->
-    <object v-else-if="iconType === 'si'" :class="`simple-icons ${size}`"
-      type="image/svg+xml" :data="getSimpleIcon(icon)"></object>
+    <svg v-else-if="iconType === 'si'" :class="`simple-icons ${size}`" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path :d="getSimpleIcon(icon)" />
+    </svg>
     <!-- Standard image asset icon -->
     <img v-else-if="icon" :src="iconPath" @error="imageNotFound"
       :class="`tile-icon ${size} ${broken ? 'broken' : ''}`"
@@ -24,6 +25,8 @@ import ErrorHandler from '@/utils/ErrorHandler';
 import { faviconApi as defaultFaviconApi, faviconApiEndpoints, iconCdns } from '@/utils/defaults';
 import EmojiUnicodeRegex from '@/utils/EmojiUnicodeRegex';
 import emojiLookup from '@/utils/emojis.json';
+
+const simpleIcons = require('simple-icons');
 
 export default {
   name: 'Icon',
@@ -113,10 +116,11 @@ export default {
     getGenerativeIcon(url) {
       return `${iconCdns.generative}/${this.getHostName(url)}.svg`;
     },
-    /* Formats the URL for getting Simple-Icons SVG asset */
+    /* Returns the SVG path content  */
     getSimpleIcon(img) {
       const imageName = img.replace('si-', '');
-      return `${iconCdns.si}/${imageName}.svg`;
+      const icon = simpleIcons.Get(imageName);
+      return icon.path;
     },
     /* Checks if the icon is from a local image, remote URL, SVG or font-awesome */
     getIconPath(img, url) {
@@ -198,10 +202,14 @@ export default {
     }
   }
   /* Simple Icons */
-  object.simple-icons {
+  .item-icon .simple-icons {
     width: 2rem;
     &.small { width: 1.5rem; }
     &.large { width: 2.5rem; }
+  }
+
+  .item-icon .simple-icons path {
+    fill: currentColor;
   }
   /* Emoji Icons */
   i.emoji-icon {

--- a/src/components/LinkItems/ItemIcon.vue
+++ b/src/components/LinkItems/ItemIcon.vue
@@ -20,13 +20,12 @@
 </template>
 
 <script>
+import simpleIcons from 'simple-icons';
 import BrokenImage from '@/assets/interface-icons/broken-icon.svg';
 import ErrorHandler from '@/utils/ErrorHandler';
 import { faviconApi as defaultFaviconApi, faviconApiEndpoints, iconCdns } from '@/utils/defaults';
 import EmojiUnicodeRegex from '@/utils/EmojiUnicodeRegex';
 import emojiLookup from '@/utils/emojis.json';
-
-const simpleIcons = require('simple-icons');
 
 export default {
   name: 'Icon',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8667,6 +8667,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
+simple-icons@^5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/simple-icons/-/simple-icons-5.12.0.tgz#8f514005f1aef02464a014706cc8e5b07d4d72c8"
+  integrity sha512-iF5ZJuv/jPU2tdkc5aNXsirQg2kOggvcOUw2kMafCrelrr3Sj0ywRJkr+0uVniD1Kj6ayT1yb1IquBRHrYw10g==
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"


### PR DESCRIPTION
![dangilbert /master → Lissy93/dashy](https://badgen.net/badge/%23194/dangilbert%20%2Fmaster%20%E2%86%92%20Lissy93%2Fdashy/ab5afc) ![Commits: 2 | Files Changed: 3 | Additions: 13](https://badgen.net/badge/New%20Code/Commits%3A%202%20%7C%20Files%20Changed%3A%203%20%7C%20Additions%3A%2013/dddd00) ![dangilbert](https://badgen.net/badge/Submitted%20by/dangilbert/fc7bf1) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Lissy93&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: 
One of: Bugfix

**Overview**
I was having problems with the SimpleIcons applying a color tint because the icons being loaded as SVGs via URL were wrapped in an `object` thus not allowing css styling to apply.

By including the node package for `simple-icons` we can directly access the `SVG` and `PATH` in order to be able to set the `fill` to `currentColor`

**New Vars** _(if applicable)_
Dependency added on `simple-icons:^5.12.0`

**Screenshot** _(if applicable)_
Before:
<img width="358" alt="Screenshot 2021-08-31 at 13 03 51" src="https://user-images.githubusercontent.com/6799566/131491793-ccbfa1f5-0051-4fe0-b671-95a0acd71a8a.png">
After:
<img width="342" alt="Screenshot 2021-08-31 at 13 03 55" src="https://user-images.githubusercontent.com/6799566/131491801-a707d415-604f-4708-a1ce-7947269a2d99.png">


**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [x] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] Bumps version, if new feature added