### PR TITLE
:sparkles: Optionally allow StatPing widget to filter on group

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -1350,6 +1350,9 @@ Displays the current and recent uptime of your running services, via a self-host
 **Field** | **Type** | **Required** | **Description**
 --- | --- | --- | ---
 **`hostname`** | `string` |  Required | The URL to your StatPing instance, without a trailing slash
+**`groupId`** | `number` | Optional | If provided, only Services in the given group are displayed. Defaults to `0` in which case all services are displayed.
+**`showChart`** | `boolean`| Optional | If provided and `false` then charts are not displayed. Defaults to `true`.
+**`showInfo`** | `boolean`| Optional | If provided and `false` then information summaries are not displayed. Defaults to `true`.
 
 ##### Example 
 
@@ -1358,6 +1361,18 @@ Displays the current and recent uptime of your running services, via a self-host
   options:
     hostname: http://192.168.130.1:8080
 ```
+or
+```yaml
+- type: stat-ping
+  options:
+    hostname: http://192.168.130.1:8080
+    groupId: 3
+    showChart: false
+    showInfo: false
+```
+You can use multiple StatPing widgets with different `groupId`s.
+
+Note, the Group Id is not directly visible in SttatPing UI, you can inspect the group select HTML element or the API response to find out.
 
 ##### Info
 - **CORS**: 🟠 Proxied

--- a/src/components/Widgets/StatPing.vue
+++ b/src/components/Widgets/StatPing.vue
@@ -15,9 +15,13 @@
       <span v-else class="status-offline">
         {{ $t('widgets.stat-ping.down') }}
       </span>
+      <Button v-on:click="service.infoHidden = !service.infoHidden"
+              class="far fa-info"></Button>
+      <Button v-on:click="service.chartHidden = !service.chartHidden"
+              class="far fa-chart-line"></button>
     </p>
     <!-- Charts -->
-    <div class="charts">
+    <div v-if="!service.chartHidden" class="charts">
       <img
         class="uptime-pie-chart" alt="24 Hour Uptime Chart"
         :src="makeChartUrl(service.uptime24, '24 Hours')" />
@@ -25,7 +29,7 @@
         :src="makeChartUrl(service.uptime7, '7 Days')" />
     </div>
     <!-- Info -->
-    <div class="info">
+    <div v-if="!service.infoHidden" class="info">
       <div class="info-row">
         <span class="lbl">Failed Pings</span>
         <span class="val">{{ service.totalFailure }}/{{ service.totalSuccess }}</span>
@@ -73,6 +77,15 @@ export default {
     endpoint() {
       return `${this.hostname}/api/services`;
     },
+    groupId() {
+      return this.options.groupId || 0;
+    },
+    showChart() {
+      return typeof this.options.showChart !== 'boolean' ? true : this.options.showChart;
+    },
+    showInfo() {
+      return typeof this.options.showInfo !== 'boolean' ? true : this.options.showInfo;
+    },
   },
   methods: {
     fetchData() {
@@ -99,6 +112,7 @@ export default {
     processData(data) {
       let services = [];
       data.forEach((service) => {
+        if (this.groupId && this.groupId !== service.group_id) return;
         services.push({
           name: service.name,
           online: service.online,
@@ -109,6 +123,8 @@ export default {
           totalFailure: showNumAsThousand(service.stats.failures),
           lastSuccess: getTimeAgo(service.last_success),
           lastFailure: getTimeAgo(service.last_error),
+          chartHidden: this.showChart ? 0 : 1,
+          infoHidden: this.showInfo ? 0 : 1,
         });
       });
       if (this.limit) services = services.slice(0, this.limit);
@@ -134,6 +150,18 @@ export default {
         &.status-online { color: var(--success); }
         &.status-offline { color: var(--danger); }
       }
+    }
+    button {
+      float: right;
+      color: var(--widget-text-color);
+      top: 4px;
+      background: none;
+      border: none;
+      position: relative;
+      opacity: .4;
+    }
+    button:hover {
+      opacity: .75;
     }
     .charts {
       display: flex;


### PR DESCRIPTION
[![marekful](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/marekful/f73ae6)](https://github.com/marekful) ![✨ Feature](https://badgen.net/badge/Type/%E2%9C%A8%20Feature/39b0fd) ![Medium](https://badgen.net/badge/PR%20Size/Medium/f3ff59) [![marekful /FEATURE/StatPing-widget-group-filter-and-compact-view → Lissy93/dashy](https://badgen.net/badge/%23714/marekful%20%2FFEATURE%2FStatPing-widget-group-filter-and-compact-view%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/FEATURE/StatPing-widget-group-filter-and-compact-view) ![Commits: 1 | Files Changed: 2 | Additions: 43](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%202%20%7C%20Additions%3A%2043/dddd00) ![Unchecked Tasks](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FNotice/Unchecked%20Tasks/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

... and to display in a more compact view.

* Add widget option: `groupId`. StatPing services are filtered for the given group.
* Add widget options: `showChart` and `showInfo`. Initially hide the chart and info summary.
* Add buttons to show/hide chart and info sections.
* Update widget documentation.

**Category**: 
> Feature

**Overview**
> Minor enhancements to the StatPing widget

**Screenshot** _(if applicable)_
> 
<img width="1018" alt="Screenshot 2022-06-08 at 20 29 24" src="https://user-images.githubusercontent.com/10281476/172705801-75e1f850-280c-47af-97ba-f11d5b588977.png">
<img width="1018" alt="Screenshot 2022-06-08 at 20 31 04" src="https://user-images.githubusercontent.com/10281476/172705826-37302303-5a54-4298-8780-307e05c64298.png">


**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] Bumps version, if new feature added