### PR TITLE
Switches default public ip provider to ipinfo

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -304,7 +304,7 @@ Displays your public IP address, ISP and approximate location.
 
 **Field** | **Type** | **Required** | **Description**
 --- | --- | --- | ---
-**`provider`** | `string` |  _Optional_ | One of `freeipapi` _(default)_, `ipinfo`, `ipquery`, `ip-api`, or `ipgeolocation`. See the table below
+**`provider`** | `string` |  _Optional_ | One of `ipinfo` _(default)_, `freeipapi`, `ipquery`, `ip-api`, or `ipgeolocation`. See the table below
 **`apiKey`** | `string` |  _Optional_ | Required for `ipgeolocation`. Optional for `ipinfo` (a [free token](https://ipinfo.io/signup) raises the rate limit from ~1k/day to ~50k/month)
 **`hideLocation`** | `boolean` |  _Optional_ | Set to `true` to hide the flag, ISP name and city/region — only the IP address is shown. Defaults to `false`
 
@@ -341,8 +341,8 @@ Using `ipgeolocation` with a key:
 
 **Provider** | **Key** | **Proxy** | **Notes**
 --- | --- | --- | ---
-`freeipapi` _(default)_ | 🟢 Not needed | 🟢 Not needed | Keyless, 60 req/min via [freeipapi.com](https://freeipapi.com/).
-`ipinfo` | 🟢 Not needed / 🟠 Optional | 🟢 Not needed | Service from [ipinfo.io](https://ipinfo.io/). Keyless gives ~1k/day; a [free token](https://ipinfo.io/signup) raises this to ~50k/month. Sometimes blocked by adblockers.
+`ipinfo` _(default)_ | 🟢 Not needed / 🟠 Optional | 🟢 Not needed | Service from [ipinfo.io](https://ipinfo.io/). Keyless gives ~1k/day; a [free token](https://ipinfo.io/signup) raises this to ~50k/month. Sometimes blocked by adblockers.
+`freeipapi` | 🟢 Not needed | 🟢 Not needed | Keyless, 60 req/min via [freeipapi.com](https://freeipapi.com/).
 `ipquery` | 🟢 Not needed | 🟢 Not needed | Modern keyless API from [ipquery.io](https://ipquery.io/). Includes VPN/Tor/datacenter risk flags in the raw response.
 `ip-api` | 🟢 Not needed | 🔴 **Required** | [ip-api.com](https://ip-api.com/) is HTTP-only on the free tier, so the proxy is needed to avoid mixed-content errors.
 `ipgeolocation` | 🔴 **Required** | 🟢 Not needed | Get a free key from [ipgeolocation.io](https://ipgeolocation.io/signup.html).

--- a/src/components/Widgets/PublicIp.vue
+++ b/src/components/Widgets/PublicIp.vue
@@ -87,7 +87,7 @@ const PROVIDERS = {
 };
 
 const REMOVED_PROVIDERS = ['ipapi.co', 'ifconfig.co', 'ip2location.io'];
-const DEFAULT_PROVIDER = 'freeipapi';
+const DEFAULT_PROVIDER = 'ipinfo';
 
 export default {
   mixins: [WidgetMixin],


### PR DESCRIPTION
### Category
Small change

### Overview
For the public IP widget, the default provider is now `ipinfo`, which so far seems the most reliable.
But, you can specify your own provider with `options.provider` in that widget, like as documented here: https://dashy.to/docs/widgets#public-ip

