### PR TITLE
Fixed #1886, remove //backdrop-filter in div.edit-mode-bottom-banner in color-themes.scss

### DIFF
--- a/src/styles/color-themes.scss
+++ b/src/styles/color-themes.scss
@@ -1889,7 +1889,7 @@ html[data-theme='neomorphic'] {
 
   div.edit-mode-bottom-banner, .add-new-section {
     background: rgba(255, 255, 255, 0.15);
-    backdrop-filter: blur(50px);
+    //backdrop-filter: blur(50px);
   }
 
   .critical-error-wrap {
@@ -1910,7 +1910,7 @@ html[data-theme='glass'] {
 }
 
 html[data-theme='glass-2'] {
-    body {
+  body {
     background: url('https://i.ibb.co/FnLH6bj/dashy-glass.jpg') center center no-repeat;
     background-size: cover;
     background-color: #090317;


### PR DESCRIPTION
<!--
Thank you for contributing to Dashy!
So that your PR can be handled effectively, please populate the following fields
-->

**Category**: 
> Bugfix

**Overview**
> Fixes an issue where modals in the "glass" and "glass-2" themes were not centered on the screen and appeared “trapped” inside the edit mode area.
The root cause was "div.edit-mode-bottom-banner" having "backdrop-filter: blur(50px)", which created an unexpected stacking context and interfered with modal positioning.
By removing this backdrop filter, the modals are now positioned correctly in the center of the viewport.

**Issue Number** _(if applicable)_ #1886  Configuration nenue stuck at line

**New Vars** _(if applicable)_

**Screenshot** _(if applicable)_
Before
<img width="1470" height="956" alt="截屏2025-08-09 下午3 20 48" src="https://github.com/user-attachments/assets/7eb9c155-642c-4f9e-9387-6648e4e54206" />

After
<img width="1470" height="956" alt="截屏2025-08-09 下午3 17 07" src="https://github.com/user-attachments/assets/dc38f24c-bac7-427f-bc72-b5d8383b55d6" />

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] _(If significant change)_ Bumps version in package.json

