### PR TITLE
Fix DomainMonitor status type mismatch (number vs string)

### DIFF
--- a/src/components/Widgets/DomainMonitor.vue
+++ b/src/components/Widgets/DomainMonitor.vue
@@ -97,7 +97,7 @@ export default {
     /* Assign data variables to the returned data */
     processData(domainResults) {
       if (domainResults.limit_hit) this.error('API Limit Reached');
-      if (domainResults.status !== '0') this.error(domainResults.status_desc || 'API Error');
+      if (Number(domainResults.status) !== 0) this.error(domainResults.status_desc || 'API Error');
       // Get domain name and registration status
       const domainName = domainResults.domain_name;
       const isRegistered = domainResults.registered;


### PR DESCRIPTION
Fixes the incorrect error message being displayed in the DomainMonitor widget, outlined in issue #1916.

### Category
Widget Bugfix

### Overview
Fixes the error message that is incorrectly being displayed.

### Issue Number
Closes #1916 

### Additional Info
- AI disclaimer - ChatGPT used to identify and suggest fix.
