### PR TITLE
- Clock Widget: fix bug, better default Handling for:  use12Hour, showSeconds

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -110,7 +110,7 @@ A simple, live-updating time and date widget with time-zone support. All fields 
 **`customCityName`** | `string` |  _Optional_ | By default the city from the time-zone is shown, but setting this value will override that text
 **`hideDate`** | `boolean` |  _Optional_ | If set to `true`, the date and city will not be shown. Defaults to `false`
 **`hideSeconds`** | `boolean` |  _Optional_ | If set to `true`, seconds will not be shown. Defaults to `false`
-**`use12Hour`** | `boolean` |  _Optional_ | If set to `true`, 12 hour time will be displayed. Defaults to `false`
+**`use12Hour`** | `boolean` |  _Optional_ | If set to `true`, 12 hour time will be displayed. Defaults to the settings suggested by the current `format` and `timeZone`
 
 #### Example
 

--- a/src/components/Widgets/Clock.vue
+++ b/src/components/Widgets/Clock.vue
@@ -37,12 +37,10 @@ export default {
       return this.timeZone.split('/')[1].replaceAll('_', ' ');
     },
     showSeconds() {
-      if (this.options.hideSeconds) return !this.options.hideSeconds;
-      // this is the default
-      return true;
+      return !this.options.hideSeconds;
     },
     use12Hour() {
-      if (this.options.use12Hour) return this.options.use12Hour;
+      if (typeof this.options.use12Hour === "boolean") return this.options.use12Hour;
       // this is the default, it gets computed by the DateTimeFormat implementation
       return Intl.DateTimeFormat(this.timeFormat, { timeZone: this.timeZone, hour: 'numeric' }).resolvedOptions().hour12 ?? false;
     },

--- a/src/components/Widgets/Clock.vue
+++ b/src/components/Widgets/Clock.vue
@@ -37,7 +37,7 @@ export default {
       return this.timeZone.split('/')[1].replaceAll('_', ' ');
     },
     showSeconds() {
-      if (this.options.hideSeconds) return this.options.hideSeconds;
+      if (this.options.hideSeconds) return !this.options.hideSeconds;
       // this is the default
       return true;
     },

--- a/src/components/Widgets/Clock.vue
+++ b/src/components/Widgets/Clock.vue
@@ -37,10 +37,14 @@ export default {
       return this.timeZone.split('/')[1].replaceAll('_', ' ');
     },
     showSeconds() {
-      return !this.options.hideSeconds;
+      if (this.options.hideSeconds) return this.options.hideSeconds;
+      // this is the default
+      return true;
     },
     use12Hour() {
-      return !this.options.use12Hour;
+      if (this.options.use12Hour) return this.options.use12Hour;
+      // this is the default, it gets computed by the DateTimeFormat implementation
+      return Intl.DateTimeFormat(this.timeFormat, { timeZone: this.timeZone, hour: 'numeric' }).resolvedOptions().hour12 ?? false;
     },
   },
   methods: {


### PR DESCRIPTION
[![Totto16](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/Totto16/f73ae6)](https://github.com/Totto16) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![Totto16 /master → Lissy93/dashy](https://badgen.net/badge/%23982/Totto16%20%2Fmaster%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/master) ![Commits: 4 | Files Changed: 2 | Additions: 2](https://badgen.net/badge/New%20Code/Commits%3A%204%20%7C%20Files%20Changed%3A%202%20%7C%20Additions%3A%202/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: 
> Bugfix / Improvement

**Overview**
> 
**config: use12Hour** | **Expected behavior** | **Previous Behavior is correct** | **PR Behavior is correct**
--- | ---  | --- | --- 
 unset | default to the DateTimeFormat format (eg. en-US true, de-DE false | :x: | :heavy_check_mark: 
 true | show  AM/PM, always! | :x: | :heavy_check_mark: 
 false |show no AM/PM, never!  |  :x: | :heavy_check_mark: 

The previous version of the function `use12Hour` was implemented wrong, it didn't separate the cases, where the options was set or unset. I fixed the behavior and added a lookup in the case, it's unset, now it behaves as expected.

I used the function [resolvedOptions()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
) from the DateTimeFormat API, to determine if it's using the 12 Hour format, according to `timeZone` and `format`.

Additionally I simplified the function `showSeconds`, so that the default is set explicitly determined, and not implictly true.


**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [x] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [x] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [x] Bumps version, if new feature added