### PR TITLE
Jasper/fix 1851 clipboard item

### DIFF
--- a/src/views/Workspace.vue
+++ b/src/views/Workspace.vue
@@ -46,6 +46,16 @@ export default {
   },
   methods: {
     launchApp(options) {
+      const { url, target } = options;
+      if (target === 'clipboard') {
+        if (navigator.clipboard) {
+          navigator.clipboard.writeText(url);
+          this.$toasted.show('Copied to clipboard!');
+        } else {
+          this.$toasted.show('Clipboard API not supported');
+        }
+        return;
+      }
       if (options.target === 'newtab') {
         window.open(options.url, '_blank');
       } else {

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -27,6 +27,7 @@ sections:
     description: Source Code, Issues and Pull Requests
     url: https://github.com/lissy93/dashy
     icon: favicon
+    target: newtab
   - title: Docs
     description: Configuring & Usage Documentation
     provider: Dashy.to
@@ -36,12 +37,14 @@ sections:
     description: See how others are using Dashy
     url: https://github.com/Lissy93/dashy/blob/master/docs/showcase.md
     icon: far fa-grin-hearts
+    target: newtab
   - title: Config Guide
     description: See full list of configuration options
     url: https://github.com/Lissy93/dashy/blob/master/docs/configuring.md
     icon: fas fa-wrench
+    target: newtab
   - title: Support
     description: Get help with Dashy, raise a bug, or get in contact
     url: https://github.com/Lissy93/dashy/blob/master/.github/SUPPORT.md
     icon: far fa-hands-helping
-  
+    target: newtab


### PR DESCRIPTION
<!--
Thank you for contributing to Dashy!
So that your PR can be handled effectively, please populate the following fields
-->

**Category**: 
> Bugfix

**Overview**
> Fixed clipboard items not working in workspace mode. Previously, clicking a target: clipboard item inside the workspace caused a Dashy 404 page and did not copy text.
Now, items with target: clipboard copy the content to the clipboard directly without trying to navigate, preserving workspace view.
Added target: newtab to other items in conf.yml to ensure proper workspace behavior.

**Issue Number** _(if applicable)_ #1851 

**New Vars** _(if applicable)_
> No new environment variables or dependencies.
Config option target: clipboard is used to trigger clipboard copy behavior.

**Screenshot** _(if applicable)_
> If you've introduced any significant UI changes, please include a screenshot

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
- [x] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] _(If significant change)_ Bumps version in package.json

