### PR TITLE
Fix storage calculation

### DIFF
--- a/src/components/Widgets/GlDiskSpace.vue
+++ b/src/components/Widgets/GlDiskSpace.vue
@@ -8,7 +8,7 @@
       ]" />
     <p class="info">
       <b>{{ $t('widgets.glances.disk-space-free') }}</b>:
-      {{ disk.used | formatSize }} out of {{ disk.size | formatSize }}
+      {{ disk.size - disk.used | formatSize }} out of {{ disk.size | formatSize }}
     </p>
     <p class="info"><b>{{ $t('widgets.glances.disk-mount-point') }}</b>: {{ disk.mnt_point }}</p>
     <p class="info"><b>{{ $t('widgets.glances.disk-file-system') }}</b>: {{ disk.fs_type }}</p>


### PR DESCRIPTION
[![BRAVO68WEB](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/BRAVO68WEB/f73ae6)](https://github.com/BRAVO68WEB) ![🐛 Fix](https://badgen.net/badge/Type/%F0%9F%90%9B%20Fix/39b0fd) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![BRAVO68WEB /fix/disk-calc → Lissy93/dashy](https://badgen.net/badge/%23788/BRAVO68WEB%20%2Ffix%2Fdisk-calc%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/fix/disk-calc) ![Commits: 1 | Files Changed: 1 | Additions: 0](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%200/dddd00) ![Unchecked Tasks](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FNotice/Unchecked%20Tasks/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: 
> One of: Bugfix

**Overview**
>  It should be 'Used' instead of 'Free'. Its calling `disk.used` hence returning the disk in use. If we want to show 'Free', it should be disk.free

<!-- **Issue Number** _(if applicable)_ #00 -->

**Screenshot** _(if applicable)_

> Old

![image](https://user-images.githubusercontent.com/41448663/177974246-93a4201d-8c58-42e9-b98b-d68be16b9b6b.png)


> New

![image](https://user-images.githubusercontent.com/41448663/177975620-5159c465-b9da-42b5-898c-f8ce0cf7d099.png)




**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] Bumps version, if new feature added