### PR TITLE
add: action for prebuild

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -82,33 +82,3 @@ jobs:
           files: ${{ env.TARBALL }}
           token: ${{ secrets.BOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - name: Job summary 📋
-        if: always()
-        run: |
-          {
-            echo "## 📦 Release Asset Build"
-            echo ""
-            echo "| | |"
-            echo "|---|---|"
-            echo "| Tag | \`${TAG}\` |"
-            echo "| Artifact | \`${TARBALL}\` |"
-            if [ -f "${TARBALL}" ]; then
-              echo "| Size | $(du -sh ${TARBALL} | cut -f1) |"
-              echo "| Status | ✅ Uploaded |"
-            else
-              echo "| Status | ❌ Failed |"
-            fi
-            echo ""
-            echo "### Install instructions"
-            echo "\`\`\`bash"
-            echo "# Download and extract"
-            echo "wget https://github.com/\${{ github.repository }}/releases/download/${TAG}/${TARBALL}"
-            echo "tar -xzf ${TARBALL} -C /opt/dashy"
-            echo ""
-            echo "# Install production dependencies"
-            echo "cd /opt/dashy && yarn install --production --ignore-engines"
-            echo ""
-            echo "# Start the server (default port 8080)"
-            echo "node server"
-            echo "\`\`\`"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js ⚙️
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '24'
           cache: 'yarn'
 
       - name: Install dependencies 📥
@@ -57,6 +57,11 @@ jobs:
           cp -r user-data    "$STAGING/"
           cp    server.js    "$STAGING/"
           cp    yarn.lock    "$STAGING/"
+
+          # src/utils/ files referenced directly by the server at runtime
+          mkdir -p "$STAGING/src/utils"
+          cp src/utils/ConfigSchema.json "$STAGING/src/utils/"
+          cp src/utils/defaults.js       "$STAGING/src/utils/"
 
           # Strip devDependencies so `yarn install --production` stays lean
           node -e "

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -6,11 +6,12 @@ name: 📦 Build & Upload Release Assets
 #
 # The tarball contains the compiled frontend (dist/) plus all server-side
 # files. Users extract it and run `yarn install --production` + `node server`.
+#
+# Triggered whenever a new release is created, or when manually dispatched
 
 on:
-  push:
-    tags:
-      - '*.*.*'
+  release:
+    types: [created]
   workflow_dispatch:
     inputs:
       tag:
@@ -20,23 +21,27 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || github.event.inputs.tag }}
+  cancel-in-progress: true
+
 jobs:
   build-release-assets:
     name: Build app & upload tarball
     runs-on: ubuntu-latest
     env:
-      TAG: ${{ github.event.inputs.tag || github.ref_name }}
+      TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
 
     steps:
       - name: Checkout code 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ env.TAG }}
 
       - name: Setup Node.js ⚙️
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '20'
           cache: 'yarn'
 
       - name: Install dependencies 📥
