### PR TITLE
[FIX] Don't remember collapse state, when specified in config

### DIFF
--- a/src/components/LinkItems/Collapsable.vue
+++ b/src/components/LinkItems/Collapsable.vue
@@ -1,14 +1,15 @@
 <template>
-  <div :class="`collapsable ${checkSpanNum(cols, 'col')} ${checkSpanNum(rows, 'row')}`"
+  <div
+    :class="`collapsable ${checkSpanNum(cols, 'col')} ${checkSpanNum(rows, 'row')}`"
     :style="`${color ? 'background: '+color : ''}; ${sanitizeCustomStyles(customStyles)};`"
   >
     <input
-        :id="`collapsible-${uniqueKey}`"
-        class="toggle"
-        type="checkbox"
-        :checked="getCollapseState()"
-        @change="collapseChanged"
-        tabIndex="-1"
+      :id="`collapsible-${uniqueKey}`"
+      class="toggle"
+      type="checkbox"
+      :checked="getCollapseState()"
+      @change="collapseChanged"
+      tabIndex="-1"
     >
     <label :for="`collapsible-${uniqueKey}`" class="lbl-toggle" tabindex="-1">
       <Icon v-if="icon" :icon="icon" size="small" :url="title" class="section-icon" />
@@ -30,14 +31,14 @@ import Icon from '@/components/LinkItems/ItemIcon.vue';
 export default {
   name: 'CollapsableContainer',
   props: {
-    uniqueKey: String,
-    title: String,
-    icon: String,
-    collapsed: Boolean,
-    cols: Number,
-    rows: Number,
-    color: String,
-    customStyles: String,
+    uniqueKey: String, // Generated unique ID
+    title: String, // The section title
+    icon: String, // An optional section icon
+    collapsed: Boolean, // Optional override collapse state
+    cols: Number, // Set section horizontal col span / width
+    rows: Number, // Set section vertical row span / height
+    color: String, // Optional color override
+    customStyles: String, // Optional custom stylings
   },
   components: {
     Icon,
@@ -45,7 +46,7 @@ export default {
   methods: {
     /* Check that row & column span is valid, and not over the max */
     checkSpanNum(span, classPrefix) {
-      const maxSpan = 8;
+      const maxSpan = 5;
       let numSpan = /^\d*$/.test(span) ? parseInt(span, 10) : 1;
       numSpan = (numSpan > maxSpan) ? maxSpan : numSpan;
       return `${classPrefix}-${numSpan}`;
@@ -78,6 +79,7 @@ export default {
       }
       return collapseState;
     },
+    /* When section collapsed, update local storage, to remember for next time */
     setCollapseState(id, newState) {
       // Get the current localstorage collapse state object
       const collapseState = JSON.parse(localStorage[localStorageKeys.COLLAPSE_STATE]);
@@ -86,9 +88,12 @@ export default {
       // Stringify, and set the new object into local storage
       localStorage.setItem(localStorageKeys.COLLAPSE_STATE, JSON.stringify(collapseState));
     },
+    /* Called when collapse state changes, trigger local storage update if needed */
     collapseChanged(whatChanged) {
-      this.initialiseStorage();
-      this.setCollapseState(this.uniqueKey.toString(), whatChanged.srcElement.checked);
+      if (this.collapseState === undefined) { // Only run, if user hasn't manually set prop
+        this.initialiseStorage();
+        this.setCollapseState(this.uniqueKey.toString(), whatChanged.srcElement.checked);
+      }
     },
   },
 };
@@ -112,22 +117,26 @@ export default {
   &.row-2 { grid-row-start: span 2; }
   &.row-3 { grid-row-start: span 3; }
   &.row-4 { grid-row-start: span 4; }
+  &.row-5 { grid-row-start: span 5; }
 
   grid-column-start: span 1;
   @include tablet-up {
     &.col-2 { grid-column-start: span 2; }
     &.col-3 { grid-column-start: span 2; }
     &.col-4 { grid-column-start: span 2; }
+    &.col-5 { grid-column-start: span 2; }
   }
   @include laptop-up {
     &.col-2 { grid-column-start: span 2; }
     &.col-3 { grid-column-start: span 3; }
     &.col-4 { grid-column-start: span 3; }
+    &.col-5 { grid-column-start: span 3; }
   }
   @include monitor-up {
     &.col-2 { grid-column-start: span 2; }
     &.col-3 { grid-column-start: span 3; }
     &.col-4 { grid-column-start: span 4; }
+    &.col-5 { grid-column-start: span 5; }
   }
 
   .wrap-collabsible {
@@ -146,7 +155,7 @@ export default {
     border-radius: var(--curve-factor);
     transition: all 0.25s ease-out;
     text-align: left;
-    color: var(--item-group-heading-text-color); //var(--item-group-background);
+    color: var(--item-group-heading-text-color);
     h3 {
       margin: 0;
       padding: 0;


### PR DESCRIPTION
![Unchecked Tasks](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FNotice/Unchecked%20Tasks/f25265) ![Medium](https://badgen.net/badge/PR%20Size/Medium/f3ff59) [![Lissy93 /FIX/252-collapse-state-ignored → Lissy93/dashy](https://badgen.net/badge/%23270/Lissy93%20%2FFIX%2F252-collapse-state-ignored%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/FIX/252-collapse-state-ignored) ![Commits: 2 | Files Changed: 1 | Additions: 11](https://badgen.net/badge/New%20Code/Commits%3A%202%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%2011/dddd00) ![🐛 Fix](https://badgen.net/badge/Type/%F0%9F%90%9B%20Fix/39b0fd)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: Bugfix

**Overview**
Currently the collapse state for each section is remembered in local storage. This PR modifies this behavior for sections where the user has specified that a section should be collapsed (e.g. `section[n].displayData.collapsed: true`), so that this value is always used. Also did a small refactor in the collapsible component file while I was there.

**Issue Number** #252

**New Vars** N/A

**Screenshot** N/A

**Code Quality Checklist** _(Please complete)_
- [X] All changes are backwards compatible
- [X] All lint checks and tests are passing
- [X] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] Bumps version, if new feature added