### PR TITLE
Fixed Pi Hole key not read from env var

### DIFF
--- a/src/components/Widgets/PiHoleTopQueries.vue
+++ b/src/components/Widgets/PiHoleTopQueries.vue
@@ -25,9 +25,9 @@ export default {
   computed: {
     /* Let user select which comic to display: random, latest or a specific number */
     hostname() {
-      const usersChoice = this.parseAsEnvVar(this.options.hostname);
+      const usersChoice = this.options.hostname;
       if (!usersChoice) this.error('You must specify the hostname for your Pi-Hole server');
-      return usersChoice;
+      return usersChoice || 'http://pi.hole';
     },
     apiKey() {
       const usersChoice = this.parseAsEnvVar(this.options.apiKey);

--- a/src/components/Widgets/PiHoleTraffic.vue
+++ b/src/components/Widgets/PiHoleTraffic.vue
@@ -19,9 +19,9 @@ export default {
   computed: {
     /* Let user select which comic to display: random, latest or a specific number */
     hostname() {
-      const usersChoice = this.parseAsEnvVar(this.options.hostname);
+      const usersChoice = this.options.hostname;
       if (!usersChoice) this.error('You must specify the hostname for your Pi-Hole server');
-      return usersChoice;
+      return usersChoice || 'http://pi.hole';
     },
     apiKey() {
       const usersChoice = this.parseAsEnvVar(this.options.apiKey);


### PR DESCRIPTION
**Category**: 
Bugfix

**Overview**
In the Pi-Hole top queries and the traffic widgets, the api key could only be specified as an input option without support for reading from an env var, as is the standard for sensetive values in other widgets. This PR resolved that, so now both `options.apiKey` and the env approach is supported.

**Issue Number** #1934

**New Vars** N/A

**Screenshot** N/A