### PR TITLE
Add config option to disable all UI config features for non admin users.

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -90,7 +90,7 @@ Any user who is not an admin (with `type: admin`) will not be able to write chan
 
 You can also prevent any user from writing changes to disk, using `preventWriteToDisk`. Or prevent any changes from being saved locally in browser storage, using `preventLocalSave`. Both properties can be found under [`appConfig`](./docs/configuring.md#appconfig-optional).
 
-To disable all UI config features, including View Config, set `disableConfiguration`.
+To disable all UI config features, including View Config, set `disableConfiguration`. Alternatively you can disable UI config features for all non admin users by setting `disableConfigurationForNonAdmin` to true.
 
 ### Security
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -127,6 +127,7 @@ The following file provides a reference of all supported configuration options.
 **`preventWriteToDisk`** | `boolean` | _Optional_ | If set to `true`, users will be prevented from saving config changes to disk through the UI
 **`preventLocalSave`** | `boolean` | _Optional_ | If set to `true`, users will be prevented from applying config changes to local storage
 **`disableConfiguration`** | `boolean` | _Optional_ | If set to true, no users will be able to view or edit the config through the UI
+**`disableConfigurationForNonAdmin`** | `boolean` | _Optional_ | If set to true, only admin users will be able to view or edit the config through the UI. disableConfiguration must not be set to true.
 **`widgetsAlwaysUseProxy`** | `boolean` | _Optional_ | If set to `true`, requests made by widgets will always be proxied, same as setting `useProxy: true` on each widget. Note that this may break some widgets.
 **`showSplashScreen`** | `boolean` | _Optional_ | If set to `true`, a loading screen will be shown. Defaults to `false`.
 **`enableErrorReporting`** | `boolean` | _Optional_ | Enable reporting of unexpected errors and crashes. This is off by default, and **no data will ever be captured unless you explicitly enable it**. Turning on error reporting helps previously unknown bugs get discovered and fixed. Dashy uses [Sentry](https://github.com/getsentry/sentry) for error reporting. Defaults to `false`.
@@ -335,7 +336,7 @@ If you have authentication set up, then any user who is not an admin (with `type
 
 You can also prevent changes from any user being written to disk, using `preventWriteToDisk`. Or prevent any changes from being saved locally in browser storage, using `preventLocalSave`.
 
-To disable all UI config features, set `disableConfiguration`.
+To disable all UI config features, set `disableConfiguration`. Alternatively you can disable UI config features for all non Admin users by setting `disableConfigurationForNonAdmin` to true.
 
 ### Example
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Dashy",
-  "version": "2.1.2",
+  "version": "2.1.1",
   "license": "MIT",
   "main": "server",
   "author": "Alicia Sykes <alicia@omg.lol> (https://aliciasykes.com)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Dashy",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "license": "MIT",
   "main": "server",
   "author": "Alicia Sykes <alicia@omg.lol> (https://aliciasykes.com)",

--- a/src/store.js
+++ b/src/store.js
@@ -107,7 +107,8 @@ const store = new Vuex.Store({
         perms.allowWriteToDisk = false;
       }
       // Disable everything
-      if (appConfig.disableConfiguration) {
+      if (appConfig.disableConfiguration
+        || (appConfig.disableConfigurationForNonAdmin && !isUserAdmin())) {
         perms.allowWriteToDisk = false;
         perms.allowSaveLocally = false;
         perms.allowViewConfig = false;

--- a/src/utils/ConfigSchema.json
+++ b/src/utils/ConfigSchema.json
@@ -509,6 +509,12 @@
           "default": false,
           "description": "If set to true, no users will be able to view or edit the config through the UI"
         },
+        "disableConfigurationForNonAdmin": {
+          "title": "Disable all UI Config for non admin users.",
+          "type": "boolean",
+          "default": false,
+          "description": "If set to true, only admin users will be able to view or edit the config through the UI. disableConfiguration must not be set to true."
+        },
         "allowConfigEdit": {
           "title": "Allow Config Editing",
           "type": "boolean",


### PR DESCRIPTION
[![Cereal916](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/Cereal916/f73ae6)](https://github.com/Cereal916) ![Medium](https://badgen.net/badge/PR%20Size/Medium/f3ff59) [![Cereal916 /disableConfigurationForNonAdmin → Lissy93/dashy](https://badgen.net/badge/%23900/Cereal916%20%2FdisableConfigurationForNonAdmin%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/disableConfigurationForNonAdmin) ![Commits: 3 | Files Changed: 4 | Additions: 8](https://badgen.net/badge/New%20Code/Commits%3A%203%20%7C%20Files%20Changed%3A%204%20%7C%20Additions%3A%208/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: 
>  Feature 

**Overview**
> Provides an option to allow admin functionality while still hiding local auth configurations from non admin users.


**New Vars** _(if applicable)_
> Config file option: disableConfigurationForNonAdmin


**Code Quality Checklist** _(Please complete)_
- [ X ] All changes are backwards compatible
- [ X ] All lint checks and tests are passing
- [ X ] There are no (new) build warnings or errors
- [ X ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ X ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ X ] Bumps version, if new feature added