### PR TITLE
Refactor conf.yml to be configurable

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,7 +22,7 @@ require('./services/config-validator'); // Include and kicks off the config file
 
 /* Include route handlers for API endpoints */
 const statusCheck = require('./services/status-check'); // Used by the status check feature, uses GET
-const saveConfig = require('./services/save-config'); // Saves users new conf.yml to file-system
+const saveConfig = require('./services/save-config'); // Saves users new config file to file-system
 const rebuild = require('./services/rebuild-app'); // A script to programmatically trigger a build
 const systemInfo = require('./services/system-info'); // Basic system info, for resource widget
 const sslServer = require('./services/ssl-server'); // TLS-enabled web server

--- a/services/config-validator.js
+++ b/services/config-validator.js
@@ -1,13 +1,17 @@
 /**
- * Checks that conf.yml is present + parsable, then validates it against the schema
+ * Checks that the config file is present + parsable, then validates it against the schema
  * Prints detailed info about any errors or warnings to help the user fix the issue
  */
+
 
 const fs = require('fs'); // For opening + reading files
 const yaml = require('js-yaml'); // For parsing YAML
 const Ajv = require('ajv'); // For validating with schema
 
 const schema = require('../src/utils/ConfigSchema.json');
+
+const path = require('path');
+const configFile = process.env.CONFIG_FILE || '/app/public/conf.yml';
 
 /* Tell AJV to use strict mode, and report all errors */
 const validatorOptions = {
@@ -62,9 +66,11 @@ const validate = (config) => {
 
 /* Error message printed when the file could not be opened */
 const bigError = () => {
+
   const formatting = '\x1b[30m\x1b[43m';
+  const filename = path.basename(configFile);
   const line = `${formatting}${new Array(38).fill('━').join('')}\x1b[0m\n`;
-  const msg = `${formatting} Error, unable to validate 'conf.yml' \x1b[0m\n`;
+  const msg = `${formatting} Error, unable to validate '${filename}' \x1b[0m\n`;
   return `\n${line}${msg}${line}`;
 };
 
@@ -99,7 +105,7 @@ const printFileReadError = (e) => {
 };
 
 try { // Try to open and parse the YAML file
-  const config = yaml.load(fs.readFileSync('./public/conf.yml', 'utf8'));
+  const config = yaml.load(fs.readFileSync(configFile, 'utf8'));
   validate(config);
 } catch (e) { // Something went very wrong...
   setIsValidVariable(false);

--- a/src/store.js
+++ b/src/store.js
@@ -5,7 +5,7 @@ import axios from 'axios';
 import yaml from 'js-yaml';
 import Keys from '@/utils/StoreMutations';
 import ConfigAccumulator from '@/utils/ConfigAccumalator';
-import { getConfigFile, componentVisibility } from '@/utils/ConfigHelpers';
+import { componentVisibility } from '@/utils/ConfigHelpers';
 import { applyItemId } from '@/utils/SectionHelpers';
 import filterUserSections from '@/utils/CheckSectionVisibility';
 import ErrorHandler, { InfoHandler, InfoKeys } from '@/utils/ErrorHandler';
@@ -315,7 +315,7 @@ const store = new Vuex.Store({
     /* Called when app first loaded. Reads config and sets state */
     async [INITIALIZE_CONFIG]({ commit }) {
       // Get the config file from the server and store it for use by the accumulator
-      commit(SET_REMOTE_CONFIG, yaml.load((await axios.get(`/${getConfigFile().FILENAME}`)).data));
+      commit(SET_REMOTE_CONFIG, yaml.load((await axios.get('/conf.yml')).data));
       const deepCopy = (json) => JSON.parse(JSON.stringify(json));
       const config = deepCopy(new ConfigAccumulator().config());
       if (config.appConfig?.theme) {

--- a/src/store.js
+++ b/src/store.js
@@ -5,7 +5,7 @@ import axios from 'axios';
 import yaml from 'js-yaml';
 import Keys from '@/utils/StoreMutations';
 import ConfigAccumulator from '@/utils/ConfigAccumalator';
-import { componentVisibility } from '@/utils/ConfigHelpers';
+import { getConfigFile, componentVisibility } from '@/utils/ConfigHelpers';
 import { applyItemId } from '@/utils/SectionHelpers';
 import filterUserSections from '@/utils/CheckSectionVisibility';
 import ErrorHandler, { InfoHandler, InfoKeys } from '@/utils/ErrorHandler';
@@ -315,11 +315,11 @@ const store = new Vuex.Store({
     /* Called when app first loaded. Reads config and sets state */
     async [INITIALIZE_CONFIG]({ commit }) {
       // Get the config file from the server and store it for use by the accumulator
-      commit(SET_REMOTE_CONFIG, yaml.load((await axios.get('/conf.yml')).data));
+      commit(SET_REMOTE_CONFIG, yaml.load((await axios.get(`/${getConfigFile().FILENAME}`)).data));
       const deepCopy = (json) => JSON.parse(JSON.stringify(json));
       const config = deepCopy(new ConfigAccumulator().config());
       if (config.appConfig?.theme) {
-        // Save theme defined in conf.yml as primary
+        // Save theme defined in the config file as primary
         localStorage.setItem(localStorageKeys.PRIMARY_THEME, config.appConfig.theme);
         // This will set theme back to primary in case we were on a themed page
         // and the index page is loaded w/o navigation (e.g. modifying browser location)

--- a/src/utils/ConfigHelpers.js
+++ b/src/utils/ConfigHelpers.js
@@ -10,6 +10,19 @@ import {
 import ErrorHandler from '@/utils/ErrorHandler';
 import ConfigSchema from '@/utils/ConfigSchema.json';
 
+const path = require('path');
+
+export const getConfigFile = () => {
+  const configFile = process.env.CONFIG_FILE || '/app/public/conf.yml';
+  return {
+    NAME: path.parse(configFile).name,
+    EXTENSION: path.extname(configFile),
+    BASE_DIR: path.dirname(configFile),
+    FILENAME: path.basename(configFile),
+    FULL: configFile,
+  };
+};
+
 /* Given a page name, converts to lowercase, removes special characters and extension */
 export const makePageName = (pageName) => {
   if (!pageName) return 'unnamed-page';

--- a/src/utils/ConfigSchema.json
+++ b/src/utils/ConfigSchema.json
@@ -513,7 +513,7 @@
           "title": "Allow Config Editing",
           "type": "boolean",
           "default": true,
-          "description": "Can user write changes to conf.yml file from the UI. If set to false, preferences are only stored locally"
+          "description": "Can user write changes to the config file from the UI. If set to false, preferences are only stored locally"
         },
         "enableServiceWorker": {
           "title": "Enable Service Worker",

--- a/src/utils/InitServiceWorker.js
+++ b/src/utils/InitServiceWorker.js
@@ -3,7 +3,6 @@ import yaml from 'js-yaml';
 import { register } from 'register-service-worker';
 import { sessionStorageKeys } from '@/utils/defaults';
 import { statusMsg, statusErrorMsg } from '@/utils/CoolConsole';
-import { getConfigFile } from '@/utils/ConfigHelpers';
 
 /* Sets a local storage item with the state from the SW lifecycle */
 const setSwStatus = (swStateToSet) => {
@@ -34,7 +33,7 @@ const setSwStatus = (swStateToSet) => {
  * Or disable if user specified to disable
  */
 const shouldEnableServiceWorker = async () => {
-  const conf = yaml.load((await axios.get(`/${getConfigFile().FILENAME}`)).data);
+  const conf = yaml.load((await axios.get('/conf.yml')).data);
   if (conf && conf.appConfig && conf.appConfig.enableServiceWorker) {
     setSwStatus({ disabledByUser: false });
     return true;

--- a/src/utils/InitServiceWorker.js
+++ b/src/utils/InitServiceWorker.js
@@ -3,6 +3,7 @@ import yaml from 'js-yaml';
 import { register } from 'register-service-worker';
 import { sessionStorageKeys } from '@/utils/defaults';
 import { statusMsg, statusErrorMsg } from '@/utils/CoolConsole';
+import { getConfigFile } from '@/utils/ConfigHelpers';
 
 /* Sets a local storage item with the state from the SW lifecycle */
 const setSwStatus = (swStateToSet) => {
@@ -33,7 +34,7 @@ const setSwStatus = (swStateToSet) => {
  * Or disable if user specified to disable
  */
 const shouldEnableServiceWorker = async () => {
-  const conf = yaml.load((await axios.get('/conf.yml')).data);
+  const conf = yaml.load((await axios.get(`/${getConfigFile().FILENAME}`)).data);
   if (conf && conf.appConfig && conf.appConfig.enableServiceWorker) {
     setSwStatus({ disabledByUser: false });
     return true;

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -157,7 +157,7 @@ module.exports = {
     EXPORT_CONFIG_MENU: 'EXPORT_CONFIG_MENU',
     MOVE_ITEM_TO: 'MOVE_ITEM_TO',
   },
-  /* Key names for the top-level objects in conf.yml */
+  /* Key names for the top-level objects in the config file */
   topLevelConfKeys: {
     PAGE_INFO: 'pageInfo',
     APP_CONFIG: 'appConfig',

--- a/src/views/Minimal.vue
+++ b/src/views/Minimal.vue
@@ -86,7 +86,7 @@ export default {
     sectionSelected(index) {
       this.selectedSection = index;
     },
-    /* Returns sections from local storage if available, otherwise uses the conf.yml */
+    /* Returns sections from local storage if available, otherwise uses the config file */
     getSections(sections) {
       // If the user has stored sections in local storage, return those
       const localSections = localStorage[localStorageKeys.CONF_SECTIONS];
@@ -94,7 +94,7 @@ export default {
         const json = JSON.parse(localSections);
         if (json.length >= 1) return json;
       }
-      // Otherwise, return the usuall data from conf.yml
+      // Otherwise, return the usual data from the config file
       return sections;
     },
     /* Clears input field, once a searched item is opened */


### PR DESCRIPTION
[![myoung34](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/myoung34/f73ae6)](https://github.com/myoung34) ![Medium](https://badgen.net/badge/PR%20Size/Medium/f3ff59) [![myoung34 /master → Lissy93/dashy](https://badgen.net/badge/%23771/myoung34%20%2Fmaster%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/master) ![Commits: 2 | Files Changed: 8 | Additions: 21](https://badgen.net/badge/New%20Code/Commits%3A%202%20%7C%20Files%20Changed%3A%208%20%7C%20Additions%3A%2021/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265) ![Unchecked Tasks](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FNotice/Unchecked%20Tasks/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

*Thank you for contributing to Dashy! So that your PR can be handled effectively, please populate the following fields (delete sections that are not applicable)*

**Category**: 
> One of: Bugfix / Feature / Code style update / Refactoring Only / Build related changes /  Documentation / Other (please specify)

Feature

**Overview**
> Briefly outline your new changes...

In some orchestrators (kubernetes) configmaps are not updated in place if subpaths are used. This means Id have to reload the pod whenever a config changes which takes forever given that it builds on startup

I'm proposing a way of letting the config file be configurable with an env variable (a best practice for web apps)

It should be noted that i had to back out the changes to `src/utils/InitServiceWorker.js` and `src/store.js`
Because it's exposing (and using) `/conf.yml` as an HTTP endpoint. I could use some guidance on how to get out of that. Perhaps `/config` which pulls it from wherever its hosted?

The errors there: 

```
Uncaught (in promise) TypeError: r.parse is not a function
    at c (save-config.svg:18:16)
    at open-top.svg:37:47
    at u (regeneratorRuntime.js:86:17)
    at Generator._invoke (regeneratorRuntime.js:66:24)
    at Generator.next (regeneratorRuntime.js:117:21)
    at s (asyncToGenerator.js:3:20)
    at a (asyncToGenerator.js:25:9)
    at asyncToGenerator.js:32:7
    at new Promise (<anonymous>)
    at asyncToGenerator.js:21:12
c @ save-config.svg:18
```


**Issue Number** _(if applicable)_ #00

**New Vars** _(if applicable)_
> If you've added any new build scripts, environmental variables, config file options, dependency or devDependency, please outline here

`CONFIG_FILE` is a full location to the file

`docker run -e CONFIG_FILE=/foo.yml -v $(pwd)/conf.yml:/foo.yml -it -p 4000:80 ...`

**Screenshot** _(if applicable)_
> If you've introduced any significant UI changes, please include a screenshot

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [ ] All lint checks and tests are passing
- [ ] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] Bumps version, if new feature added