### PR TITLE
[FIX] Fixing docker-compose example volume path

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -89,7 +89,7 @@ services:
     container_name: Dashy
     # Pass in your config file below, by specifying the path on your host machine
     # volumes:
-      # - /root/my-config.yml:/app/public/conf.yml
+      # - /root/my-config.yml:/public/conf.yml
     ports:
       - 4000:80
     # Set any environmental variables


### PR DESCRIPTION
[![StevKast](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/StevKast/f73ae6)](https://github.com/StevKast) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![StevKast /master → Lissy93/dashy](https://badgen.net/badge/%23565/StevKast%20%2Fmaster%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/master) ![Commits: 1 | Files Changed: 1 | Additions: 0](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%200/dddd00) ![Quality Checklist](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Quality%20Checklist/f25265) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**:  Documentation

**Overview**
The container root folder is not needed when specifying a volume. It causes an unknown directory error because it is trying to mount `/app/app/public/conf.yml` instead of `/app/public/conf.yml`