### PR TITLE
Allow favicons for subdomains

### DIFF
--- a/src/components/LinkItems/ItemIcon.vue
+++ b/src/components/LinkItems/ItemIcon.vue
@@ -202,7 +202,7 @@ export default {
     /* For a given URL, return the hostname only. Used for favicon and generative icons */
     getHostName(url) {
       try {
-        return new URL(url).hostname.split('.').slice(-2).join('.');
+        return new URL(url).hostname;
       } catch (e) {
         ErrorHandler('Unable to format URL');
         return url;


### PR DESCRIPTION
[![dkyeremeh](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/dkyeremeh/f73ae6)](https://github.com/dkyeremeh) ![🐛 Fix](https://badgen.net/badge/Type/%F0%9F%90%9B%20Fix/39b0fd) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![dkyeremeh /subdomain-favicon → Lissy93/dashy](https://badgen.net/badge/%23926/dkyeremeh%20%2Fsubdomain-favicon%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/subdomain-favicon) ![Commits: 1 | Files Changed: 1 | Additions: 0](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%200/dddd00) ![Unchecked Tasks](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FNotice/Unchecked%20Tasks/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

*Thank you for contributing to Dashy! So that your PR can be handled effectively, please populate the following fields (delete sections that are not applicable)*

**Category**: 
> One of: Bugfix 

**Overview**
> When the `url` of an item is set to a subdomain such as `http://sub.domain.com`; and the icon is set to `favicon`, Dashy fetches the favicon for the main domain (`domain.com`) instead. This can cause some confusion if the url of multiple items point to subdomains of the same domain. This PR allows Dashy to fetch the favicon of the url instead of the root domain

**Issue Number** _(if applicable)_ #00

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] Bumps version, if new feature added