### PR TITLE
XKCD: Use tooltip for alt text

### DIFF
--- a/src/components/Widgets/XkcdComic.vue
+++ b/src/components/Widgets/XkcdComic.vue
@@ -1,8 +1,8 @@
 <template>
-<div class="xkcd-wrapper">
+<div class="xkcd-wrapper" v-tooltip="toolTip(alt)">
   <h3 class="xkcd-title">{{ title }}</h3>
   <a :href="`https://xkcd.com/${comicNum}/`">
-    <img :src="image" :alt="alt" class="xkcd-comic" />
+    <img :src="image" :alt="alt" class="xkcd-comic"/>
   </a>
 </div>
 </template>
@@ -59,6 +59,12 @@ export default {
       this.alt = data.alt;
       this.comicNum = data.num;
     },
+    toolTip(alt) {
+      const content = alt;
+      return {
+        content, html: false, trigger: 'hover focus', delay: 250, classes: 'xkcd-alt-tt',
+      };
+    },
   },
 };
 </script>
@@ -79,4 +85,9 @@ export default {
   }
 }
 
+</style>
+<style lang="scss">
+.xkcd-alt-tt {
+  min-width: 20rem;
+}
 </style>


### PR DESCRIPTION
[![m42e](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/m42e/f73ae6)](https://github.com/m42e) ![Medium](https://badgen.net/badge/PR%20Size/Medium/f3ff59) [![m42e /xkcd-show-alt → Lissy93/dashy](https://badgen.net/badge/%231043/m42e%20%2Fxkcd-show-alt%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/xkcd-show-alt) ![Commits: 1 | Files Changed: 1 | Additions: 11](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%2011/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

*Thank you for contributing to Dashy! So that your PR can be handled effectively, please populate the following fields (delete sections that are not applicable)*

**Category**: Bufix

**Overview**
The alt text is not shown while hovering. I added a tooltip, so the alt text could be revealed easily.

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors