### PR TITLE
Hiddentile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Dashy",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-24-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:latest",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/src/components/LinkItems/Collapsable.vue
+++ b/src/components/LinkItems/Collapsable.vue
@@ -104,6 +104,7 @@ export default {
     checkboxState(newState) {
       this.isExpanded = newState;
       this.updateLocalStorage(); // Save every change immediately
+      this.$emit('collapse-change', this.checkboxState);
     },
     uniqueKey(newVal, oldVal) {
       if (newVal !== oldVal) {

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -155,6 +155,7 @@ export default {
       resizeObserver: null,
       isCollapsed: false,
       autoOpenedBySearch: false,
+      showHiddenMode: false,
     };
   },
   computed: {
@@ -228,7 +229,7 @@ export default {
       if (this.isEditMode) return true;
 
       // If not hidden, render as usual
-      if (!hidden) return true;
+      if (!hidden || this.showHiddenMode) return true;
 
       // If hidden, only show when search is active AND this section has hits
       const searchActive = (this.searchTerm || '').trim().length > 0;
@@ -239,6 +240,8 @@ export default {
   watch: {
     searchTerm: {
       handler(newSeachTerm) {
+        const showHidden = newSeachTerm.trim().toLowerCase() === '<hidden>';
+        this.showHiddenMode = showHidden;
         let searchIsActive = false;
         if (newSeachTerm && newSeachTerm.trim().length > 0) {
           searchIsActive = true;

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -151,6 +151,7 @@ export default {
       },
       sectionWidth: 0,
       resizeObserver: null,
+      isCollapsed: false,
     };
   },
   computed: {
@@ -226,7 +227,7 @@ export default {
           searchIsActive = true;
         }
         const hasHits = this.items.length > 0;
-        if (searchIsActive && hasHits) {
+        if (searchIsActive && hasHits && this.isCollapsed) {
           this.expandCollapseSection();
         }
       },
@@ -276,7 +277,12 @@ export default {
     expandCollapseSection() {
       const secElem = this.$refs[this.sectionRef];
       if (secElem) secElem.toggle();
+      this.toggleCollapsedState();
       this.closeContextMenu();
+    },
+    /* Toggle sections collapse state tracking */
+    toggleCollapsedState() {
+      this.isCollapsed = !this.isCollapsed;
     },
     /* Open the Section Edit Menu */
     openEditSection() {
@@ -327,6 +333,9 @@ export default {
     if (this.$refs[this.sectionRef]) {
       this.resizeObserver = new ResizeObserver(this.calculateSectionWidth)
         .observe(this.$refs[this.sectionRef].$el);
+    }
+    if (this.displayData.collapsed) {
+      this.isCollapsed = this.displayData.collapsed;
     }
   },
   beforeDestroy() {

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -130,6 +130,7 @@ export default {
     index: Number,
     isWide: Boolean,
     activeColCount: Number,
+    searchTerm: String,
   },
   components: {
     Collapsable,
@@ -215,6 +216,21 @@ export default {
       const { cols } = this.displayData;
       if (!cols) return cols;
       return Math.min(this.activeColCount, cols);
+    },
+  },
+  watch: {
+    searchTerm: {
+      handler(newSeachTerm) {
+        let searchIsActive = false;
+        if (newSeachTerm && newSeachTerm.trim().length > 0) {
+          searchIsActive = true;
+        }
+        const hasHits = this.items.length > 0;
+        if (searchIsActive && hasHits) {
+          this.expandCollapseSection();
+        }
+      },
+      immediate: true,
     },
   },
   methods: {

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -1,5 +1,6 @@
 <template>
   <Collapsable
+    v-if="shouldRenderSection"
     :title="title"
     :icon="icon"
     :uniqueKey="groupId"
@@ -219,6 +220,20 @@ export default {
       const { cols } = this.displayData;
       if (!cols) return cols;
       return Math.min(this.activeColCount, cols);
+    },
+    shouldRenderSection() {
+      const hidden = this.displayData?.hiddenOnPurpose === true;
+
+      // Always show in Edit Mode so the user can unhide it
+      if (this.isEditMode) return true;
+
+      // If not hidden, render as usual
+      if (!hidden) return true;
+
+      // If hidden, only show when search is active AND this section has hits
+      const searchActive = (this.searchTerm || '').trim().length > 0;
+      const hasHits = Array.isArray(this.items) && this.items.length > 0;
+      return searchActive && hasHits;
     },
   },
   watch: {

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -240,17 +240,26 @@ export default {
   watch: {
     searchTerm: {
       handler(newSeachTerm) {
+        // find if special code search is used
         const showHidden = newSeachTerm.trim().toLowerCase() === '<hidden>';
         this.showHiddenMode = showHidden;
+
+        // check if search is active
         let searchIsActive = false;
         if (newSeachTerm && newSeachTerm.trim().length > 0) {
           searchIsActive = true;
         }
+
+        // check if search is hit
         const hasHits = this.items.length > 0;
+
+        // action if search is active and search hits and it was collapsed
         if (searchIsActive && hasHits && this.isCollapsed) {
           this.expandCollapseSection();
           this.autoOpenedBySearch = true;
         }
+
+        // action if that search is not a hit anymore
         if (this.autoOpenedBySearch && (!searchIsActive || !hasHits)) {
           this.expandCollapseSection();
           this.autoOpenedBySearch = false;

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -152,6 +152,7 @@ export default {
       sectionWidth: 0,
       resizeObserver: null,
       isCollapsed: false,
+      autoOpenedBySearch: false,
     };
   },
   computed: {
@@ -229,6 +230,11 @@ export default {
         const hasHits = this.items.length > 0;
         if (searchIsActive && hasHits && this.isCollapsed) {
           this.expandCollapseSection();
+          this.autoOpenedBySearch = true;
+        }
+        if (this.autoOpenedBySearch && (!searchIsActive || !hasHits)) {
+          this.expandCollapseSection();
+          this.autoOpenedBySearch = false;
         }
       },
       immediate: true,

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -11,6 +11,7 @@
     :cutToHeight="displayData.cutToHeight"
     @openEditSection="openEditSection"
     @openContextMenu="openContextMenu"
+    @collapse-change="onCollapseChange"
     :id="sectionRef"
     :ref="sectionRef"
   >
@@ -283,12 +284,11 @@ export default {
     expandCollapseSection() {
       const secElem = this.$refs[this.sectionRef];
       if (secElem) secElem.toggle();
-      this.toggleCollapsedState();
       this.closeContextMenu();
     },
     /* Toggle sections collapse state tracking */
-    toggleCollapsedState() {
-      this.isCollapsed = !this.isCollapsed;
+    onCollapseChange(childExpanded) {
+      this.isCollapsed = !childExpanded;
     },
     /* Open the Section Edit Menu */
     openEditSection() {

--- a/src/utils/ConfigSchema.json
+++ b/src/utils/ConfigSchema.json
@@ -951,6 +951,12 @@
                 "type": "boolean",
                 "default": false,
                 "description": "If set to true, section will be visible in the default view but not in the Workspace view sidebar"
+              },
+              "hiddenOnPurpose": {
+                "title": "Hidden On Purpose",
+                "type": "boolean",
+                "default": false,
+                "description": "If true, this section is intentionally hidden"
               }
             }
           },

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -36,7 +36,8 @@
           @itemClicked="finishedSearching()"
           @change-modal-visibility="updateModalVisibility"
           :isWide="!!singleSectionView || layoutOrientation === 'horizontal'"
-          :class="(searchValue && section.filteredItems.length === 0) ? 'no-results' : ''"
+          :class="(searchValue &&
+          !isCodeSearch && section.filteredItems.length === 0) ? 'no-results' : ''"
           :activeColCount="activeColCount"
         />
       </template>
@@ -89,6 +90,11 @@ export default {
     activeColCount: 1,
   }),
   computed: {
+    isCodeSearch() {
+      const term = (this.searchTerm || this.searchValue || '').trim();
+      // true if it starts with "<" and ends with ">", with at least one char inside
+      return /^<[^>]+>$/.test(term);
+    },
     singleSectionView() {
       return this.findSingleSection(this.$store.getters.sections, this.$route.params.section);
     },

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -109,9 +109,15 @@ export default {
     /* Return sections with filtered items, that match users search term */
     filteredSections() {
       const sections = this.singleSectionView || this.sections;
+      const codeMode = this.isCodeSearch;
+
       return sections.map((_section) => {
         const section = _section;
-        section.filteredItems = this.filterTiles(section.items, this.searchValue);
+        if (codeMode) {
+          section.filteredItems = section.items;
+        } else {
+          section.filteredItems = this.filterTiles(section.items, this.searchValue);
+        }
         return section;
       });
     },

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -44,3 +44,18 @@ sections:
     description: Get help with Dashy, raise a bug, or get in contact
     url: https://github.com/Lissy93/dashy/blob/master/.github/SUPPORT.md
     icon: far fa-hands-helping
+- name: Stuff
+  icon: fas fa-rocket
+  displayData:
+    collapsed: true 
+  items:
+  - title: hidden tile 1
+    description: Development a project management links for Dashy
+    icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
+    url: https://live.dashy.to/
+    target: newtab
+  - title: hidden tile 2
+    description: Development a project management links for Dashy
+    icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
+    url: https://live.dashy.to/
+    target: newtab

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -47,7 +47,7 @@ sections:
 - name: Stuff
   icon: fas fa-rocket
   displayData:
-    collapsed: true 
+    hiddenOnPurpose: true 
   items:
   - title: hidden tile 1
     description: Development a project management links for Dashy

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -49,13 +49,9 @@ sections:
   displayData:
     hiddenOnPurpose: true 
   items:
-  - title: hidden tile 1
-    description: Development a project management links for Dashy
+  - title: s
+    description: s
     icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
     url: https://live.dashy.to/
     target: newtab
-  - title: hidden tile 2
-    description: Development a project management links for Dashy
-    icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
-    url: https://live.dashy.to/
-    target: newtab
+

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -49,8 +49,8 @@ sections:
   displayData:
     hiddenOnPurpose: true 
   items:
-  - title: s
-    description: s
+  - title: hiddentile
+    description: This is a hidden tile
     icon: https://i.ibb.co/qWWpD0v/astro-dab-128.png
     url: https://live.dashy.to/
     target: newtab


### PR DESCRIPTION
### Category
Feature

### Overview
added feature requested to hide tiles which will reveal themselves on search as per issue 1854 https://github.com/Lissy93/dashy/issues/1854

### Issue Number
#1854 

### Additional Info
<!--
- Schema changes - required explanation if you've added or modified any inputs
- Screenshot - required if any significant UI changes, widget or theme added
- Breaking changes - does this introduce any potential backward compatibility issues?
- Testing instructions - if applicable, give instructions to reviewers for testing
- AI disclaimer - if you are an AI, you must clearly state this
-->
in conf.yaml you can now have a section which can have a hiddenOnPurpose (boolean) under displayData. if true, the section will not show up by. but searches in the search box will make the section unhide itself and show up. 

example of how to set up the conf.yaml
<img width="700" height="248" alt="image" src="https://github.com/user-attachments/assets/529e25a3-598e-4c2a-9e80-1eda75cbfb10" />

result:
hidden section is not showing up 
<img width="1232" height="657" alt="image" src="https://github.com/user-attachments/assets/8792a70b-edbb-4fde-9f34-725aae08f4b5" />

then we do a search in the search box and it shows up. 

<img width="897" height="556" alt="image" src="https://github.com/user-attachments/assets/1ff8dcc8-6ba9-4175-bd84-7945bd7d6dee" />

