### PR TITLE
docs:fix theming title and themes' count

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,6 +1,6 @@
-## Theming
+# Theming
 
-By default Dashy comes with 20 built in themes, which can be applied from the dropwodwn menu in the UI
+By default Dashy comes with 25+ built-in themes, which can be applied from the dropwodwn menu in the UI.
 
 ![Built-in Themes](https://i.ibb.co/GV3wRss/Dashy-Themes.png)
 
@@ -125,7 +125,7 @@ You can target specific elements on the UI with these variables. All are optiona
 - `--nav-link-text-color` - The text color for links displayed in the navigation bar. Defaults to `--primary`
 - `--nav-link-background-color` - The background color for links displayed in the navigation bar
 - `--nav-link-text-color-hover` - The text color when a navigation bar link is hovered over. Defaults to `--primary`
-- `--nav-link-background-color-hover` - The background color for nav bar links when hovered over 
+- `--nav-link-background-color-hover` - The background color for nav bar links when hovered over
 - `--nav-link-border-color` - The border color for nav bar links. Defaults to `transparent`
 - `--nav-link-border-color-hover` - The border color for nav bar links when hovered over. Defaults to `--primary`
 - `--search-container-background` - Background for the container containing the search bar. Defaults to `--background-darker`


### PR DESCRIPTION
[![icy-comet](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/icy-comet/f73ae6)](https://github.com/icy-comet) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![icy-comet /patch-1 → Lissy93/dashy](https://badgen.net/badge/%23458/icy-comet%20%2Fpatch-1%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/patch-1) ![Commits: 1 | Files Changed: 1 | Additions: 0](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%200/dddd00) ![Quality Checklist](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Quality%20Checklist/f25265) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: 
Documentation

**Overview**
The secondary heading caused inconsistent styling on the documentation site. And I noticed there are now 27 built-in themes. So, I updated the docs accordingly.

Here's a screenshot of the inconsistent style in the sidebar with secondary heading:
![Screenshot](https://user-images.githubusercontent.com/50461557/151647257-e6e5f15e-6980-46d9-b973-5e3de52c3858.png)