### PR TITLE
Fixed filtering by productId in cve-vulnerabilities widget

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -620,7 +620,7 @@ Keep track of recent security advisories and vulnerabilities, with optional filt
 **`minScore`** | `number` |  _Optional_ | If set, will only display results with a CVE score higher than the number specified. Can be a number between `0` and `9.9`. By default, vulnerabilities of all CVE scores are shown
 **`hasExploit`** | `boolean` |  _Optional_ | If set to `true`, will only show results with active exploits. Defaults to `false`
 **`vendorId`** | `number` |  _Optional_ | Only show results from a specific vendor, specified by ID. See [Vendor Search](https://www.cvedetails.com/vendor-search.php) for list of vendors. E.g. `23` (Debian), `26` (Microsoft), `23682` (CloudFlare)
-**`productId`** | `number` |  _Optional_ | Only show results from a specific app or product, specified by ID. See [Product Search](https://www.cvedetails.com/product-search.php) for list of products. E.g. `13534` (Docker), `15913` (NextCloud), `19294` (Portainer), `17908` (ProtonMail)
+**`productId`** | `number` |  _Optional_ | Only show results from a specific app or product, specified by ID. See [Product Search](https://www.cvedetails.com/product-search.php) for list of products. E.g. `28125` (Docker), `34622` (NextCloud), `50211` (Portainer), `95391` (ProtonMail)
 
 #### Example
 
@@ -635,7 +635,7 @@ or
   options:
     sortBy: publish-date
     productId: 28125
-    hasExploit: true
+    hasExploit: false
     minScore: 5
     limit: 30
 ```

--- a/src/components/Widgets/CveVulnerabilities.vue
+++ b/src/components/Widgets/CveVulnerabilities.vue
@@ -92,7 +92,7 @@ export default {
     },
     endpoint() {
       return `${widgetApiEndpoints.cveVulnerabilities}?${this.sortBy}${this.limit}`
-        + `${this.minScore}${this.vendorId}${this.hasExploit}`;
+        + `${this.minScore}${this.vendorId}${this.productId}${this.hasExploit}`;
     },
     proxyReqEndpoint() {
       const baseUrl = process.env.VUE_APP_DOMAIN || window.location.origin;


### PR DESCRIPTION
[![albcp](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/albcp/f73ae6)](https://github.com/albcp) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![albcp /master → Lissy93/dashy](https://badgen.net/badge/%231075/albcp%20%2Fmaster%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/master) ![Commits: 2 | Files Changed: 2 | Additions: 0](https://badgen.net/badge/New%20Code/Commits%3A%202%20%7C%20Files%20Changed%3A%202%20%7C%20Additions%3A%200/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265) ![Unchecked Tasks](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FNotice/Unchecked%20Tasks/f25265)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: Bugfix and Documentation

**Overview**
The *cve-vulnerabilities* widget has been updated to include a filter by productId in the endpoint. The necessary logic was already present in the code, but it was not being applied to the endpoint. In addition, the productId values listed in the documentation were corrected as they were pointing to incorrect products. The example provided has also been updated to ensure that the default configuration returns some CVEs.

**Code Quality Checklist** _(Please complete)_
- [ x] All changes are backwards compatible
- [ x] All lint checks and tests are passing
- [ x] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] Bumps version, if new feature added