### PR TITLE
:sparkles: Allow pages to override theme

### DIFF
--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -120,6 +120,7 @@ module.exports = {
     COLLAPSE_STATE: 'collapseState',
     ICON_SIZE: 'iconSize',
     THEME: 'theme',
+    PRIMARY_THEME: 'primaryTheme',
     CUSTOM_COLORS: 'customColors',
     CONF_SECTIONS: 'confSections',
     CONF_WIDGETS: 'confSections',


### PR DESCRIPTION
[![marekful](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/marekful/f73ae6)](https://github.com/marekful) ![Medium](https://badgen.net/badge/PR%20Size/Medium/f3ff59) [![marekful /FEATURE/page-theme-override → Lissy93/dashy](https://badgen.net/badge/%23752/marekful%20%2FFEATURE%2Fpage-theme-override%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/FEATURE/page-theme-override) ![Commits: 1 | Files Changed: 2 | Additions: 16](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%202%20%7C%20Additions%3A%2016/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265) ![Unchecked Tasks](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FNotice/Unchecked%20Tasks/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: 
> One of: Feature

**Overview**
> This is probably the simplest way to achieve a page theme override feature and, as such, is not very scalable. A page theme can only be defined in its yaml file e.g.
```yaml
appConfig:
  theme: page-theme
pageInfo:
...
```
> and Dashy is not able to handle the overrides (other than apply the theme).
>
> A better solution would be to introduce `pageConfig` as a top level element in the schema which is always ignored for the main `conf.yml` , and overrides certain attributes in `appConfig` for pages (e.g. `statusCheckInterval` and `widgetsAlwaysUseProxy` would make sense in addition to `theme`).
>
> Weighing the overall benefits versus the size of the change needed to appropriately realise that ^^, however, I'd consider this solution sufficient for the time being. What do you think?
>
> Also, I didn't test this with history routing mode. 

**Screenshot** _(if applicable)_
> https://user-images.githubusercontent.com/10281476/175116329-951753a3-017c-4781-be88-3bad255bf2b3.mov



**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] Bumps version, if new feature added