### PR TITLE
:bug: Fix a bug in RssFeed widget that crashes on small feeds.

### DIFF
--- a/src/components/Widgets/RssFeed.vue
+++ b/src/components/Widgets/RssFeed.vue
@@ -131,7 +131,7 @@ export default {
       const posts = [];
       let { length } = items;
       if (this.limit) {
-        length = this.limit;
+        length = Math.min(length, this.limit);
       }
       for (let i = 0; length > i; i += 1) {
         posts.push({


### PR DESCRIPTION
RssFeed would always default to `this.limit` for the size of the feed item array. Feeds that came in with fewer items than the limit would throw an exception, because the loop would then try to iterate over non-existent entries.

<!--
Thank you for contributing to Dashy!
So that your PR can be handled effectively, please populate the following fields
-->

**Category**: Bugfix

**Overview**
The RssFeed widget would always try to read `this.limit` items from the array. For feeds with fewer items, it would throw an exception. My change will populate the lower of: (the limit amount of items, or the amount of items actually available).

**Issue Number** _(if applicable)_ 
N/A

**New Vars** _(if applicable)_
N/A

**Screenshot** _(if applicable)_
N/A

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [x] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [x] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [x] _(If significant change)_ Bumps version in package.json

