### PR TITLE
String to Bool for statusCheckAllowInsecure on save

### DIFF
--- a/src/components/InteractiveEditor/EditItem.vue
+++ b/src/components/InteractiveEditor/EditItem.vue
@@ -227,7 +227,9 @@ export default {
       };
       if (newItem.tags) newItem.tags = strToTags(newItem.tags);
       if (newItem.statusCheck) newItem.statusCheck = strToBool(newItem.statusCheck);
-      if (newItem.statusCheckAllowInsecure) newItem.statusCheckAllowInsecure = strToBool(newItem.statusCheckAllowInsecure);
+      if (newItem.statusCheckAllowInsecure) {
+        newItem.statusCheckAllowInsecure = strToBool(newItem.statusCheckAllowInsecure);
+      }
       // if (newItem.hotkey) newItem.hotkey = parseInt(newItem.hotkey, 10);
       return newItem;
     },

--- a/src/components/InteractiveEditor/EditItem.vue
+++ b/src/components/InteractiveEditor/EditItem.vue
@@ -227,6 +227,7 @@ export default {
       };
       if (newItem.tags) newItem.tags = strToTags(newItem.tags);
       if (newItem.statusCheck) newItem.statusCheck = strToBool(newItem.statusCheck);
+      if (newItem.statusCheckAllowInsecure) newItem.statusCheckAllowInsecure = strToBool(newItem.statusCheckAllowInsecure);
       // if (newItem.hotkey) newItem.hotkey = parseInt(newItem.hotkey, 10);
       return newItem;
     },


### PR DESCRIPTION
[![olearycrew](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/olearycrew/f73ae6)](https://github.com/olearycrew) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![olearycrew /344-allow-insecure-type-issue → Lissy93/dashy](https://badgen.net/badge/%23345/olearycrew%20%2F344-allow-insecure-type-issue%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/344-allow-insecure-type-issue) ![Commits: 2 | Files Changed: 1 | Additions: 3](https://badgen.net/badge/New%20Code/Commits%3A%202%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%203/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

*Thank you for contributing to Dashy! So that your PR can be handled effectively, please populate the following fields (delete sections that are not applicable)*

**Category**: 
Bugfix

**Overview**
This adds the `strToBool` check when saving a new item for the `statusCheckAllowInsecure` field (as it already is for `statusCheck`) to help with #344 

**Issue Number** #344 

**New Vars** _(if applicable)_
N.A

**Screenshot** _(if applicable)_
N.A

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- `N/A` _(If a new config option is added)_ Attribute is outlined in the schema and documented
- `N/A` _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- `N/A` Bumps version, if new feature added