### PR TITLE
:bug: Fix context menu on mobile/touch devices

### DIFF
--- a/src/components/LinkItems/Collapsable.vue
+++ b/src/components/LinkItems/Collapsable.vue
@@ -17,6 +17,8 @@
       <h3>{{ title }}</h3>
       <EditModeIcon v-if="isEditMode" @click="openEditModal"
         v-tooltip="editTooltip()" class="edit-mode-item" />
+      <OpenIcon @click.prevent.stop="openContextMenu" @contextmenu.prevent
+        class="edit-mode-item" />
     </label>
     <div class="collapsible-content">
       <div class="content-inner">
@@ -31,6 +33,7 @@
 import { localStorageKeys } from '@/utils/defaults';
 import Icon from '@/components/LinkItems/ItemIcon.vue';
 import EditModeIcon from '@/assets/interface-icons/interactive-editor-edit-mode.svg';
+import OpenIcon from '@/assets/interface-icons/config-open-settings.svg';
 
 export default {
   name: 'CollapsableContainer',
@@ -48,6 +51,7 @@ export default {
   components: {
     Icon,
     EditModeIcon,
+    OpenIcon,
   },
   computed: {
     isEditMode() {
@@ -244,6 +248,8 @@ export default {
     float: right;
     right: 0.5rem;
     top: 0.5rem;
+    margin-left: 0.2rem;
+    margin-right: 0.2rem;
   }
 
   /* Makes sections fill available space */

--- a/src/components/LinkItems/SectionContextMenu.vue
+++ b/src/components/LinkItems/SectionContextMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <transition name="slide">
     <div class="context-menu" v-if="show && !isMenuDisabled"
-      :style="posX && posY ? `top:${posY}px;left:${posX}px;` : ''">
+      :style="posX && posY ? calcPosition() : ''">
       <!-- Open Options -->
       <ul class="menu-section">
         <li @click="openSection()">
@@ -58,6 +58,13 @@ export default {
     },
     removeSection() {
       this.$emit('removeSection');
+    },
+    calcPosition() {
+      const bounds = this.$parent.$el.getBoundingClientRect();
+      const left = this.posX < (bounds.right + bounds.left) / 2;
+      const position = `top:${this.posY}px;${left ? 'left' : 'right'}:\
+        ${left ? this.posX : document.documentElement.clientWidth - this.posX}px;`;
+      return position;
     },
   },
 };


### PR DESCRIPTION
*Thank you for contributing to Dashy! So that your PR can be handled effectively, please populate the following fields (delete sections that are not applicable)*

**Category**: 
Bugfix

**Overview**
This proposal adds a method of accessing the context menu on touchscreen devices which don't have a right click action. This is achieved by adding a button to open the menu, that also helps with indicating that a menu is available.
While working on this I noticed another issue with the menu positioning and changed the menu to ensure it no longer extends past the edge of the window and within it's own section.

**Issue Number** #508

**Screenshot** _(if applicable)_
Before:
![before](https://user-images.githubusercontent.com/5369885/157224376-7735c610-7dd4-4565-ac2a-e568de630813.jpg)

After:
![after](https://user-images.githubusercontent.com/5369885/157224688-9a0aec7b-02ad-4099-9c78-1e90a54308c1.jpg)

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors

