### PR TITLE
✨ Permit users to choose Celsius or Fahrenheit.

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -2380,12 +2380,19 @@ You'll need to enable the sensors plugin to use this widget, using: `--enable-pl
 
 <p align="center"><img width="400" src="https://i.ibb.co/xSs4Gqd/gl-cpu-temp.png" /></p>
 
+#### Options
+
+**Field** | **Type** | **Required** | **Description**
+--- | --- | --- | ---
+**`units`** | `string` |  _Optional_ | Use `C` to display temperatures in Celsius or `F` to use Fahrenheit. Defaults to `C`.
+
 #### Example
 
 ```yaml
 - type: gl-cpu-temp
   options:
     hostname: http://192.168.130.2:61208
+    units: C
 ```
 
 ---

--- a/src/utils/MiscHelpers.js
+++ b/src/utils/MiscHelpers.js
@@ -165,6 +165,11 @@ export const getValueFromCss = (colorVar) => {
   return cssProps.getPropertyValue(`--${colorVar}`).trim();
 };
 
+/* Given a temperature in Celsius, returns value in Fahrenheit */
+export const celsiusToFahrenheit = (celsius) => {
+  return Math.round((celsius * 1.8) + 32);
+};
+
 /* Given a temperature in Fahrenheit, returns value in Celsius */
 export const fahrenheitToCelsius = (fahrenheit) => {
   return Math.round(((fahrenheit - 32) * 5) / 9);


### PR DESCRIPTION
[![altearius](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/altearius/f73ae6)](https://github.com/altearius) ![Medium](https://badgen.net/badge/PR%20Size/Medium/f3ff59) [![altearius /FEATURE/cpu-temp-units → Lissy93/dashy](https://badgen.net/badge/%231182/altearius%20%2FFEATURE%2Fcpu-temp-units%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/FEATURE/cpu-temp-units) ![Commits: 1 | Files Changed: 3 | Additions: 47](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%203%20%7C%20Additions%3A%2047/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265) ![Unchecked Tasks](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FNotice/Unchecked%20Tasks/f25265) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Lissy93&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

*Thank you for contributing to Dashy! So that your PR can be handled effectively, please populate the following fields (delete sections that are not applicable)*

**Category**: 
> One of: Bugfix / Feature / Code style update / Refactoring Only / Build related changes /  Documentation / Other (please specify)

Feature

**Overview**
> Briefly outline your new changes...

If merged, this PR will introduce a new option for the `GlCpuTemp` widget, permitting users to express a preference for either Celsius or Fahrenheit values.

The underlying Glances sensor API can already be configured to report temperatures using either scale, using the `--fahrenheit` [command line argument][1].

This PR utilizes the unit reported by the Glances API to determine whether any conversion is necessary.

Prior to this PR, the default behavior is to always display values in Celsius, whether Glances has been configured to report in Fahrenheit or not.  This default behavior has been retained, as the new option is understood to have a default value of `C`.

**Issue Number** _(if applicable)_ #00

None.

**New Vars** _(if applicable)_
> If you've added any new build scripts, environmental variables, config file options, dependency or devDependency, please outline here

A new widget option named `units` has been introduced to the `GlCpuTemp` widget. Documentation for this option has been added to `widgets.md`.

**Screenshot** _(if applicable)_
> If you've introduced any significant UI changes, please include a screenshot

![image](https://github.com/Lissy93/dashy/assets/270430/f377f27f-da9e-429b-b585-270718ad73fd)

**Code Quality Checklist** _(Please complete)_
- [X] All changes are backwards compatible
- [X] All lint checks and tests are passing
- [X] There are no (new) build warnings or errors
- [X] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] Bumps version, if new feature added

Note: There is currently a lint failure in the `src/components/Widgets/RssFeed.vue` file. This appears to be unrelated to my changes and I presently understand this to be out of scope. Please let me know if I should correct this anyway.

I am unclear on whether this is a big enough "feature" to warrant a version bump. Please advise.

[1]: https://glances.readthedocs.io/en/latest/cmds.html#cmdoption-fahrenheit 'Glances command line argument'