### PR TITLE
Adjusting SSL Portion of HealthCheck

### DIFF
--- a/services/healthcheck.js
+++ b/services/healthcheck.js
@@ -4,7 +4,15 @@
  * Note that exiting with code 1 indicates failure, and 0 is success
  */
 
-const isSsl = !!process.env.SSL_PRIV_KEY_PATH && !!process.env.SSL_PUB_KEY_PATH;
+const fs = require('fs');
+/* setting default paths for public and pvt keys to match of ssl-server.js */
+const httpsCerts = {
+  private: process.env.SSL_PRIV_KEY_PATH || '/etc/ssl/certs/dashy-priv.key',
+  public: process.env.SSL_PUB_KEY_PATH || '/etc/ssl/certs/dashy-pub.pem',
+};
+
+/* Check if either if simular conditions exist that would of had ssl-server.js to enable ssl */
+const isSsl = !!fs.existsSync(httpsCerts.private) && !!fs.existsSync(httpsCerts.public);
 
 // eslint-disable-next-line import/no-dynamic-require
 const http = require(isSsl ? 'https' : 'http');


### PR DESCRIPTION

<!--
Thank you for contributing to Dashy!
So that your PR can be handled effectively, please populate the following fields
-->

**Category**: 
>  Bugfix

**Overview**
> I ran into a issue running dashy in a podman oci container with the default value for public & private key paths  not being set the same way in `healthcheck.js` vs `ssl-server.js`

>This difference was allowing SSL to start but causing the healthcheck to get a 302 redirect to https as the criteria for checking
the `isSsl` in healthcheck.js` was not the same as what `enableSSL` is using in `ssl-server.js`

hopefully this change removes the need for `SSL_PUB_KEY_PATH`  & `SSL_PRIV_KEY_PATH` to also be set as env vars in the compose file (although i assume with the nature of how the check is currently written bare metal installs have the same issue) 


**Issue Number** _(if applicable)_ #00
>This probably solves #843 and #1410  i do not think this totally solves #768.   

> i had a hard time following that thread on #768  and if it is the same issue then awesome!!! but if not  may need to unlink it from the other 2 issues because issue scope creep might be a thing there.   

>side note: if this does not solve #768 please let me know if i can be of any help there as well. i wasnt able to follow it and  understand how it was related to the SSL issues  but am happy to help with it if i can 

**New Vars** _(if applicable)_
> this change copies `const fs`  & `const httpsCerts` from ssl-server.js and adjusts the logic of `const isSsl`

>side note: i realize httpsCerts is probably not the right name for the constant in healthcheck.js but i kept it the same as ssl-server.js to hopefully help maintainability in the future by others

**Screenshot** _(if applicable)_
> N/A

**Code Quality Checklist** _(Please complete)_
- [ ] All changes are backwards compatible
- [ ] All lint checks and tests are passing
- [ ] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] _(If significant change)_ Bumps version in package.json

