### PR TITLE
Fixes OIDC/KC auth guard, cb skip login page

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -62,7 +62,7 @@ const mount = () => app.mount('#app');
 const handleAuthFailure = (provider, err) => {
   ErrorHandler(`Failed to authenticate with ${provider}`, err);
   store.commit(Keys.CRITICAL_ERROR_MSG, `Authentication failed (${provider}). See console for details.`);
-  mount();
+  router.replace({ name: 'login' }).catch(() => {}).finally(mount);
 };
 
 router.isReady().then(() => {

--- a/src/router.js
+++ b/src/router.js
@@ -16,6 +16,8 @@ import store from '@/store';
 import i18n from '@/utils/i18n';
 import Keys from '@/utils/StoreMutations';
 import { isAuthEnabled, isLoggedIn, isGuestAccessEnabled } from '@/utils/auth/Auth';
+import { isOidcEnabled } from '@/utils/auth/OidcAuth';
+import { isKeycloakEnabled } from '@/utils/auth/KeycloakAuth';
 import { startingView as defaultStartingView, routePaths } from '@/utils/config/defaults';
 import { VIEW_META } from '@/utils/config/ConfigHelpers';
 import ErrorHandler from '@/utils/logging/ErrorHandler';
@@ -29,6 +31,12 @@ const isAuthenticated = () => {
   const guestEnabled = isGuestAccessEnabled();
   return (!authEnabled || userLoggedIn || guestEnabled);
 };
+
+/* Determines if the page URL is an OAuth2 redirect-back from OIDC or Keycloak
+ * Passes through the auth guard, so the callback ?code reaches the handler */
+const isOauthCallback = () =>
+  new URLSearchParams(window.location.search).has('code')
+  && (isOidcEnabled() || isKeycloakEnabled());
 
 /* Resolve landing view from appConfig.startingView at runtime if set */
 const resolveStartingView = () => {
@@ -131,7 +139,7 @@ router.beforeEach(async (to, from, next) => {
     // If in edit mode and navigating to a DIFFERENT page, confirm + cancel edit.
     const pageChanged = from.params?.page !== to.params?.page;
     if (store.state.editMode && pageChanged) {
-       
+
       const ok = confirm(i18n.global.t('interactive-editor.menu.leave-while-editing-confirm'));
       if (!ok) {
         progress.end();
@@ -142,8 +150,9 @@ router.beforeEach(async (to, from, next) => {
       await store.dispatch(Keys.INITIALIZE_CONFIG, store.state.currentConfigInfo.confId);
       store.commit(Keys.SET_EDIT_MODE, false);
     }
-    if (to.name !== 'login' && !isAuthenticated()) next({ name: 'login' });
-    else next();
+    if (to.name !== 'login' && !isAuthenticated() && !isOauthCallback()) {
+      next({ name: 'login' });
+    } else next();
   } catch (e) {
     ErrorHandler('Navigation guard failed', e);
     next();


### PR DESCRIPTION
### Category
Bugfix

### Overview
Fix OIDC/Keycloak login loop after Vue 3 upgrade by letting the auth guard pass through OAuth2 callback URLs (?code=...) so signinCallback can consume them, instead of redirecting to /login and stripping the query. Also routes failed callbacks to /login before mounting so a bad ?code= can't briefly render protected content under the critical-error overlay.

### Issue Number

#2117

