### PR TITLE
Add in rss parsing library and option to use it instead of the API

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -219,6 +219,7 @@ Display news and updates from any RSS-enabled service.
 **`limit`** | `number` |  _Optional_ | The number of posts to return. If you haven't specified an API key, this will be limited to 10
 **`orderBy`** | `string` |  _Optional_ | How results should be sorted. Can be either `pubDate`, `author` or `title`. Defaults to `pubDate`
 **`orderDirection`** | `string` |  _Optional_ | Order direction of feed items to return. Can be either `asc` or `desc`. Defaults to `desc`
+**`parseLocally`** | `boolean`     |  _Optional_ | If true parse the rss feed locally instead of using the rss2json API.
 
 #### Example
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Dashy",
-  "version": "2.1.2",
+  "version": "2.1.1",
   "license": "MIT",
   "main": "server",
   "author": "Alicia Sykes <alicia@omg.lol> (https://aliciasykes.com)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Dashy",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "license": "MIT",
   "main": "server",
   "author": "Alicia Sykes <alicia@omg.lol> (https://aliciasykes.com)",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "vue-select": "^3.20.2",
     "vue-swatches": "^2.1.1",
     "vue-toasted": "^1.1.28",
-    "vuex": "^3.6.2"
+    "vuex": "^3.6.2",
+    "rss-parser": "3.13.0"
   },
   "devDependencies": {
     "@architect/sandbox": "^4.5.2",

--- a/src/components/Widgets/RssFeed.vue
+++ b/src/components/Widgets/RssFeed.vue
@@ -31,6 +31,7 @@
 </template>
 
 <script>
+import * as Parser from 'rss-parser';
 import WidgetMixin from '@/mixins/WidgetMixin';
 import { widgetApiEndpoints } from '@/utils/defaults';
 
@@ -47,10 +48,13 @@ export default {
     /* The URL to users atom-format RSS feed */
     rssUrl() {
       if (!this.options.rssUrl) this.error('Missing feed URL');
-      return encodeURIComponent(this.options.rssUrl || '');
+      return this.options.rssUrl || '';
     },
     apiKey() {
       return this.options.apiKey;
+    },
+    parseLocally() {
+      return this.options.parseLocally;
     },
     limit() {
       const usersChoice = this.options.limit;
@@ -73,8 +77,12 @@ export default {
       const limit = this.limit && this.apiKey ? `&count=${this.limit}` : '';
       const orderBy = this.orderBy && this.apiKey ? `&order_by=${this.orderBy}` : '';
       const direction = this.orderDirection ? `&order_dir=${this.orderDirection}` : '';
-      return `${widgetApiEndpoints.rssToJson}?rss_url=${this.rssUrl}`
-        + `${apiKey}${limit}${orderBy}${direction}`;
+      if (this.parseLocally) {
+        return this.rssUrl;
+      } else {
+        return `${widgetApiEndpoints.rssToJson}?rss_url=${encodeURIComponent(this.rssUrl)}`
+          + `${apiKey}${limit}${orderBy}${direction}`;
+      }
     },
   },
   filters: {
@@ -88,31 +96,51 @@ export default {
     },
   },
   methods: {
-    /* Make GET request to Rss2Json */
+    /* Make GET request to whatever endpoint we are using */
     fetchData() {
       this.makeRequest(this.endpoint).then(this.processData);
     },
     /* Assign data variables to the returned data */
-    processData(data) {
-      const { feed, items } = data;
-      this.meta = {
-        title: feed.title,
-        link: feed.link,
-        author: feed.author,
-        description: feed.description,
-        image: feed.image,
-      };
+    async processData(data) {
+      if (this.parseLocally) {
+        const parser = new Parser();
+        const { link, title, items, author, description, image } = await parser.parseString(data);
+        this.meta = {
+          title,
+          link,
+          author,
+          description,
+          image,
+        };
+        this.processItems(items);
+      } else {
+        const { feed, items } = data;
+        this.meta = {
+          title: feed.title,
+          link: feed.link,
+          author: feed.author,
+          description: feed.description,
+          image: feed.image,
+        };
+        this.processItems(items);
+      }
+    },
+    processItems(items) {
       const posts = [];
-      items.forEach((post) => {
+      let { length } = items;
+      if (this.limit) {
+        length = this.limit;
+      }
+      for (let i = 0; length > i; i += 1) {
         posts.push({
-          title: post.title,
-          description: post.description,
-          image: post.thumbnail,
-          author: post.author,
-          date: post.pubDate,
-          link: post.link,
+          title: items[i].title,
+          description: items[i].description,
+          image: items[i].thumbnail,
+          author: items[i].author,
+          date: items[i].pubDate,
+          link: items[i].link,
         });
-      });
+      }
       this.posts = posts;
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4093,7 +4093,7 @@ enquirer@^2.3.5:
   dependencies:
     ansi-colors "^4.1.1"
 
-entities@^2.0.0:
+entities@^2.0.0, entities@^2.0.3:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
@@ -8595,6 +8595,14 @@ router@~1.3.6:
     setprototypeof "1.2.0"
     utils-merge "1.0.1"
 
+rss-parser@3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/rss-parser/-/rss-parser-3.13.0.tgz#f1f83b0a85166b8310ec531da6fbaa53ff0f50f0"
+  integrity sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==
+  dependencies:
+    entities "^2.0.3"
+    xml2js "^0.5.0"
+
 rsup-progress@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/rsup-progress/-/rsup-progress-3.0.0.tgz#e5eab5c1e75794cc288d567aa765b50faaf0cc89"
@@ -10561,6 +10569,19 @@ xml2js@0.4.19:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xml2js@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
+  integrity sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
[![hockeymikey](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/hockeymikey/f73ae6)](https://github.com/hockeymikey) ![Medium](https://badgen.net/badge/PR%20Size/Medium/f3ff59) [![hockeymikey /master → Lissy93/dashy](https://badgen.net/badge/%231167/hockeymikey%20%2Fmaster%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/master) ![Commits: 3 | Files Changed: 4 | Additions: 51](https://badgen.net/badge/New%20Code/Commits%3A%203%20%7C%20Files%20Changed%3A%204%20%7C%20Additions%3A%2051/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Lissy93&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: 
Feature

**Overview**
I don't like the idea of relying on a random API service for parsing RSS feeds or the privacy implications of it. Added an option to instead locally parse the feed. If true, it makes the request to grab the feed instead directly, then it processes it and displays it just the same.

**New Vars**
options.parseLocally in the rss_feed widget and the rss-parser dependency was added.

**Code Quality Checklist**
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [x] Attribute is outlined in the schema and documented
- [x] Package is essential, and has been checked out for security or performance
- [x] Bumps version, if new feature added