### PR TITLE
Fix OIDC getUser and added admin role and group

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -286,6 +286,7 @@ appConfig:
       clientId: [registered client id]
       endpoint: [OIDC endpoint]
       scope: [The scope(s) to request from the OIDC provider]
+      adminGroup: admin
 ```
 
 Because Dashy is a SPA, a [public client](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1) registration with PKCE is needed.

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -204,6 +204,8 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 --- | --- | --- | ---
 **`clientId`** | `string` | Required | The client id registered in the OIDC server
 **`endpoint`** | `string` | Required | The URL of the OIDC server that should be used.
+**`adminRole`** | `string` | _Optional_ | The role that will be considered as admin.
+**`adminGroup`** | `string` | _Optional_ | The group that will be considered as admin.
 **`scope`** | `string` | Required | The scope(s) to request from the OIDC provider
 
 **[⬆️ Back to Top](#configuring)**

--- a/src/utils/ConfigSchema.json
+++ b/src/utils/ConfigSchema.json
@@ -566,6 +566,18 @@
                   "type": "string",
                   "description": "ClientId from OIDC provider"
                 },
+                "adminRole" : {
+                  "title": "Admin Role",
+                  "type": "string",
+                  "default": false,
+                  "description": "The role that will be considered as admin. If not set, no roles will be considered as admin"
+                },
+                "adminGroup" : {
+                  "title": "Admin Group",
+                  "type": "string",
+                  "default": false,
+                  "description": "The group that will be considered as admin. If not set, no groups will be considered as admin"
+                },
                 "scope" : {
                     "title": "OIDC Scope",
                     "type": "string",

--- a/src/utils/OidcAuth.js
+++ b/src/utils/OidcAuth.js
@@ -13,7 +13,13 @@ const getAppConfig = () => {
 class OidcAuth {
   constructor() {
     const { auth } = getAppConfig();
-    const { clientId, endpoint, scope } = auth.oidc;
+    const {
+      clientId,
+      endpoint,
+      scope,
+      adminGroup,
+      adminRole,
+    } = auth.oidc;
     const settings = {
       userStore: new WebStorageStateStore({ store: window.localStorage }),
       authority: endpoint,
@@ -25,6 +31,8 @@ class OidcAuth {
       filterProtocolClaims: true,
     };
 
+    this.adminGroup = adminGroup;
+    this.adminRole = adminRole;
     this.userManager = new UserManager(settings);
   }
 
@@ -43,22 +51,27 @@ class OidcAuth {
     if (user === null) {
       await this.userManager.signinRedirect();
     } else {
-      const { roles, groups } = user.profile;
+      const { roles = [], groups = [] } = user.profile;
       const info = {
         groups,
         roles,
       };
+      const isAdmin = (Array.isArray(groups) && groups.includes(this.adminGroup))
+                      || (Array.isArray(roles) && roles.includes(this.adminRole))
+                      || false;
 
-      statusMsg(`user: ${user.profile.preferred_username}`, JSON.stringify(info));
+      statusMsg(`user: ${user.profile.preferred_username}   admin: ${isAdmin}`, JSON.stringify(info));
 
       localStorage.setItem(localStorageKeys.KEYCLOAK_INFO, JSON.stringify(info));
       localStorage.setItem(localStorageKeys.USERNAME, user.profile.preferred_username);
+      localStorage.setItem(localStorageKeys.ISADMIN, isAdmin);
     }
   }
 
   async logout() {
     localStorage.removeItem(localStorageKeys.USERNAME);
     localStorage.removeItem(localStorageKeys.KEYCLOAK_INFO);
+    localStorage.removeItem(localStorageKeys.ISADMIN);
 
     try {
       await this.userManager.signoutRedirect();

--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -137,6 +137,7 @@ module.exports = {
     MOST_USED: 'mostUsed',
     LAST_USED: 'lastUsed',
     KEYCLOAK_INFO: 'keycloakInfo',
+    ISADMIN: 'isAdmin',
     DISABLE_CRITICAL_WARNING: 'disableCriticalWarning',
   },
   /* Key names for cookie identifiers */


### PR DESCRIPTION
<!--
Thank you for contributing to Dashy!
So that your PR can be handled effectively, please populate the following fields
-->

**Category**: 
> One of: Bugfix / Feature

**Overview**
> Bugfix: fixed the behaviour of `getUsers` and `isLoggedIn` to support users logged in via OIDC

> Feature: added a `adminRole` and `adminGroup` that can be used to create a mapping from an OIDC group or role to Dashy admins

**Issue Number** _(if applicable)_ #1893 #1823

**New Vars** _(if applicable)_
> If you've added any new build scripts, environmental variables, config file options, dependency or devDependency, please outline here

#### `appConfig.auth.oidc`
**Field** | **Type** | **Required**| **Description**
--- | --- | --- | ---
**`adminRole`** | `string` | _Optional_ | The role that will be considered as admin.
**`adminGroup`** | `string` | _Optional_ | The group that will be considered as admin.

`localStorageKeys.ISADMIN` which is used for OIDC to pass the user admin status to `getUsers` (from `@/utils/Auth`) who can then handle it like any other user

**Screenshot** _(if applicable)_
> If you've introduced any significant UI changes, please include a screenshot

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [x] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [x] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [x] _(If significant change)_ Bumps version in package.json

