### PR TITLE
fix WeatherForecast widget: time of day not being displayed

### DIFF
--- a/src/components/Widgets/WeatherForecast.vue
+++ b/src/components/Widgets/WeatherForecast.vue
@@ -10,6 +10,7 @@
       @click="showMoreInfo(weather.info)"
     >
       <p class="date">{{ weather.date }}</p>
+      <p class="date">{{ weather.time }}</p>
       <p class="description">{{ weather.main }}</p>
       <p class="temp">{{ weather.temp }}</p>
       <i :class="`owi owi-${weather.icon}`"></i>
@@ -86,6 +87,11 @@ export default {
       const dateFormat = { weekday: 'short', day: 'numeric', month: 'short' };
       return new Date(timestamp * 1000).toLocaleDateString(localFormat, dateFormat);
     },
+    timeFromStamp(timestamp) {
+      const localFormat = navigator.language;
+      const timeFormat = { hour: 'numeric', minute: 'numeric' };
+      return new Date(timestamp * 1000).toLocaleTimeString(localFormat, timeFormat);
+    },
     fetchData() {
       this.makeRequest(this.endpoint).then(this.processData);
     },
@@ -96,6 +102,7 @@ export default {
         uiWeatherData.push({
           index,
           date: this.dateFromStamp(day.dt),
+          time: this.timeFromStamp(day.dt),
           icon: day.weather[0].icon,
           main: day.weather[0].main,
           description: day.weather[0].description,


### PR DESCRIPTION
[![t-nil](https://img.shields.io/badge/%F0%9F%92%95_Submitted_by-t--nil-f73ae6?logo=)](https://github.com/t-nil) ![Quick](https://img.shields.io/badge/PR_Size-Quick-3eef8b?logo=) ![✏️ Draft](https://img.shields.io/badge/Status-%E2%9C%8F%EF%B8%8F_Draft-ffa933?logo=) [![t-nil /issue-1887 → Lissy93/dashy](https://img.shields.io/badge/%231974-t--nil_%2Fissue--1887_%E2%86%92_Lissy93%2Fdashy-ab5afc?logo=)](https://github.com/Lissy93/dashy/tree/issue-1887) ![Commits: 1 | Files Changed: 1 | Additions: 7](https://img.shields.io/badge/New_Code-Commits%3A_1_%7C_Files_Changed%3A_1_%7C_Additions%3A_7-dddd00?logo=) ![Label](https://img.shields.io/badge/%E2%9A%A0%EF%B8%8FMissing-Label-f25265?logo=) ![Unchecked Tasks](https://img.shields.io/badge/%E2%9A%A0%EF%B8%8FNotice-Unchecked_Tasks-f25265?logo=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=Lissy93&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!--
Thank you for contributing to Dashy!
So that your PR can be handled effectively, please populate the following fields
-->

**Category**:  Bugfix

**Overview**
For some time now, the weather forecast data fetched from OpenWeatherMap contains multiple forecasts per day (in my case, every three hours. Since the Vue template doesn't expect this, only the date is printed, which results in seemingly "multiple forecasts per day".

This PR fixes it by introducing a new "time" row, beneath the date. This way, it is clearly visible to the user which time instances are referred to by the forecasts.

Open issues:
- [ ] now the config var `numDays` doesn't make sense. We could rename it to `numForecastInstances` or the likes.
- [ ] this is a relatively quick 'n' dirty fix, since I didn't want to look into the OWM API on how to force daily forecasts. But, atleast for me, I think 3 hour intervals are preferred anyways.
- [ ] (`yarn test` fails with `error Command "test" not found.`. `yarn lint/dev` work as expected. Any idea?)

@<maintainers>, WDYT?

**Issue Number** fixes #1887

**New Vars** 
> *nada*

**Screenshot** _(if applicable)_
> <img width="422" height="233" alt="image" src="https://github.com/user-attachments/assets/5b6906f3-84e5-4832-b18f-c006711bbf51" />

**Code Quality Checklist** _(Please complete)_
- [x] All changes are backwards compatible
- [x] All lint checks and tests are passing
- [x] There are no (new) build warnings or errors
//- [ ] _(If a new config option is added)_ Attribute is outlined in the schema and documented
//- [ ] _(If a new dependency is added)_ Package is essential, and has been checked out for security or performance
//- [ ] _(If significant change)_ Bumps version in package.json