### PR TITLE
Removed build watch and tini from container run-time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN yarn install --frozen-lockfile --network-timeout 1000000
 COPY . ./
 
 # Build initial app for production
-RUN yarn build
+RUN yarn build --mode production
 
 # Production stage
 FROM node:16.13.2-alpine
@@ -35,8 +35,8 @@ ENV PORT=80 \
 # Create and set the working directory
 WORKDIR ${DIRECTORY}
 
-# Install tini for initialization and tzdata for setting timezone
-RUN apk add --no-cache tzdata tini
+# Update tzdata for setting timezone
+RUN apk add --no-cache tzdata
 
 # Copy built application from build phase
 COPY --from=BUILD_IMAGE /app ./
@@ -44,8 +44,7 @@ COPY --from=BUILD_IMAGE /app ./
 RUN rm dist/conf.yml
 
 # Finally, run start command to serve up the built application
-ENTRYPOINT [ "/sbin/tini", "--" ]
-CMD [ "yarn", "build-and-start" ]
+CMD [ "yarn", "start" ]
 
 # Expose the port
 EXPOSE ${PORT}


### PR DESCRIPTION
[![sur1v](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/sur1v/f73ae6)](https://github.com/sur1v) ![🏗️ Architecture](https://badgen.net/badge/Type/%F0%9F%8F%97%EF%B8%8F%20Architecture/39b0fd) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![sur1v /master → Lissy93/dashy](https://badgen.net/badge/%23891/sur1v%20%2Fmaster%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/master) ![Commits: 1 | Files Changed: 1 | Additions: -1](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%20-1/dddd00)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

*Thank you for contributing to Dashy! So that your PR can be handled effectively, please populate the following fields (delete sections that are not applicable)*

**Category**: 
Build related changes

**Overview**
Current production Dockerfile run-time command for the container is `yarn build-and-start`, that is a parallel run of `node server` and `vue-cli-service build --watch --mode production`. This parameter will make the build process keep watching the folder waiting to rebuild the app on any change. I guess this is related with 2 needs, developing or the app itself need to rebuild to show some changes.

Presented Dockerfile just init the container with `yarn start` and removes `tini`, effectively using ~60 Mb of RAM (reduced from ~500Mb!), with no rebuilds. I restored my dashboard with ID and then created new items and everything seems to be working as it should, but no extensive testing has been done.

**Code Quality Checklist** 
- [X] All changes are backwards compatible
- [X] All lint checks and tests are passing
- [X] There are no (new) build warnings or errors