### PR TITLE
🩹 Fix typo in Public Ip Widget endpoint definition for ip-api provider

### DIFF
--- a/src/components/Widgets/PublicIp.vue
+++ b/src/components/Widgets/PublicIp.vue
@@ -26,7 +26,7 @@ export default {
         return `${widgetApiEndpoints.publicIp2}?apiKey=${this.apiKey}`;
       } else if (this.provider === 'ip2location.io') {
         return `${widgetApiEndpoints.publicIp4}?key=${this.apiKey}`;
-      } else if (this.provider === 'ipapi') {
+      } else if (this.provider === 'ip-api') {
         return widgetApiEndpoints.publicIp3;
       }
       return widgetApiEndpoints.publicIp;


### PR DESCRIPTION
[![s-weigand](https://badgen.net/badge/%F0%9F%92%95%20Submitted%20by/s-weigand/f73ae6)](https://github.com/s-weigand) ![Quick](https://badgen.net/badge/PR%20Size/Quick/3eef8b) [![s-weigand /fix/typo-in-ip-api-provider-check → Lissy93/dashy](https://badgen.net/badge/%231869/s-weigand%20%2Ffix%2Ftypo-in-ip-api-provider-check%20%E2%86%92%20Lissy93%2Fdashy/ab5afc)](https://github.com/Lissy93/dashy/tree/fix/typo-in-ip-api-provider-check) ![Commits: 1 | Files Changed: 1 | Additions: 0](https://badgen.net/badge/New%20Code/Commits%3A%201%20%7C%20Files%20Changed%3A%201%20%7C%20Additions%3A%200/dddd00) ![Label](https://badgen.net/badge/%E2%9A%A0%EF%B8%8FMissing/Label/f25265) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Lissy93&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Category**: Bugfix 

**Overview**
First of all, thanks for the nice dashboard ❤️ 
I'm running `3.1.0` via docker in my home lab and found that the `Public Ip` Widget does not work with the `ip-api` provider.
After some looking around, I found [endpoint lookup uses `ipapi` in the comparison](https://github.com/Lissy93/dashy/blob/03ac6ec5ec1ded9dbb12c2f82bd1167da14021ce/src/components/Widgets/PublicIp.vue#L29) instead of `ip-api`, which is [used in processData](https://github.com/Lissy93/dashy/blob/03ac6ec5ec1ded9dbb12c2f82bd1167da14021ce/src/components/Widgets/PublicIp.vue#L72) and [in the docs](https://github.com/Lissy93/dashy/blob/03ac6ec5ec1ded9dbb12c2f82bd1167da14021ce/docs/widgets.md?plain=1#L302).
This causes either the data fetching to be incorrect (for me `ipapi.co` fails to fetch 🤷‍♀️) or the data processing.

**Before**

Widget with provider `ip-adr`
<img width="600" height="174" alt="image" src="https://github.com/user-attachments/assets/2cb326c1-da81-41ad-940b-1793be6f3afa" />

Widget with provider `ipadr`
<img width="609" height="184" alt="image" src="https://github.com/user-attachments/assets/b3066181-909d-4be5-9981-8556299b5c55" />

**After**
Widget with provider `ip-adr`
<img width="601" height="147" alt="image" src="https://github.com/user-attachments/assets/03458053-b4c2-446c-8132-432f5161458f" />


**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors