### PR TITLE
 🔧 add OIDC scope option

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -15,6 +15,7 @@
   - [Setting up Keycloak](#2-setup-keycloak-users)
   - [Configuring Dashy for Keycloak](#3-enable-keycloak-in-dashy-config-file)
   - [Toubleshooting Keycloak](#troubleshooting-keycloak)
+- [OpenID Connect](#oidc)
 - [Alternative Authentication Methods](#alternative-authentication-methods)
   - [VPN](#vpn)
   - [IP-Based Access](#ip-based-access)
@@ -283,6 +284,7 @@ appConfig:
     oidc:
       clientId: [registered client id]
       endpoint: [OIDC endpoint]
+      scope: [The scope(s) to request from the OIDC provider]
 ```
 
 Because Dashy is a SPA, a [public client](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1) registration with PKCE is needed.

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -202,6 +202,7 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 --- | --- | --- | ---
 **`clientId`** | `string` | Required | The client id registered in the OIDC server
 **`endpoint`** | `string` | Required | The URL of the OIDC server that should be used.
+**`scope`** | `string` | Required | The scope(s) to request from the OIDC provider
 
 **[⬆️ Back to Top](#configuring)**
 

--- a/src/utils/ConfigSchema.json
+++ b/src/utils/ConfigSchema.json
@@ -565,7 +565,12 @@
                   "title": "OIDC Client Id",
                   "type": "string",
                   "description": "ClientId from OIDC provider"
-                }
+                },
+                "scope" : {
+                    "title": "OIDC Scope",
+                    "type": "string",
+                    "description": "The scope(s) to request from the OIDC provider"
+                  }
               }
             },
             "enableHeaderAuth": {

--- a/src/utils/OidcAuth.js
+++ b/src/utils/OidcAuth.js
@@ -20,7 +20,7 @@ class OidcAuth {
       client_id: clientId,
       redirect_uri: `${window.location.origin}`,
       response_type: 'code',
-      scope,
+      scope: scope || 'openid profile email roles groups',
       response_mode: 'query',
       filterProtocolClaims: true,
     };

--- a/src/utils/OidcAuth.js
+++ b/src/utils/OidcAuth.js
@@ -13,14 +13,14 @@ const getAppConfig = () => {
 class OidcAuth {
   constructor() {
     const { auth } = getAppConfig();
-    const { clientId, endpoint } = auth.oidc;
+    const { clientId, endpoint, scope } = auth.oidc;
     const settings = {
       userStore: new WebStorageStateStore({ store: window.localStorage }),
       authority: endpoint,
       client_id: clientId,
       redirect_uri: `${window.location.origin}`,
       response_type: 'code',
-      scope: 'openid profile email roles groups',
+      scope,
       response_mode: 'query',
       filterProtocolClaims: true,
     };


### PR DESCRIPTION
[![nOw-Ay](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/nOw-Ay/f73ae6)](https://github.com/nOw-Ay) ![Medium](https://badgen.net/badge/PR%20Size/Medium/f3ff59) [![nOw-Ay /master → Lissy93/dashy](https://badgen.net/badge/%231641/nOw-Ay%20%2Fmaster%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/master) ![Commits: 1 | Files Changed: 4 | Additions: 8](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%204%20%7C%20Additions%3A%208/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Lissy93&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: 
New configuration option

**Overview**
Add an option to customise the requested OIDC scopes. 

As of today, Dashy always ask for a lot of scopes (`openid profile email roles groups`) that the user might not be willing to configure. This PR gives more flexibility to the user, allowing him to decide which scopes to request.

**New Vars**
New config option : `scope`, `string` : The scope(s) to request from the OIDC provider

By default,`oidc-client-ts` defaults the scope to `openid`, there is thus no breaking change.

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [x] _(If a new config option is added)_ Attribute is outlined in the schema and documented