### PR TITLE
[FIX] Counter for most-used + last-used, and lint warns

### DIFF
--- a/src/components/Widgets/Clock.vue
+++ b/src/components/Widgets/Clock.vue
@@ -40,7 +40,7 @@ export default {
       return !this.options.hideSeconds;
     },
     use12Hour() {
-      if (typeof this.options.use12Hour === "boolean") return this.options.use12Hour;
+      if (typeof this.options.use12Hour === 'boolean') return this.options.use12Hour;
       // this is the default, it gets computed by the DateTimeFormat implementation
       return Intl.DateTimeFormat(this.timeFormat, { timeZone: this.timeZone, hour: 'numeric' }).resolvedOptions().hour12 ?? false;
     },

--- a/src/components/Widgets/Mvg.vue
+++ b/src/components/Widgets/Mvg.vue
@@ -23,7 +23,7 @@
       :class="{cancelled: departure.cancelled}">{{ departure.destination }}</div>
       <span class="delay"
         :class="{'has-delay': departure.realtimeDepartureTime > departure.plannedDepartureTime}"
-      >{{ Math.max(0, 
+      >{{ Math.max(0,
           (departure.realtimeDepartureTime - departure.plannedDepartureTime)/60000) }}</span>
       <span class="occupancy"
       :class="'occupancy-' + departure.occupancy"
@@ -131,9 +131,9 @@ export default {
     filter_results(value) {
       if (!this.options.filters) return true;
       let useEntry = (
-          (!this.options.filters.line)
+        (!this.options.filters.line)
             || this.ensure_array(this.options.filters.line).includes(value.label)
-        );
+      );
       useEntry = useEntry
         && (
           (!this.options.filters.product)

--- a/src/mixins/ItemMixin.js
+++ b/src/mixins/ItemMixin.js
@@ -157,8 +157,8 @@ export default {
       this.$emit('itemClicked');
       // Update the most/ last used ledger, for smart-sorting
       if (!this.appConfig.disableSmartSort) {
-        this.incrementMostUsedCount(this.id);
-        this.incrementLastUsedCount(this.id);
+        this.incrementMostUsedCount(this.item.id);
+        this.incrementLastUsedCount(this.item.id);
       }
     },
     /* Open item, using specified method */


### PR DESCRIPTION
![🐛 Fix](https://badgen.net/badge/Type/%F0%9F%90%9B%20Fix/39b0fd) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![Lissy93 /FIX/most-used-last-used-counter → Lissy93/dashy](https://badgen.net/badge/%231123/Lissy93%20%2FFIX%2Fmost-used-last-used-counter%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/FIX/most-used-last-used-counter) ![Commits: 3 | Files Changed: 3 | Additions: 0](https://badgen.net/badge/New%20Code/Commits%3A%203%20%7C%20Files%20Changed%3A%203%20%7C%20Additions%3A%200/dddd00)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: Bugfix

**Overview**
- 🐛 4fc3abf5110f92508ab6d23ca8cc66b5f0dc29ca - Fix most-used and last-used counter
  - The issue was caused by item ID being undefined, as `this.id` should have been `this.item.id`
- 🚨 c3749c68370a94eb8033df8b225b6e516a99bd9c - Fix lint warning in clock component (use single quotes)
- 🚨 743232e59741e4837aa33c7f27204254592267ca - Fix lint warning in Mvg widget (use 2-space indentation)


**Issue Number** #1056 #1033

**New Vars** N/A

**Screenshot** N/A

**Code Quality Checklist** _(Please complete)_
- [X] All changes are backwards compatible
- [X] All lint checks and tests are passing
- [X] There are no (new) build warnings or errors
- [] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [] Bumps version, if new feature added