### PR TITLE
Fix pwa conflicting/missing entries in cache list

### DIFF
--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -328,8 +328,12 @@ module.exports = {
       msTileImage: './web-icons/dashy-logo.png',
     },
     workboxOptions: {
-      globIgnores: [
-        '**/.*', // Ignore dotfiles
+      exclude: [
+        // https://developer.chrome.com/docs/workbox/modules/workbox-build#properties_14
+        /\.map$/,
+        /^manifest.*\.js$/, // default value
+        /\.nojekyll$/,
+        /\.gitignore$/,
       ],
     },
   },

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -327,5 +327,10 @@ module.exports = {
       maskIcon: './web-icons/dashy-logo.png',
       msTileImage: './web-icons/dashy-logo.png',
     },
+    workboxOptions: {
+      globIgnores: [
+        '**/.*', // Ignore dotfiles
+      ],
+    },
   },
 };

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -316,7 +316,6 @@ module.exports = {
   /* Progressive Web App settings, used by Vue Config */
   pwa: {
     name: 'Dashy',
-    manifestPath: './manifest.json',
     themeColor: '#00af87',
     msTileColor: '#0b1021',
     mode: 'production',


### PR DESCRIPTION
[![he0119](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/he0119/f73ae6)](https://github.com/he0119) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![he0119 /fix/manifest → Lissy93/dashy](https://badgen.net/badge/%231868/he0119%20%2Ffix%2Fmanifest%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/fix/manifest) ![Commits: 3 | Files Changed: 1 | Additions: 8](https://badgen.net/badge/New%20Code/Commits%3A%203%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%208/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Lissy93&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thank you for contributing to Dashy!
So that your PR can be handled effectively, please populate the following fields
-->
**Category**: 

Bugfix

**Overview**

When enableServiceWorker set to true, Service Worker was unable to registered because of the following reason.

```log
Uncaught add-to-cache-list-conflicting-entries: Two of the entries passed to 'workbox-precaching.PrecacheController.addToCacheList()' had the URL undefined but different revision details. Workbox is is unable to cache and version the asset correctly. Please remove one of the entries.
```

This is because the precache-manifest has two manifest.json.

```js
  {
    "revision": "f8719853266e47aaf6f0ae56946b8014",
    "url": "/./manifest.json"
  },
  {
    "revision": "d41d8cd98f00b204e9800998ecf8427e",
    "url": "/.nojekyll"
  },
  {
    "revision": "5a8d250cf776a741afb8b4ccd2afc6b0",
    "url": "/item-icons/.gitignore"
  },
   {
    "revision": "2ebc58280d4a5a1922d2ec55e74a8c23",
    "url": "/manifest.json"
  },
```

And the default Express static file configuration excludes dotfiles (e.g. .nojekyll), causing precache files to return 404 errors during service worker installation.

https://cli.vuejs.org/core-plugins/pwa.html#configuration
https://developer.chrome.com/docs/workbox/modules/workbox-build?hl=zh-cn#type-GlobPartial

Accouding to the docs, we just need to remove the manifestPath config, and also exclude .nojekyll/.gitignore.

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [x] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [x] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [x] _(If significant change)_ Bumps version in package.json