### PR TITLE
[FIX] Icon overlap and squeeze issues

### DIFF
--- a/src/components/LinkItems/Item.vue
+++ b/src/components/LinkItems/Item.vue
@@ -434,24 +434,4 @@ export default {
   pointer-events: none;
 }
 
-/* Modifications for more equal width on auto-layout. This is bad code. */
-.orientation-auto {
-  .collapsable.col-1 .wrap-size-medium {
-    max-width: 50%;
-  }
-  @include tablet-up {
-    .collapsable.col-2 .wrap-size-medium {
-      max-width: 25%;
-    }
-  }
-  @include tablet-up {
-    .collapsable.col-1 .wrap-size-small {
-      min-width: 50%;
-    }
-    .collapsable.col-2 .wrap-size-small {
-      min-width: 20%;
-    }
-  }
-}
-
 </style>

--- a/src/styles/color-themes.scss
+++ b/src/styles/color-themes.scss
@@ -406,20 +406,11 @@ html[data-theme='material'], html[data-theme='material-dark'] {
         min-height: 2rem;
       }	
     }
-    &.size-large {
-      width: 18rem;
-      min-width: 18rem;
-      max-height: 5rem;
-      margin: 0.4rem;
-      img {
-        padding: 0.2rem 0.5rem;
-      }
-    }
   }
   .tooltip.item-description-tooltip:not(.tooltip-is-small) {
     display: none !important;
   }
-  .orientation-horizontal {
+  .orientation-horizontal:not(.single-section-view) {
     display: flex;
     flex-direction: column;
     .there-are-items {
@@ -431,6 +422,11 @@ html[data-theme='material'], html[data-theme='material-dark'] {
       @include monitor { grid-template-columns: repeat(4, 1fr); }
       @include big-screen { grid-template-columns: repeat(5, 1fr); }
       @include big-screen-up { grid-template-columns: repeat(6, 1fr); }
+    }
+    .there-are-items .item-wrapper .item {
+      width: auto;
+      min-width: auto;
+      max-height: auto;
     }
   }
   a.item {
@@ -480,15 +476,9 @@ html[data-theme='material'], html[data-theme='material-dark'] {
       padding-left: 0.5rem;
       min-width: 11rem;
     }
-    &.size-large {
-      &:before {
-        width: 1.5rem;
-      }
-      &:hover {
-        div:nth-child(2) {
-          text-indent: 1.5rem;
-        }
-      }
+    &.short:not(.size-large) {
+      min-height: 2rem;
+      height: auto;
     }
   }
 }


### PR DESCRIPTION
![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![Lissy93 /FIX/icons-layout → Lissy93/dashy](https://badgen.net/badge/%23287/Lissy93%20%2FFIX%2Ficons-layout%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/FIX/icons-layout) ![Commits: 1 | Files Changed: 2 | Additions: -30](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%202%20%7C%20Additions%3A%20-30/dddd00) ![🐛 Fix](https://badgen.net/badge/Type/%F0%9F%90%9B%20Fix/39b0fd)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**:  Bugfix
**Overview**
Recently fixed the item squeeze issue, which introduced a new bug, causing items to overlap when using material theme. This PR fixes both issues. And this time, I have tested it properly.

**Issue Number** #283 and  #285

**New Vars** N/A

**Screenshot** N/A

**Code Quality Checklist** _(Please complete)_
- [X] All changes are backwards compatible
- [X] All lint checks and tests are passing
- [X] There are no (new) build warnings or errors
- [] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [] Bumps version, if new feature added