### PR TITLE
Allow disabling HTTP server when enabling SSL

### DIFF
--- a/.env
+++ b/.env
@@ -35,3 +35,6 @@
 
 # Again, set automatically using package.json during build time
 # VUE_APP_VERSION=2.0.0
+
+# Allow disabling HTTP server
+# SSL_ONLY=false

--- a/server.js
+++ b/server.js
@@ -41,6 +41,9 @@ const port = process.env.PORT || (isDocker ? 80 : 4000);
 /* Checks env var for host. If undefined, will use 0.0.0.0 */
 const host = process.env.HOST || '0.0.0.0';
 
+/* Allow SSL only server by disabing HTTP server. Defaults to false. */
+const sslOnly = process.env.SSL_ONLY || false;
+
 /* Attempts to get the users local IP, used as part of welcome message */
 const getLocalIp = () => {
   const dnsLookup = util.promisify(dns.lookup);
@@ -124,13 +127,15 @@ const app = express()
   });
 
 /* Create HTTP server from app on port, and print welcome message */
-http.createServer(app)
-  .listen(port, host, () => {
-    printWelcomeMessage();
-  })
-  .on('error', (err) => {
-    printWarning('Unable to start Dashy\'s Node server', err);
-  });
+if (sslOnly === false) {
+  http.createServer(app)
+    .listen(port, host, () => {
+      printWelcomeMessage();
+    })
+    .on('error', (err) => {
+      printWarning('Unable to start Dashy\'s Node server', err);
+    });
+}
 
 /* Check, and if possible start SSL server too */
 sslServer.startSSLServer(app);


### PR DESCRIPTION
[![flechaig](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/flechaig/f73ae6)](https://github.com/flechaig) ![Medium](https://badgen.net/badge/PR%20Size/Medium/f3ff59) [![flechaig /master → Lissy93/dashy](https://badgen.net/badge/%23786/flechaig%20%2Fmaster%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/master) ![Commits: 1 | Files Changed: 2 | Additions: 8](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%202%20%7C%20Additions%3A%208/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

*Thank you for contributing to Dashy! So that your PR can be handled effectively, please populate the following fields (delete sections that are not applicable)*

**Category**: 
Feature

**Overview**
Allow totally disabling HTTP server (port 80) when SSL is enabled.

**New Vars** _(if applicable)_
SSL_ONLY

**Code Quality Checklist** _(Please complete)_
- [X] All changes are backwards compatible
- [X] All lint checks and tests are passing
- [X] There are no (new) build warnings or errors
- [] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [X] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [] Bumps version, if new feature added