### PR TITLE
Update simple-icons to bring it the latest icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "remedial": "^1.0.8",
     "rss-parser": "3.13.0",
     "rsup-progress": "^3.2.0",
-    "simple-icons": "^12.2.0",
+    "simple-icons": "^14.4.0",
     "v-jsoneditor": "^1.4.5",
     "v-tooltip": "^2.1.3",
     "vue": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9201,10 +9201,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-simple-icons@^12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/simple-icons/-/simple-icons-12.2.0.tgz#dade5fdcb8f9d7833e7b8630028bda45c7867f25"
-  integrity sha512-q8Qpts9HIW1PP1gdwT2/NqJBgou3XG44Z4xDGvdqFZYG+eINDyHu7PEidHkPFHpP5TLcB9s4Ne70Uy5u83u7Ig==
+simple-icons@^14.4.0:
+  version "14.4.0"
+  resolved "https://registry.yarnpkg.com/simple-icons/-/simple-icons-14.4.0.tgz#64226b8deb841bcffe4c42b269049753297f6e11"
+  integrity sha512-eR4WWGF2/dMn6Na7wQZ9nUnGQg4CC9MnqYUlKKfIO0kQ79BdwyFS2L+X/MIxArULsh/IE0U48d4r9N4JVPicIQ==
 
 simple-swizzle@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
<!--
Thank you for contributing to Dashy!
So that your PR can be handled effectively, please populate the following fields
-->

**Category**: 
> One of: Bugfix / Feature / Code style update / Refactoring Only / Build related changes /  Documentation / Other (please specify)
Dependency update

**Overview**
> Briefly outline your new changes...
Updates the `simple-icons` package to bring in the latest icons. Unfortunately this is a "breaking" change in that some icons have been removed due to legal reasons (notably the Adobe suite and Nintendo icons). I'm not sure if this counts as breaking for this project. I could argue either way.

@Lissy93 would you please recommend a version bump that is appropriate for this change?

**Issue Number** _(if applicable)_ #00

**New Vars** _(if applicable)_
> If you've added any new build scripts, environmental variables, config file options, dependency or devDependency, please outline here

**Screenshot** _(if applicable)_
> If you've introduced any significant UI changes, please include a screenshot

**Code Quality Checklist** _(Please complete)_
- [ ] All changes are backwards compatible
- [ ] All lint checks and tests are passing
- [ ] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] _(If significant change)_ Bumps version in package.json

