### PR TITLE
:bug: Updated GlAlerts to use latest Glances Alerts API

### DIFF
--- a/src/components/Widgets/GlAlerts.vue
+++ b/src/components/Widgets/GlAlerts.vue
@@ -49,7 +49,7 @@ export default {
             time: timestampToDateTime(alert.begin * 1000),
             ongoing: (alert.end === -1),
             timeAgo: getTimeAgo(alert.begin * 1000),
-            lasted: alert.begin ? getTimeDifference(alert.begin * 1000, alert.end * 1000) : 'Ongoing',
+            lasted: alert.end !== -1 ? getTimeDifference(alert.begin * 1000, alert.end * 1000) : 'Ongoing',
             severity: alert.state,
             category: alert.type,
             value: round(alert.sum),


### PR DESCRIPTION
[![sypticus](https://img.shields.io/badge/%F0%9F%92%95_Submitted_by-sypticus-f73ae6?logo=)](https://github.com/sypticus) ![Quick](https://img.shields.io/badge/PR_Size-Quick-3eef8b?logo=) [![sypticus /FIX/1953_glances_alerts_api_update → Lissy93/dashy](https://img.shields.io/badge/%231954-sypticus_%2FFIX%2F1953__glances__alerts__api__update_%E2%86%92_Lissy93%2Fdashy-ab5afc?logo=)](https://github.com/Lissy93/dashy/tree/FIX/1953_glances_alerts_api_update) ![Commits: 2 | Files Changed: 1 | Additions: 0](https://img.shields.io/badge/New_Code-Commits%3A_2_%7C_Files_Changed%3A_1_%7C_Additions%3A_0-dddd00?logo=) ![Label](https://img.shields.io/badge/%E2%9A%A0%EF%B8%8FMissing-Label-f25265?logo=) ![Unchecked Tasks](https://img.shields.io/badge/%E2%9A%A0%EF%B8%8FNotice-Unchecked_Tasks-f25265?logo=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Lissy93&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thank you for contributing to Dashy!
So that your PR can be handled effectively, please populate the following fields
-->

**Category**: 
Bugfix

**Overview**
The Glances alerts API has [changed](https://github.com/nicolargo/glances/commit/6edd6fd1ff5f69c9a6e1fab27ecad1bd69f091a1), and instead of returning a list of lists, it is now returning a list of objects
GlAlerts.vue is still trying to get values by index. This PR updates the Alerts widget to use this object.

**Issue Number** 
[1953](https://github.com/Lissy93/dashy/issues/1953)



**Code Quality Checklist** _(Please complete)_
- [x ] All changes are backwards compatible
- [ x] All lint checks and tests are passing
- [ ]x There are no (new) build warnings or errors
- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
- [ ] _(If significant change)_ Bumps version in package.json