### PR TITLE
with built in auth, if user adds a capital letter to username they ca…

### DIFF
--- a/src/utils/Auth.js
+++ b/src/utils/Auth.js
@@ -150,7 +150,7 @@ export const getCurrentUser = () => {
   let foundUserObject = false; // Value to return
   getUsers().forEach((user) => {
     // If current logged-in user found, then return that user
-    if (user.user === username) foundUserObject = user;
+    if (user.user.toLowerCase() === username.toLowerCase()) foundUserObject = user;
   });
   return foundUserObject;
 };
@@ -180,7 +180,7 @@ export const isUserAdmin = () => {
   const currentUser = localStorage[localStorageKeys.USERNAME];
   let isAdmin = false;
   users.forEach((user) => {
-    if (user.user === currentUser) {
+    if (user.user.toLowerCase() === currentUser.toLowerCase()) {
       if (user.type === 'admin') isAdmin = true;
     }
   });


### PR DESCRIPTION
[![Cereal916](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/Cereal916/f73ae6)](https://github.com/Cereal916) ![🐛 Fix](https://badgen.net/badge/Type/%F0%9F%90%9B%20Fix/39b0fd) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![Cereal916 /master → Lissy93/dashy](https://badgen.net/badge/%23887/Cereal916%20%2Fmaster%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/master) ![Commits: 1 | Files Changed: 1 | Additions: 0](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%200/dddd00)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…n see all items.

*Thank you for contributing to Dashy! So that your PR can be handled effectively, please populate the following fields (delete sections that are not applicable)*

**Category**: 
Bugfix 

**Overview**
I've found that if a user logs in with a capital letter in their name (their config username is all lowercase), then there's a loophole in the auth flow where the user doesn't get identified properly, and is able to view all items, even when they're not included in the showForUsers list.

**Issue Number** _(if applicable)_ #00


**Code Quality Checklist** _(Please complete)_
- [ X ] All changes are backwards compatible
- [ X ] All lint checks and tests are passing
- [ X ] There are no (new) build warnings or errors
- [ X ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ X ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ X ] Bumps version, if new feature added