### PR TITLE
Fix Vue's PWA manifestCrossorigin, remove second mainfest from head

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,12 +5,11 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <!-- Favicon, App Icon and PWA -->
+  <!-- Favicon, App Icon -->
   <link rel="icon" type="image/png" sizes="64x64" href="<%= BASE_URL %>/web-icons/favicon-64x64.png">
   <link rel="icon" type="image/png" sizes="32x32" href="web-icons/favicon-32x32.png">
   <link rel="icon" type="image/png" href="/favicon.ico" />
   <link rel="stylesheet" type="text/css" href="/loading-screen.css" />
-  <link rel="manifest" href="/manifest.json">
   <!-- Default Page Title -->
   <title>Dashy</title>
 </head>

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -306,8 +306,8 @@ module.exports = {
     themeColor: '#00af87',
     msTileColor: '#0b1021',
     mode: 'production',
+    manifestCrossorigin: 'use-credentials',
     iconPaths: {
-      manifestCrossorigin: 'use-credentials',
       favicon64: './web-icons/favicon-64x64.png',
       favicon32: './web-icons/favicon-32x32.png',
       maskIcon: './web-icons/dashy-logo.png',


### PR DESCRIPTION
**Category**:  Bugfix
**Overview**
Fixed PWA manifest crossorigin, required for PWA behind auth proxy. Removed manually added manifest duplicate as redundant.

**Issue Number** #1219

**Code Quality Checklist**
- [ x] All changes are backwards compatible