@@ -81,4 +86,3 @@ jobs:
           tag_name: ${{ env.TAG }}
           files: ${{ env.TARBALL }}
           token: ${{ secrets.BOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -1,0 +1,109 @@
+name: 📦 Build & Upload Release Assets
+
+# Builds Dashy and uploads a pre-built tarball to the GitHub release.
+# This allows non-Docker installs (e.g. Proxmox VE community scripts) to
+# download a ready-to-run package without having to build from source.
+#
+# The tarball contains the compiled frontend (dist/) plus all server-side
+# files. Users extract it and run `yarn install --production` + `node server`.
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build assets for (must already exist as a release)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-release-assets:
+    name: Build app & upload tarball
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event.inputs.tag || github.ref_name }}
+
+    steps:
+      - name: Checkout code 🛎️
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Setup Node.js ⚙️
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'yarn'
+
+      - name: Install dependencies 📥
+        run: yarn install --frozen-lockfile --ignore-engines --network-timeout 300000
+
+      - name: Build app 🏗️
+        run: NODE_OPTIONS=--openssl-legacy-provider yarn build --mode production
+
+      - name: Package release artifact 📦
+        run: |
+          STAGING="dashy-release-staging"
+          mkdir -p "$STAGING"
+
+          # Runtime files
+          cp -r dist         "$STAGING/"
+          cp -r services     "$STAGING/"
+          cp -r public       "$STAGING/"
+          cp -r user-data    "$STAGING/"
+          cp    server.js    "$STAGING/"
+          cp    yarn.lock    "$STAGING/"
+
+          # Strip devDependencies so `yarn install --production` stays lean
+          node -e "
+            const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
+            delete pkg.devDependencies;
+            require('fs').writeFileSync('$STAGING/package.json', JSON.stringify(pkg, null, 2));
+          "
+
+          TARBALL="dashy-${TAG}.tar.gz"
+          tar -czf "${TARBALL}" -C "${STAGING}" .
+          echo "TARBALL=${TARBALL}" >> "$GITHUB_ENV"
+          echo "Size: $(du -sh ${TARBALL} | cut -f1)"
+
+      - name: Upload tarball to GitHub Release 🚀
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          files: ${{ env.TARBALL }}
+          token: ${{ secrets.BOT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Job summary 📋
+        if: always()
+        run: |
+          {
+            echo "## 📦 Release Asset Build"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Tag | \`${TAG}\` |"
+            echo "| Artifact | \`${TARBALL}\` |"
+            if [ -f "${TARBALL}" ]; then
+              echo "| Size | $(du -sh ${TARBALL} | cut -f1) |"
+              echo "| Status | ✅ Uploaded |"
+            else
+              echo "| Status | ❌ Failed |"
+            fi
+            echo ""
+            echo "### Install instructions"
+            echo "\`\`\`bash"
+            echo "# Download and extract"
+            echo "wget https://github.com/\${{ github.repository }}/releases/download/${TAG}/${TARBALL}"
+            echo "tar -xzf ${TARBALL} -C /opt/dashy"
+            echo ""
+            echo "# Install production dependencies"
+            echo "cd /opt/dashy && yarn install --production --ignore-engines"
+            echo ""
+            echo "# Start the server (default port 8080)"
+            echo "node server"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Hi Lissy, 
Happy to see Dashy going again!

### Category
Feature / CI

### Overview
First of all, I've appreciate, if you could give this a thorough look, if I included all the correct behaviour and if that actually works with things like `appConfig.startingView`

This PR adds a new GitHub Actions workflow that builds Dashy and
uploads a pre-built tarball as a release asset on every tag push.

This enables non-Docker install methods (for example our Proxmox VE community scripts project) to download
a ready-to-run package without requiring Node.js build tooling on the target machine, as these normally are pretty ressource intensive.

The tarball includes the compiled frontend (`dist/`), the Node.js server, and all
runtime files. Users extract it, run `yarn install --production`, and start with
`node server`, no build step needed, as we got a couple of reports, that dashy is using very high memory and cpu during build.


This draws ressource from this: 

<img width="431" height="135" alt="grafik" src="https://github.com/user-attachments/assets/d8a611fb-1ea6-429c-851d-d0fd6f92fb76" />


To roughly 200MB at max during initial start.


### Issue Number
<!-- N/A or link a relevant issue/discussion if one exists -->

### Additional Info
**What's in the tarball:**
- `dist/` — compiled Vue frontend
- `server.js` + `services/` — Node.js server
- `public/` — static assets
- `user-data/` — default config directory
- `src/utils/ConfigSchema.json` + `defaults.js` — referenced by the server at runtime
- `package.json` (devDependencies stripped) + `yarn.lock`

**No breaking changes** — existing Docker and manual install flows are untouched.


**Disclaimer** this PR was developed with AI assistance (Claude Code), as I've not really worked a lot with actions yet . But this has been tested on my fork https://github.com/CrazyWolf13/dashy and users also tested the dashy built-in recompile button.

Feel free to edit this to your liking, I thought I give it a go with a small PR if I have to test it anyway :)

Edit: apologies for the direct push on the repo, was by accident, more on this via matrix.