### PR TITLE
fix(pwa): should always fetch conf.yml first

### DIFF
--- a/src/utils/defaults.js
+++ b/src/utils/defaults.js
@@ -337,6 +337,18 @@ module.exports = {
         /^manifest.*\.js$/, // default value
         /\.nojekyll$/,
         /\.gitignore$/,
+        /conf\.yml$/, // ignore config for runtimeCaching
+      ],
+      // https://developer.chrome.com/docs/workbox/modules/workbox-build#type-RuntimeCaching
+      runtimeCaching: [
+        {
+          urlPattern: /conf\.yml$/,
+          handler: 'NetworkFirst',
+          options: {
+            cacheName: 'config-cache',
+            networkTimeoutSeconds: 3,
+          },
+        },
       ],
     },
   },


### PR DESCRIPTION
<!--
Thank you for contributing to Dashy!
So that your PR can be handled effectively, please populate the following fields
-->

**Category**: 

Bugfix

**Overview**

When enableServiceWorker is set to true, the conf.yml file is also cached. After editing the file, the website remains unchanged even after refreshing.

We should use the NetworkFirst cache mode for the conf.yml file.

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [x] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [x] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [x] _(If significant change)_ Bumps version in package.json

