### PR TITLE
Fix apikey for Weather Forecast

### DIFF
--- a/src/components/Widgets/WeatherForecast.vue
+++ b/src/components/Widgets/WeatherForecast.vue
@@ -56,7 +56,8 @@ export default {
       return this.options.numDays || 6;
     },
     endpoint() {
-      const { apiKey, city } = this.options;
+      const apiKey = this.parseAsEnvVar(this.options.apiKey);
+      const city = this.options;
       const params = `?q=${city}&cnt=${this.numDays}&units=${this.units}&appid=${apiKey}`;
       return `${widgetApiEndpoints.weatherForecast}${params}`;
     },


### PR DESCRIPTION
<!--
Thank you for contributing to Dashy!
So that your PR can be handled effectively, please populate the following fields
-->

**Category**: 
> Bugfix 

**Overview**
> The Weather Forecast widget does not read in from env for the API key in the same way the weather app does

**Issue Number** _(if applicable)_ #00
#1828  :  created bug to attach to PR

**New Vars** _(if applicable)_
> slight adjustment of the apikey constant to hopefully allow it to read in the API key from an env var

**Screenshot** _(if applicable)_
> If you've introduced any significant UI changes, please include a screenshot

**Code Quality Checklist** _(Please complete)_
- [ ] All changes are backwards compatible
- [ ] All lint checks and tests are passing
- [ ] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] _(If significant change)_ Bumps version in package.json

