### PR TITLE
:sparkles: Adds state option for PublicHolidays widget

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -694,7 +694,8 @@ Counting down to the next day off work? This widget displays upcoming public hol
 
 **Field** | **Type** | **Required** | **Description**
 --- | --- | --- | ---
-**`country`** | `string` |  Required | The region to fetch holiday data for, specified as a country code, e.g. `GB` or `US`
+**`country`** | `string` |  Required | The country to fetch holiday data for, specified as a country code, e.g. `GB` or `US`
+**`state`** | `string` |  **Optional** | restrict a country to a specific state defined by [ISO_3166-2](https://en.wikipedia.org/wiki/ISO_3166-2), e.g. `LND`.
 **`holidayType`** | `string` |  **Optional** | The type of holidays to fetch. Can be: `all`, `public_holiday`, `observance`, `school_holiday`, `other_day` or `extra_working_day`. Defaults to `public_holiday`
 **`monthsToShow`** | `number` |  **Optional** | The number of months in advance to show. Min: `1`, max: `24`. Defaults to `12`
 
@@ -704,6 +705,7 @@ Counting down to the next day off work? This widget displays upcoming public hol
 - type: public-holidays
   options:
     country: GB
+    region: LND
     holidayType: all
     monthsToShow: 12
 ```

--- a/src/components/Widgets/PublicHolidays.vue
+++ b/src/components/Widgets/PublicHolidays.vue
@@ -57,7 +57,8 @@ export default {
     endpoint() {
       return `${widgetApiEndpoints.holidays}`
       + `&fromDate=${this.startDate}&toDate=${this.endDate}`
-      + `&country=${this.country}&holidayType=${this.holidayType}`;
+      + `&country=${this.country}&holidayType=${this.holidayType}`
+      + `${this.options?.state ? `&region=${this.options.state}` : ''}`;
     },
   },
   methods: {

--- a/src/components/Widgets/PublicHolidays.vue
+++ b/src/components/Widgets/PublicHolidays.vue
@@ -61,10 +61,10 @@ export default {
       return '';
     },
     endpoint() {
-      return `${`${widgetApiEndpoints.holidays}`
+      return `${widgetApiEndpoints.holidays}`
       + `&fromDate=${this.startDate}&toDate=${this.endDate}`
-      + `&country=${this.country}&holidayType=${this.holidayType}`}${
-        this.region}`;
+      + `&country=${this.country}&holidayType=${this.holidayType}`
+      + `${this.region}`;
     },
   },
   methods: {

--- a/src/components/Widgets/PublicHolidays.vue
+++ b/src/components/Widgets/PublicHolidays.vue
@@ -54,11 +54,17 @@ export default {
       const then = new Date((now.setMonth(now.getMonth() + this.monthsToShow)));
       return `${then.getDate()}-${then.getMonth() + 1}-${then.getFullYear()}`;
     },
+    region() {
+      if (this.options?.state) {
+        return `&region=${this.options.state}`;
+      }
+      return '';
+    },
     endpoint() {
-      return `${widgetApiEndpoints.holidays}`
+      return `${`${widgetApiEndpoints.holidays}`
       + `&fromDate=${this.startDate}&toDate=${this.endDate}`
-      + `&country=${this.country}&holidayType=${this.holidayType}`
-      + `${this.options?.state ? `&region=${this.options.state}` : ''}`;
+      + `&country=${this.country}&holidayType=${this.holidayType}`}${
+        this.region}`;
     },
   },
   methods: {


### PR DESCRIPTION
[![cauterize](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/cauterize/f73ae6)](https://github.com/cauterize) ![✨ Feature](https://badgen.net/badge/Type/%E2%9C%A8%20Feature/39b0fd) ![Medium](https://badgen.net/badge/PR%20Size/Medium/f3ff59) [![cauterize /feat/public_holidays_widget_state_parameter → Lissy93/dashy](https://badgen.net/badge/%23875/cauterize%20%2Ffeat%2Fpublic_holidays_widget_state_parameter%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/feat/public_holidays_widget_state_parameter) ![Commits: 3 | Files Changed: 2 | Additions: 9](https://badgen.net/badge/New%20Code/Commits%3A%203%20%7C%20Files%20Changed%3A%202%20%7C%20Additions%3A%209/dddd00)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

*Thank you for contributing to Dashy! So that your PR can be handled effectively, please populate the following fields (delete sections that are not applicable)*

**Category**: Feature

**Overview**
This PR simply exposes the `region` parameter from `Enrico Service 2.0` as an option in the PublicHolidays widget.

I chose `state` instead of `region` as the name of the option because I think it's more convenient.

Why do I want this feature? Because at least in Germany holidays are widely different between each state...

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [x] Bumps version, if new feature added (I at least would think so... Small feature, but a feature nonetheless)