### PR TITLE
[FIX] Prevent line breaks in search-label when using CJK languages

### DIFF
--- a/src/components/Settings/SearchBar.vue
+++ b/src/components/Settings/SearchBar.vue
@@ -172,6 +172,7 @@ export default {
         color: var(--search-label-color);
         margin: 0.5rem;
         display: inline;
+        word-break: keep-all;
     }
     input {
       display: inline-block;


### PR DESCRIPTION
[![moemoeq](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/moemoeq/f73ae6)](https://github.com/moemoeq) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![moemoeq /FIX/611_keep-all-word-break-for-cjk → Lissy93/dashy](https://badgen.net/badge/%23612/moemoeq%20%2FFIX%2F611_keep-all-word-break-for-cjk%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/FIX/611_keep-all-word-break-for-cjk) ![Commits: 1 | Files Changed: 1 | Additions: 1](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%201/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265) ![Unchecked Tasks](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FNotice/Unchecked%20Tasks/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

*Thank you for contributing to Dashy! So that your PR can be handled effectively, please populate the following fields (delete sections that are not applicable)*

**Category**: Bugfix

**Overview**
> Prevent line breaks in search-label when using CJK languages

**Issue Number**: #611

**Screenshot** 
<img width="943" alt="image" src="https://user-images.githubusercontent.com/1808434/164916007-b4bf2dd5-b509-4135-b6cb-61cf02122653.png">

**Code Quality Checklist** 
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] Bumps version, if new feature added