### PR TITLE
new feature: Section can be locked with a pin of hashed pin

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -243,6 +243,7 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 **`items`** | `array` | _Optional_ | An array of items to be displayed within the section. See [`item`](#sectionitem). Sections must include either 1 or more items, or 1 or more widgets.
 **`widgets`** | `array` | _Optional_ | An array of widgets to be displayed within the section. See [`widget`](#sectionwidget-optional)
 **`displayData`** | `object` | _Optional_ | Meta-data to optionally override display settings for a given section. See [`displayData`](#sectiondisplaydata-optional)
+**`pin`** | `string` | _Optional_ | The PIN code for unlocking this section if `secret` under `displayData` is true. Provide at the section root (e.g., pin: 2749). Validated client-side and remembered only for the current browser tab/session. Not intended for protecting highly sensitive data. Only for Child-proofing 
 
 **[⬆️ Back to Top](#configuring)**
 
@@ -317,6 +318,7 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 **`hideForGuests`** | `boolean` | _Optional_ | Current section will be visible for logged in users, but not for guests (see `appConfig.enableGuestAccess`). Defaults to `false`
 **`hideForKeycloakUsers`** | `object`  | _Optional_ | Current section will be visible to all keycloak users, except for those configured via these groups and roles. See `hideForKeycloakUsers`
 **`showForKeycloakUsers`** | `object`  | _Optional_ | Current section will be hidden from all keycloak users, except for those configured via these groups and roles. See `showForKeycloakUsers`
+**`secret`** | `boolean` | _Optional_ | When true, the section is hidden behind a PIN gate. The PIN must be provided at the section root via `pin`. While locked, the section shows a PIN input instead of its items. On successful entry, the section unlocks for the current browser tab/session (not persisted across tab closes). In Edit Mode the gate is bypassed so you can configure/unhide the section.
 
 **[⬆️ Back to Top](#configuring)**
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -243,7 +243,7 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 **`items`** | `array` | _Optional_ | An array of items to be displayed within the section. See [`item`](#sectionitem). Sections must include either 1 or more items, or 1 or more widgets.
 **`widgets`** | `array` | _Optional_ | An array of widgets to be displayed within the section. See [`widget`](#sectionwidget-optional)
 **`displayData`** | `object` | _Optional_ | Meta-data to optionally override display settings for a given section. See [`displayData`](#sectiondisplaydata-optional)
-**`pin`** | `string` | _Optional_ | The PIN code for unlocking this section if `secret` under `displayData` is true. Provide at the section root (e.g., pin: 2749). Validated client-side and remembered only for the current browser tab/session. Not intended for protecting highly sensitive data. Only for Child-proofing 
+**`pin`** | `string` | _Optional_ | The PIN code for unlocking this section if `secret` under `displayData` is true. Provide at the section root (e.g., pin: 2749). Validated client-side and remembered only for the current browser tab/session. Not intended for protecting highly sensitive data. Only for Child-proofing. if not entered but section is locked then default pin will be 0000 
 
 **[⬆️ Back to Top](#configuring)**
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -243,7 +243,7 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 **`items`** | `array` | _Optional_ | An array of items to be displayed within the section. See [`item`](#sectionitem). Sections must include either 1 or more items, or 1 or more widgets.
 **`widgets`** | `array` | _Optional_ | An array of widgets to be displayed within the section. See [`widget`](#sectionwidget-optional)
 **`displayData`** | `object` | _Optional_ | Meta-data to optionally override display settings for a given section. See [`displayData`](#sectiondisplaydata-optional)
-**`pin`** | `string` | _Optional_ | The PIN code for unlocking this section if `secret` under `displayData` is true. Provide at the section root (e.g., pin: 2749). Validated client-side and remembered only for the current browser tab/session. Not intended for protecting highly sensitive data. Only for Child-proofing. if not entered but section is locked then default pin will be 0000 
+**`pin`** | `string` | _Optional_ | The PIN code for unlocking this section if `secret` under `displayData` is true. Provide at the section root (e.g., pin: 2749). Validated client-side and remembered only for the current browser tab/session. Not intended for protecting highly sensitive data. Only for Child-proofing. if not entered but section is locked then default pin will be 0000. optionally user can input SHA256 hash of their pin here. 
 
 **[⬆️ Back to Top](#configuring)**
 

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -251,6 +251,12 @@
       "remove-section": "Remove"
     }
   },
+  "pin": {
+    "unlock": "Unlock",
+    "lock": "Lock",
+    "lockedSection": "Locked section",
+    "enter-pin": "Enter PIN"
+  },
   "footer": {
     "dev-by": "Developed by",
     "licensed-under": "Licensed under",

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -255,7 +255,8 @@
     "unlock": "Unlock",
     "lock": "Lock",
     "lockedSection": "Locked section",
-    "enter-pin": "Enter PIN"
+    "enter-pin": "Enter PIN",
+    "incorrect-pin": "Incorrect PIN"
   },
   "footer": {
     "dev-by": "Developed by",

--- a/src/components/InteractiveEditor/PinInput.vue
+++ b/src/components/InteractiveEditor/PinInput.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="pin-gate">
+    <div class="pin-head">
+      <i class="far fa-lock" aria-hidden="true"></i>
+      <span>Locked section</span>
+    </div>
+
+    <FormSchema
+      :schema="schema"
+      v-model="form"
+      name="pinInputForm"
+      class="pin-form"
+    />
+
+    <div class="pin-actions">
+      <button class="pin-btn" @click="submit">Unlock</button>
+      <button class="pin-reset" @click="lockAgain" type="button">Lock again</button>
+    </div>
+  </div>
+</template>
+
+<script>
+import FormSchema from '@formschema/native';
+
+export default {
+  name: 'PinInput',
+  components: { FormSchema },
+  props: {
+    id: String,
+  },
+  data() {
+    return {
+      form: { pin: '' },
+      schema: {
+        type: 'object',
+        properties: {
+          pin: {
+            title: 'Enter PIN',
+            type: 'string',
+            attrs: {
+              type: 'password',
+              inputmode: 'numeric',
+              autocomplete: 'one-time-code',
+              placeholder: '••••',
+              class: 'pin-input',
+            },
+          },
+        },
+        required: ['pin'],
+      },
+    };
+  },
+  methods: {
+    submit() {
+      const tried = String(this.form.pin || '');
+      this.$emit('unlock_attempt', {
+        pin: tried,
+        id: this.id,
+      });
+      // clear local field
+      this.form.pin = '';
+    },
+    lockAgain() {
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+</style>

--- a/src/components/InteractiveEditor/PinInput.vue
+++ b/src/components/InteractiveEditor/PinInput.vue
@@ -13,8 +13,12 @@
     />
 
     <div class="pin-actions">
-      <button class="pin-btn" @click="submit">Unlock</button>
-      <button class="pin-reset" @click="lockAgain" type="button">Lock again</button>
+      <button class="pin-btn" @click="submit">
+        <i class="fas fa-unlock-alt btn-icon" aria-hidden="true"></i>
+        Unlock</button>
+      <button class="pin-reset" @click="lockAgain" type="button">
+        <i class="fas fa-lock btn-icon" aria-hidden="true"></i>
+        Lock</button>
     </div>
   </div>
 </template>
@@ -42,7 +46,6 @@ export default {
               inputmode: 'numeric',
               autocomplete: 'one-time-code',
               placeholder: '••••',
-              class: 'pin-input',
             },
           },
         },
@@ -66,5 +69,61 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
+  .pin-gate {
+    padding: .9rem;
+    border-radius: var(--curve-factor);
+    border: 1px solid var(--border);
+    background: var(--item-background);
+    box-shadow: var(--item-shadow);
+    color: var(--primary);
+  }
+
+  .pin-head {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    margin-bottom: .6rem;
+    font-weight: 600;
+  }
+  .pin-form {
+    margin-bottom: .6rem;
+  }
+  .pin-actions {
+    display: flex;
+    align-items: center;
+    justify-content: right;
+    gap: .5rem;
+    flex-wrap: wrap;
+  }
+
+  .pin-btn {
+    padding: .5rem .9rem;
+    border-radius: .6rem;
+    border: 1px solid var(--border);
+    background: var(--button-bg);
+    color: var(--primary);
+    cursor: pointer;
+    transition: transform .06s ease;
+
+    &:active { transform: translateY(1px); }
+  }
+
+  .pin-reset {
+    background: transparent;
+    border: none;
+    padding: .3rem .2rem;
+    color: var(--primary);
+    opacity: .8;
+    text-decoration: underline;
+    cursor: pointer;
+
+    &:hover { opacity: 1; }
+  }
+  .btn-icon {
+    margin-right: .4rem;
+    font-size: .95em;
+    line-height: 0;
+    opacity: .9;
+  }
 </style>

--- a/src/components/InteractiveEditor/PinInput.vue
+++ b/src/components/InteractiveEditor/PinInput.vue
@@ -68,60 +68,7 @@ export default {
 </script>
 
 <style scoped lang="scss">
-  .pin-gate {
-    padding: .9rem;
-    border-radius: var(--curve-factor);
-    border: 1px solid var(--border);
-    background: var(--item-background);
-    box-shadow: var(--item-shadow);
-    color: var(--primary);
-  }
 
-  .pin-head {
-    display: flex;
-    align-items: center;
-    gap: .5rem;
-    margin-bottom: .6rem;
-    font-weight: 600;
-  }
-  .pin-form {
-    margin-bottom: .6rem;
-  }
-  .pin-actions {
-    display: flex;
-    align-items: center;
-    justify-content: right;
-    gap: .5rem;
-    flex-wrap: wrap;
-  }
+@import '@/styles/pin-input.scss';
 
-  .pin-btn {
-    padding: .5rem .9rem;
-    border-radius: .6rem;
-    border: 1px solid var(--border);
-    background: var(--button-bg);
-    color: var(--primary);
-    cursor: pointer;
-    transition: transform .06s ease;
-
-    &:active { transform: translateY(1px); }
-  }
-
-  .pin-reset {
-    background: transparent;
-    border: none;
-    padding: .3rem .2rem;
-    color: var(--primary);
-    opacity: .8;
-    text-decoration: underline;
-    cursor: pointer;
-
-    &:hover { opacity: 1; }
-  }
-  .btn-icon {
-    margin-right: .4rem;
-    font-size: .95em;
-    line-height: 0;
-    opacity: .9;
-  }
 </style>

--- a/src/components/InteractiveEditor/PinInput.vue
+++ b/src/components/InteractiveEditor/PinInput.vue
@@ -2,7 +2,7 @@
   <div class="pin-gate">
     <div class="pin-head">
       <i class="far fa-lock" aria-hidden="true"></i>
-      <span>Locked section</span>
+      <span>{{ $t('pin.lockedSection') }}</span>
     </div>
 
     <FormSchema
@@ -13,12 +13,10 @@
     />
 
     <div class="pin-actions">
-      <button class="pin-btn" @click="submit">
+      <button class="pin-btn" @click="submit" :aria-label="$t('pin.unlock')">
         <i class="fas fa-unlock-alt btn-icon" aria-hidden="true"></i>
-        Unlock</button>
-      <button class="pin-reset" @click="lockAgain" type="button">
-        <i class="fas fa-lock btn-icon" aria-hidden="true"></i>
-        Lock</button>
+        {{ $t('pin.unlock') }}
+      </button>
     </div>
   </div>
 </template>
@@ -39,7 +37,7 @@ export default {
         type: 'object',
         properties: {
           pin: {
-            title: 'Enter PIN',
+            title: this.$t('pin.enter-pin'),
             type: 'string',
             attrs: {
               type: 'password',

--- a/src/components/InteractiveEditor/PinInput.vue
+++ b/src/components/InteractiveEditor/PinInput.vue
@@ -13,11 +13,13 @@
     />
 
     <div class="pin-actions">
+      <div v-if="errorMessage" class="pin-error">{{ errorMessage }}</div>
       <button class="pin-btn" @click="submit" :aria-label="$t('pin.unlock')">
         <i class="fas fa-unlock-alt btn-icon" aria-hidden="true"></i>
         {{ $t('pin.unlock') }}
       </button>
     </div>
+
   </div>
 </template>
 
@@ -29,6 +31,7 @@ export default {
   components: { FormSchema },
   props: {
     id: String,
+    errorMessage: String,
   },
   data() {
     return {

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -126,6 +126,7 @@ import ContextMenu from '@/components/LinkItems/SectionContextMenu.vue';
 import PinInput from '@/components/InteractiveEditor/PinInput.vue';
 import ErrorHandler from '@/utils/ErrorHandler';
 import StoreKeys from '@/utils/StoreMutations';
+import { pinHash } from '@/utils/SectionHelpers';
 import {
   sortOrder as defaultSortOrder,
   localStorageKeys,
@@ -141,7 +142,7 @@ export default {
     groupId: String,
     title: String,
     icon: String,
-    pin: String,
+    pin: [String, Number],
     displayData: Object,
     items: Array,
     widgets: Array,
@@ -337,7 +338,9 @@ export default {
       sessionStorage.setItem(SECRET_UNLOCKED_KEY, JSON.stringify(map));
       const unlockPins = JSON.parse(sessionStorage.getItem(SECRET_UNLOCKED_KEY) || '{}');
       const sectionKey = this.sectionRef;
-      if (unlockPins[sectionKey] === this.pin) {
+      const savedPin = unlockPins[sectionKey];
+
+      if (savedPin === pinHash(pin) || savedPin === pin.toString()) {
         this.pinError = '';
         this.isUnlocked = true;
       } else {

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -17,6 +17,7 @@
     <PinInput
       v-if="showPinRequired"
       :id = "sectionRef"
+      :errorMessage="pinError"
       @unlock_attempt="saveUnlockPins"
     />
     <div v-if="!showPinRequired">
@@ -168,6 +169,7 @@ export default {
       sectionWidth: 0,
       resizeObserver: null,
       isUnlocked: true,
+      pinError: '',
     };
   },
   computed: {
@@ -378,14 +380,13 @@ export default {
       const map = JSON.parse(sessionStorage.getItem(SECRET_UNLOCKED_KEY) || '{}');
       map[id] = pin;
       sessionStorage.setItem(SECRET_UNLOCKED_KEY, JSON.stringify(map));
-      this.updateUnlocked();
-    },
-    updateUnlocked() {
       const unlockPins = JSON.parse(sessionStorage.getItem(SECRET_UNLOCKED_KEY) || '{}');
       const sectionKey = this.sectionRef;
       if (unlockPins[sectionKey] === this.pin) {
+        this.pinError = '';
         this.isUnlocked = true;
       } else {
+        this.pinError = this.$t('pin.incorrect-pin');
         this.isUnlocked = false;
       }
     },
@@ -396,6 +397,7 @@ export default {
         delete unlockPins[sectionKey];
         sessionStorage.setItem(SECRET_UNLOCKED_KEY, JSON.stringify(unlockPins));
       }
+      this.pinError = '';
       this.isUnlocked = false;
     },
   },

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -336,7 +336,7 @@ export default {
       const map = JSON.parse(sessionStorage.getItem(SECRET_UNLOCKED_KEY) || '{}');
       map[id] = pin;
       sessionStorage.setItem(SECRET_UNLOCKED_KEY, JSON.stringify(map));
-      const unlockPins = JSON.parse(sessionStorage.getItem(SECRET_UNLOCKED_KEY) || '{}');
+      const unlockPins = JSON.parse(sessionStorage.getItem(SECRET_PINS_KEY) || '{}');
       const sectionKey = this.sectionRef;
       const savedPin = unlockPins[sectionKey];
 
@@ -373,7 +373,7 @@ export default {
 
       const secretPin = String(this.pin || '0000');
       const sectionKey = this.sectionRef;
-
+      console.log('Section Key', sectionKey, secretPin);
       const pins = JSON.parse(sessionStorage.getItem(SECRET_PINS_KEY) || '{}');
       if (pins[sectionKey] !== secretPin) {
         pins[sectionKey] = secretPin;

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -232,20 +232,6 @@ export default {
       }
       return styles;
     },
-    shouldRenderSection() {
-      const hidden = this.displayData?.hiddenOnPurpose === true;
-
-      // Always show in Edit Mode so the user can unhide it
-      if (this.isEditMode) return true;
-
-      // If not hidden, render as usual
-      if (!hidden || this.showHiddenMode) return true;
-
-      // If hidden, only show when search is active AND this section has hits
-      const searchActive = (this.searchTerm || '').trim().length > 0;
-      const hasHits = Array.isArray(this.items) && this.items.length > 0;
-      return searchActive && hasHits;
-    },
     showPinRequired() {
       if (this.isEditMode) return false;
       return this.displayData.secret === true && !this.isUnlocked;
@@ -253,37 +239,6 @@ export default {
     unLockedWithPin() {
       if (this.isEditMode) return false;
       return this.displayData.secret === true && this.isUnlocked;
-    },
-  },
-  watch: {
-    searchTerm: {
-      handler(newSeachTerm) {
-        // find if special code search is used
-        const showHidden = newSeachTerm.trim().toLowerCase() === '<hidden>';
-        this.showHiddenMode = showHidden;
-
-        // check if search is active
-        let searchIsActive = false;
-        if (newSeachTerm && newSeachTerm.trim().length > 0) {
-          searchIsActive = true;
-        }
-
-        // check if search is hit
-        const hasHits = this.items.length > 0;
-
-        // action if search is active and search hits and it was collapsed
-        if (searchIsActive && hasHits && this.isCollapsed) {
-          this.expandCollapseSection();
-          this.autoOpenedBySearch = true;
-        }
-
-        // action if that search is not a hit anymore
-        if (this.autoOpenedBySearch && (!searchIsActive || !hasHits)) {
-          this.expandCollapseSection();
-          this.autoOpenedBySearch = false;
-        }
-      },
-      immediate: true,
     },
   },
   methods: {

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -20,6 +20,10 @@
       @unlock_attempt="saveUnlockPins"
     />
     <div v-if="!showPinRequired">
+      <button v-if="unLockedWithPin" class="pin-reset" @click="lockAgain" type="button">
+        <i class="fas fa-lock btn-icon" aria-hidden="true"></i>
+        {{ $t('pin.lock') }}
+      </button>
       <!-- If no items, show message -->
       <div v-if="isEmpty" class="no-items">
         {{ $t('home.no-items-section') }}
@@ -242,6 +246,10 @@ export default {
       if (this.isEditMode) return false;
       return this.displayData.secret === true && !this.isUnlocked;
     },
+    unLockedWithPin() {
+      if (this.isEditMode) return false;
+      return this.displayData.secret === true && this.isUnlocked;
+    },
   },
   watch: {
     searchTerm: {
@@ -365,19 +373,28 @@ export default {
       if (secElem && secElem.$el.clientWidth) this.sectionWidth = secElem.$el.clientWidth;
     },
     saveUnlockPins({ pin, id }) {
-      const map = JSON.parse(localStorage.getItem(SECRET_UNLOCKED_KEY) || '{}');
+      const map = JSON.parse(sessionStorage.getItem(SECRET_UNLOCKED_KEY) || '{}');
       map[id] = pin;
-      localStorage.setItem(SECRET_UNLOCKED_KEY, JSON.stringify(map));
+      sessionStorage.setItem(SECRET_UNLOCKED_KEY, JSON.stringify(map));
       this.updateUnlocked();
     },
     updateUnlocked() {
-      const unlockPins = JSON.parse(localStorage.getItem(SECRET_UNLOCKED_KEY) || '{}');
+      const unlockPins = JSON.parse(sessionStorage.getItem(SECRET_UNLOCKED_KEY) || '{}');
       const sectionKey = this.sectionRef;
       if (unlockPins[sectionKey] === this.pin) {
         this.isUnlocked = true;
       } else {
         this.isUnlocked = false;
       }
+    },
+    lockAgain() {
+      const unlockPins = JSON.parse(sessionStorage.getItem(SECRET_UNLOCKED_KEY) || '{}');
+      const sectionKey = this.sectionRef;
+      if (unlockPins[sectionKey]) {
+        delete unlockPins[sectionKey];
+        sessionStorage.setItem(SECRET_UNLOCKED_KEY, JSON.stringify(unlockPins));
+      }
+      this.isUnlocked = false;
     },
   },
   mounted() {
@@ -395,10 +412,10 @@ export default {
       const secretPin = String(this.pin || '0000');
       const sectionKey = this.sectionRef;
 
-      const pins = JSON.parse(localStorage.getItem(SECRET_PINS_KEY) || '{}');
+      const pins = JSON.parse(sessionStorage.getItem(SECRET_PINS_KEY) || '{}');
       if (pins[sectionKey] !== secretPin) {
         pins[sectionKey] = secretPin;
-        localStorage.setItem(SECRET_PINS_KEY, JSON.stringify(pins));
+        sessionStorage.setItem(SECRET_PINS_KEY, JSON.stringify(pins));
       }
     }
   },

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -20,10 +20,6 @@
       @unlock_attempt="saveUnlockPins"
     />
     <div v-if="!showPinRequired">
-      <button v-if="unLockedWithPin" class="pin-reset" @click="lockAgain" type="button">
-        <i class="fas fa-lock btn-icon" aria-hidden="true"></i>
-        {{ $t('pin.lock') }}
-      </button>
       <!-- If no items, show message -->
       <div v-if="isEmpty" class="no-items">
         {{ $t('home.no-items-section') }}
@@ -81,6 +77,12 @@
           :index="index"
           @navigateToSection="navigateToSection"
         />
+      </div>
+      <div v-if="unLockedWithPin" class="pin-unlocked-bar">
+        <button class="pin-reset" @click="lockAgain" type="button">
+          <i class="fas fa-lock btn-icon" aria-hidden="true"></i>
+          {{ $t('pin.lock') }}
+        </button>
       </div>
     </div>
     <!-- Modal for opening in modal view -->
@@ -431,6 +433,7 @@ export default {
 <style scoped lang="scss">
 @import '@/styles/media-queries.scss';
 @import '@/styles/style-helpers.scss';
+@import '@/styles/pin-input.scss';
 
 .no-items {
     width: 100px;

--- a/src/styles/pin-input.scss
+++ b/src/styles/pin-input.scss
@@ -1,0 +1,65 @@
+.btn-icon {
+  margin-right: .4rem;
+  font-size: .95em;
+  line-height: 0;
+  opacity: .9;
+}
+
+.pin-gate {
+  padding: .9rem;
+  border-radius: var(--curve-factor);
+  border: 1px solid var(--border);
+  background: var(--item-background);
+  box-shadow: var(--item-shadow);
+  color: var(--primary);
+}
+
+.pin-head {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  margin-bottom: .6rem;
+  font-weight: 600;
+}
+
+.pin-form {
+  margin-bottom: .6rem;
+}
+.pin-actions {
+  display: flex;
+  align-items: center;
+  justify-content: right;
+  gap: .5rem;
+  flex-wrap: wrap;
+}
+
+.pin-btn {
+  padding: .5rem .9rem;
+  border-radius: .6rem;
+  border: 1px solid var(--border);
+  background: var(--button-bg);
+  color: var(--primary);
+  cursor: pointer;
+  transition: transform .06s ease;
+
+  &:active { transform: translateY(1px); }
+}
+
+.pin-reset {
+  background: transparent;
+  border: none;
+  padding: .3rem .2rem;
+  color: var(--primary);
+  opacity: .8;
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:hover { opacity: 1; }
+}
+
+.pin-unlocked-bar{
+  display: flex;
+  align-items: center;
+  width: 100%;
+  justify-content: flex-end;
+}

--- a/src/styles/pin-input.scss
+++ b/src/styles/pin-input.scss
@@ -63,3 +63,7 @@
   width: 100%;
   justify-content: flex-end;
 }
+
+.pin-error {
+  color: var(--error, #d9534f);
+}

--- a/src/utils/ConfigSchema.json
+++ b/src/utils/ConfigSchema.json
@@ -756,6 +756,11 @@
             "type": "string",
             "description": "Icon will be displayed next to title"
           },
+          "pin":{
+            "title": "Section Pin",
+            "type": "string",
+            "description": "PIN to unlock this section"
+          },
           "displayData": {
             "title": "Display Data",
             "type": "object",
@@ -775,6 +780,12 @@
                 ],
                 "default": "default",
                 "description": "How to sort items within the section. By default items are displayed in the order in which they are listed in within the config"
+              },
+              "secret": {
+                "title": "Pin Locked",
+                "type": "boolean",
+                "default": false,
+                "description": "If true, section will be hidden by default, and can be revealed by inputing pin"
               },
               "collapsed": {
                 "title": "Is Collapsed?",

--- a/src/utils/ConfigSchema.json
+++ b/src/utils/ConfigSchema.json
@@ -758,7 +758,7 @@
           },
           "pin":{
             "title": "Section Pin",
-            "type": "string",
+            "type": ["number", "string"],
             "description": "PIN to unlock this section"
           },
           "displayData": {

--- a/src/utils/SectionHelpers.js
+++ b/src/utils/SectionHelpers.js
@@ -1,5 +1,5 @@
 /* Helper functions for Sections and Items */
-
+import sha256 from 'crypto-js/sha256';
 import { hideFurnitureOn } from '@/utils/defaults';
 
 /* Returns false if page furniture should be hidden on said route */
@@ -38,4 +38,9 @@ export const applyItemId = (inputSections) => {
     }
   });
   return sections;
+};
+
+export const pinHash = (pin) => {
+  if (!pin) return null;
+  return sha256(pin).toString().toUpperCase();
 };

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -26,6 +26,7 @@
           :index="index"
           :title="section.name"
           :icon="section.icon || undefined"
+          :pin="section.pin || undefined"
           :displayData="getDisplayData(section)"
           :groupId="makeSectionId(section)"
           :items="section.filteredItems"

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -46,7 +46,7 @@ sections:
     icon: far fa-hands-helping
 - name: Stuff
   icon: fas fa-rocket
-  pin: "1112"
+  pin: FE91A760983D401D9B679FB092B689488D1F46D92F3AF5E9E93363326F3E8AA4
   displayData:
     secret: true
   items:
@@ -62,7 +62,7 @@ sections:
     target: newtab
 - name: Stuff 2
   icon: fas fa-rocket
-  pin: "1114"
+  pin: 1114
   displayData:
     secret: true
   items:

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -44,4 +44,19 @@ sections:
     description: Get help with Dashy, raise a bug, or get in contact
     url: https://github.com/Lissy93/dashy/blob/master/.github/SUPPORT.md
     icon: far fa-hands-helping
-  
+- name: Stuff
+  icon: fas fa-rocket
+  pin: "1111"
+  displayData:
+    secret: true
+  items:
+  - title: hidden tile 1
+    description: Development a project management links for Dashy
+    icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
+    url: https://live.dashy.to/
+    target: newtab
+  - title: hidden tile 2
+    description: Development a project management links for Dashy
+    icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
+    url: https://live.dashy.to/
+    target: newtab

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -17,9 +17,6 @@ appConfig:
 sections:
 - name: Getting Started
   icon: fas fa-rocket
-  pin: 1245
-  displayData:
-    secret: true
   items:
   - title: Dashy Live
     description: Development a project management links for Dashy

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -43,36 +43,4 @@ sections:
   - title: Support
     description: Get help with Dashy, raise a bug, or get in contact
     url: https://github.com/Lissy93/dashy/blob/master/.github/SUPPORT.md
-    icon: far fa-hands-helping
-- name: Stuff
-  icon: fas fa-rocket
-  pin: FE91A760983D401D9B679FB092B689488D1F46D92F3AF5E9E93363326F3E8AA4
-  displayData:
-    secret: true
-  items:
-  - title: hidden tile 1
-    description: Development a project management links for Dashy
-    icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
-    url: https://live.dashy.to/
-    target: newtab
-  - title: hidden tile 2
-    description: Development a project management links for Dashy
-    icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
-    url: https://live.dashy.to/
-    target: newtab
-- name: Stuff 2
-  icon: fas fa-rocket
-  pin: 1114
-  displayData:
-    secret: true
-  items:
-  - title: hidden tile 1
-    description: Development a project management links for Dashy
-    icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
-    url: https://live.dashy.to/
-    target: newtab
-  - title: hidden tile 2
-    description: Development a project management links for Dashy
-    icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
-    url: https://live.dashy.to/
-    target: newtab
+    icon: far fa-hands-helping  

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -17,6 +17,9 @@ appConfig:
 sections:
 - name: Getting Started
   icon: fas fa-rocket
+  pin: 1245
+  displayData:
+    secret: true
   items:
   - title: Dashy Live
     description: Development a project management links for Dashy

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -60,3 +60,19 @@ sections:
     icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
     url: https://live.dashy.to/
     target: newtab
+- name: Stuff 2
+  icon: fas fa-rocket
+  pin: "1114"
+  displayData:
+    secret: true
+  items:
+  - title: hidden tile 1
+    description: Development a project management links for Dashy
+    icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
+    url: https://live.dashy.to/
+    target: newtab
+  - title: hidden tile 2
+    description: Development a project management links for Dashy
+    icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
+    url: https://live.dashy.to/
+    target: newtab

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -46,7 +46,7 @@ sections:
     icon: far fa-hands-helping
 - name: Stuff
   icon: fas fa-rocket
-  pin: "1111"
+  pin: "1112"
   displayData:
     secret: true
   items:


### PR DESCRIPTION
<!--
Thank you for contributing to Dashy!
So that your PR can be handled effectively, please populate the following fields
-->

**Category**: 
> One of: Bugfix / Feature / Code style update / Refactoring Only / Build related changes /  Documentation / Other (please specify)

Feature 

**Overview**
> Briefly outline your new changes...

Added the feature to lock a Section with a pin. in the conf yml, if you add a key called `secret` under displayData, the section will be locked with a default pin of 0000. the locked section will not show any of it's items or widget but will show a input field where pin number can be entered. upon entering the right pin, the section will unlock and show its contents.

user can change the default pin by adding a key `pin` under the section. a number can be used or sha256 hash can also be used in this field. 

**Issue Number** _(if applicable)_ #00

**New Vars** _(if applicable)_
> If you've added any new build scripts, environmental variables, config file options, dependency or devDependency, please outline here

under section : pin
under section.displayData: secret

**Screenshot** _(if applicable)_
> If you've introduced any significant UI changes, please include a screenshot

<img width="521" height="306" alt="image" src="https://github.com/user-attachments/assets/746ea454-bb18-46c8-b100-cc6e7ce071a9" />


**Code Quality Checklist** _(Please complete)_
- [X] All changes are backwards compatible
- [X] All lint checks and tests are passing
- [X] There are no (new) build warnings or errors
- [X] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] _(If significant change)_ Bumps version in package.json

