### PR TITLE
Fix several issues with conf not loaded

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.0.5 - Bug Fixes and a few New Features
+
+### Partially revert 2.0.4, fixing several issues caused by `conf.yml` not being loaded at startup.
+This change requires a rebuild of the application when several options under `appConfig` are changed.
+Fixes #544 #555
+
+### Several other changes since 2.0.4, including:
+The `Add New Section` button on the UI editor now displays if no sections are present. #536
+When using SSL, the server can now redirect from HTTP to HTTPS. This is enabled by default when using SSL. #538
+Section context menus are now accessible on mobile, and will no longer clip off the screen. #541
+Italian translations have been added. #556
+
 ## :sparkles: 2.0.4 - Dynamic Config Loading [PR #528](https://github.com/Lissy93/dashy/pull/528)
 - `conf.yml` is now loaded dynamically and the app now only needs a browser refresh on config change, not a full rebuild!
 

--- a/.github/LATEST_CHANGELOG.md
+++ b/.github/LATEST_CHANGELOG.md
@@ -1,2 +1,9 @@
-## :sparkles: Dynamic Config Loading [PR #528](https://github.com/Lissy93/dashy/pull/528)
-- `conf.yml` is now loaded dynamically and the app now only needs a browser refresh on config change, not a full rebuild!
+### Partially revert 2.0.4, fixing several issues caused by `conf.yml` not being loaded at startup.
+This change requires a rebuild of the application when several options under `appConfig` are changed.
+Fixes #544 #555
+
+### Several other changes since 2.0.4, including:
+The `Add New Section` button on the UI editor now displays if no sections are present. #536
+When using SSL, the server can now redirect from HTTP to HTTPS. This is enabled by default when using SSL. #538
+Section context menus are now accessible on mobile, and will no longer clip off the screen. #541
+Italian translations have been added. #556

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,15 +39,13 @@ WORKDIR ${DIRECTORY}
 RUN apk add --no-cache tzdata tini
 
 # Copy built application from build phase
-COPY --from=BUILD_IMAGE /app/dist/ public/
-COPY --from=BUILD_IMAGE /app/node_modules/ node_modules/
-COPY services/ services/
-COPY src/utils/ src/utils/
-COPY package.json yarn.lock server.js ./
+COPY --from=BUILD_IMAGE /app ./
+# Ensure only one version of conf.yml exists
+RUN rm dist/conf.yml
 
 # Finally, run start command to serve up the built application
 ENTRYPOINT [ "/sbin/tini", "--" ]
-CMD [ "yarn", "start" ]
+CMD [ "yarn", "build-and-start" ]
 
 # Expose the port
 EXPOSE ${PORT}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Dashy",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "main": "server",
   "author": "Alicia Sykes <alicia@omg.lol> (https://aliciasykes.com)",

--- a/src/utils/ConfigAccumalator.js
+++ b/src/utils/ConfigAccumalator.js
@@ -16,6 +16,8 @@ import ErrorHandler from '@/utils/ErrorHandler';
 import { applyItemId } from '@/utils/SectionHelpers';
 import $store from '@/store';
 
+import buildConf from '../../public/conf.yml';
+
 export default class ConfigAccumulator {
   constructor() {
     this.conf = $store.state.remoteConfig;
@@ -25,7 +27,7 @@ export default class ConfigAccumulator {
   appConfig() {
     let appConfigFile = {};
     // Set app config from file
-    if (this.conf) appConfigFile = this.conf.appConfig || {};
+    if (this.conf) appConfigFile = this.conf.appConfig || buildConf.appConfig || {};
     // Fill in defaults if anything missing
     let usersAppConfig = defaultAppConfig;
     if (localStorage[localStorageKeys.APP_CONFIG]) {


### PR DESCRIPTION
[![Ateroz](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/Ateroz/f73ae6)](https://github.com/Ateroz) ![Medium](https://badgen.net/badge/PR%20Size/Medium/f3ff59) [![Ateroz /fix-several-issues-with-conf-not-loaded → Lissy93/dashy](https://badgen.net/badge/%23559/Ateroz%20%2Ffix-several-issues-with-conf-not-loaded%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/fix-several-issues-with-conf-not-loaded) ![Commits: 3 | Files Changed: 5 | Additions: 19](https://badgen.net/badge/New%20Code/Commits%3A%203%20%7C%20Files%20Changed%3A%205%20%7C%20Additions%3A%2019/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

*Thank you for contributing to Dashy! So that your PR can be handled effectively, please populate the following fields (delete sections that are not applicable)*

**Category**: 
Bugfix

**Overview**
This is a cleaner version of #549.

Fixes several issues caused by the loading of `conf.yml` dynamically. This does so by building the application at start and including the necessary config options under `appConfig` at build time. Changes made to `pageInfo` and `sections` will still be loaded dynamically, and will not require a rebuild. Users should rebuiild when changing `appConfig`.

This PR also removes the copy of `conf.yml` that is placed into `dist` at build time from the Docker image, which users running on bare metal may have to delete manually if they have issues with their config updating.

I also bumped the version due to the collection of bugs that have been fixed, and features that have been added since 2.0.4.

**Issue Number** #544 #555 

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors