### PR TITLE
Update generative icon API

### DIFF
--- a/docs/icons.md
+++ b/docs/icons.md
@@ -89,7 +89,7 @@ sections:
 
 ## Generative Icons
 
-To uses a unique and programmatically generated icon for a given service just set `icon: generative`. This is particularly useful when you have a lot of similar services with a different IP or port, and no specific icon. These icons are generated with [DiceBear](https://avatars.dicebear.com/) (or [Evatar](https://evatar.io/) for fallback), and use a hash of the services domain/ ip for entropy, so each domain will have a unique icon.
+To uses a unique and programmatically generated icon for a given service just set `icon: generative`. This is particularly useful when you have a lot of similar services with a different IP or port, and no specific icon. These icons are generated with [DiceBear](https://api.dicebear.com/) (or [Evatar](https://evatar.io/) for fallback), and use a hash of the services domain/ ip for entropy, so each domain will have a unique icon.
 
 <p align="center">
   <img width="500" src="https://i.ibb.co/b2pC2CL/generative-icons-2.png" />

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -202,7 +202,7 @@ module.exports = {
     fa: 'https://kit.fontawesome.com',
     mdi: 'https://cdn.jsdelivr.net/npm/@mdi/font@7.0.96/css/materialdesignicons.min.css',
     si: 'https://unpkg.com/simple-icons@v7/icons',
-    generative: 'https://avatars.dicebear.com/api/identicon/{icon}.svg',
+    generative: 'https://api.dicebear.com/7.x/identicon/svg?seed={icon}',
     generativeFallback: 'https://evatar.io/{icon}',
     localPath: './item-icons',
     faviconName: 'favicon.ico',


### PR DESCRIPTION
[![bubylou](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/bubylou/f73ae6)](https://github.com/bubylou) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![bubylou /master → Lissy93/dashy](https://badgen.net/badge/%231344/bubylou%20%2Fmaster%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/master) ![Commits: 1 | Files Changed: 2 | Additions: 0](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%202%20%7C%20Additions%3A%200/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Lissy93&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**:  Bugfix

**Overview**
> Dicebear API has been reorganized and previous endpoint only provides the same generic avatar icon

**Issue Number**
> Did not see any open issues for this. I had this problem in my kubernetes cluster and on docker on my local machine.

**Code Quality Checklist**
- [X] All changes are backwards compatible
- [X] All lint checks and tests are passing
- [X] There are no (new) build warnings or errors