### PR TITLE
fix: Load userInfo in OidcAuth

### DIFF
--- a/src/utils/OidcAuth.js
+++ b/src/utils/OidcAuth.js
@@ -29,6 +29,7 @@ class OidcAuth {
       scope: scope || 'openid profile email roles groups',
       response_mode: 'query',
       filterProtocolClaims: true,
+      loadUserInfo: true,
     };
 
     this.adminGroup = adminGroup;


### PR DESCRIPTION

**Category**: 
Bugfix

**Overview**
According to the [OIDC ID Token spec](https://openid.net/specs/openid-connect-core-1_0-final.html#IDToken), the ID token doesn't have to include any of the userinfo fields (username, email, groups, etc). They have to be requested separately from the `userinfo` endpoint. `oidc-client-ts` by [default](https://authts.github.io/oidc-client-ts/interfaces/UserManagerSettings.html#loaduserinfo) doesn't call that endpoint. So Dashy ends up with `user: undefined` and no groups/roles.

To fix this, we simply need to pass `loadUserInfo` flag to OIDC's settings.
More detailed info: https://github.com/Lissy93/dashy/issues/1901#issuecomment-3263460454

**Issue Number** _(if applicable)_ #1901

**New Vars** _(if applicable)_
N/A

**Screenshot** _(if applicable)_
N/A

**Code Quality Checklist** _(Please complete)_
- [X] All changes are backwards compatible
- [X] All lint checks and tests are passing
- [X] There are no (new) build warnings or errors
- [X] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [X] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [X] _(If significant change)_ Bumps version in package.json

