### PR TITLE
Deep copy auth.users to prevent infinite loop

### DIFF
--- a/src/utils/Auth.js
+++ b/src/utils/Auth.js
@@ -32,7 +32,7 @@ const getUsers = () => {
   }
   // Otherwise, return the users array, if available
 
-  const users = auth.users || [];
+  const users = [...(auth.users || [])];
   if (isOidcEnabled()) {
     if (localStorage[localStorageKeys.USERNAME]) {
       const user = {


### PR DESCRIPTION
**Category**: Bugfix

**Overview**
OIDC auth was causing an infinite Vue render loop that spiked CPU/RAM until the browser crashed.

Because `getUsers()` in Auth.js grabbed a direct reference to the auth.users array in the Vuex store, then `.push()`'d the OIDC user onto it. But since Vue 2 intercepts array mutations like push for reactivity, every call to getUsers() during a render was re-triggering another render, which called `getUsers()` again and again. 

Fixed by just doing a deep copy, so the push only hits a local copy, and store is never mutated.

**Issue Number** #1995

**New Vars** N/A

**Screenshot** N/A