### PR TITLE
Added the ntfy stream widget

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -2473,7 +2473,7 @@ Subscribes to topics on a **private** [ntfy](https://docs.ntfy.sh/) server, and 
 - **CORS**: Disabled
 - **Auth**: Optional
 - **Price**: Free
-- **Host**: [Self-hosted](https://https://docs.ntfy.sh/install/)
+- **Host**: [Self-hosted](https://docs.ntfy.sh/install/)
 - **Privacy**: [ntfy Privacy Policy](https://docs.ntfy.sh/privacy/)
 
 ---

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -66,6 +66,7 @@ Dashy has support for displaying dynamic content in the form of widgets. There a
   - [Nextcloud System](#nextcloud-system)
   - [Nextcloud Stats](#nextcloud-stats)
   - [Nextcloud PHP OPcache](#nextcloud-php-opcache-stats)
+  - [Ntfy stream](#ntfy-stream)
   - [Proxmox lists](#proxmox-lists)
   - [Sabnzbd](#sabnzbd)
   - [Gluetun VPN Info](#gluetun-vpn-info)
@@ -2441,6 +2442,39 @@ Shows statistics about PHP OPcache performance on your Nextcloud server.
 - **Host**: Self-Hosted (see [Nextcloud](https://nextcloud.com))
 - **Privacy**: _See [Nextcloud Privacy Policy](https://nextcloud.com/privacy)_
 
+---
+
+### ntfy stream
+
+Subscribes to topics on a **private** [ntfy](https://docs.ntfy.sh/) server, and shows **new messages** as they arrive.
+
+#### Options
+
+**Field** | **Type** | **Required** | **Description**
+--- | --- | --- | ---
+**`server_url`** | `string` |  Required | The server url
+**`topic`** | `string` |  Required | A topic, or a comma separated list of topics
+**`auth`** | `string` |  optional | An [auth string](https://docs.ntfy.sh/subscribe/api/#authentication). ⚠️ This is sent as query parameter.
+**`title`** | `string` |  optional | A title for the widget.
+
+#### Example
+
+```yaml
+- type: ntfy-stream
+  useProxy: false
+  options:
+    title: NTFY stream
+    server_url: https://myntfy.server.tld
+    topic: alert,warning,mytopic
+```
+
+#### Info
+
+- **CORS**: Disabled
+- **Auth**: Optional
+- **Price**: Free
+- **Host**: [Self-hosted](https://https://docs.ntfy.sh/install/)
+- **Privacy**: [ntfy Privacy Policy](https://docs.ntfy.sh/privacy/)
 
 ---
 

--- a/src/components/Widgets/NtfyStream.vue
+++ b/src/components/Widgets/NtfyStream.vue
@@ -25,6 +25,12 @@ export default {
       messages: [],
     };
   },
+  beforeUnmount() {
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+  },
   computed: {
     serverUrl() {
       if (!this.options.server_url) this.error('The server URL is required.');
@@ -40,19 +46,33 @@ export default {
     title() {
       return this.parseAsEnvVar(this.options.title) || '';
     },
-
+    limit() {
+      return parseInt(this.options.limit, 10) || 50;
+    },
   },
   methods: {
     fetchData() {
       // @see https://docs.ntfy.sh/subscribe/api/#subscribe-as-sse-stream
       this.finishLoading();
+      if (this.eventSource) {
+        this.eventSource.close();
+      }
       let url = `${this.serverUrl}/${this.topic}/sse`;
       if (this.auth !== '') {
-        url = `${url}?auth=${this.auth}`;
+        url = `${url}?auth=${encodeURIComponent(this.auth)}`;
       }
-      const eventSource = new EventSource(url);
-      eventSource.onmessage = (e) => {
+      this.eventSource = new EventSource(url);
+      this.eventSource.onmessage = (e) => {
         this.messages.unshift(JSON.parse(e.data));
+        if (this.messages.length > this.limit) {
+          this.messages = this.messages.slice(0, this.limit);
+        }
+      };
+      this.eventSource.onerror = (e) => {
+        const msg = this.eventSource.readyState === EventSource.CLOSED ?
+          'ntfy connection closed by the server (check URL, topic and auth).'
+          : 'Unable to reach the ntfy server, reconnecting...';
+        this.error(msg, e);
       };
     },
   },

--- a/src/components/Widgets/NtfyStream.vue
+++ b/src/components/Widgets/NtfyStream.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="ntfy-stream">
+    <div class="ntfy-stream-widget-title" v-if="title">
+        {{ title }}
+    </div>
+    <div v-for="(item, key) in messages" :key="key" class="ntfy-stream-row">
+      <div v-if="item.title" class="ntfy-stream-title">
+          {{ item.title }}
+      </div>
+      <div v-if="item.message" class="ntfy-stream-content">
+        {{ item.message }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import WidgetMixin from '@/mixins/WidgetMixin';
+
+export default {
+  mixins: [WidgetMixin],
+  components: {},
+  data() {
+    return {
+      messages: [],
+    };
+  },
+  computed: {
+    serverUrl() {
+      if (!this.options.server_url) this.error('The server URL is required.');
+      return this.parseAsEnvVar(this.options.server_url) || '';
+    },
+    topic() {
+      if (!this.options.topic) this.error('The topic is required.');
+      return this.parseAsEnvVar(this.options.topic) || '';
+    },
+    auth() {
+      return this.parseAsEnvVar(this.options.auth) || '';
+    },
+    title() {
+      return this.parseAsEnvVar(this.options.title) || '';
+    },
+
+  },
+  methods: {
+    fetchData() {
+      // @see https://docs.ntfy.sh/subscribe/api/#subscribe-as-sse-stream
+      this.finishLoading();
+      let url = `${this.serverUrl}/${this.topic}/sse`;
+      if (this.auth !== '') {
+        url = `${url}?auth=${this.auth}`;
+      }
+      const eventSource = new EventSource(url);
+      eventSource.onmessage = (e) => {
+        this.messages.unshift(JSON.parse(e.data));
+      };
+    },
+  },
+};
+
+</script>
+
+<style scoped lang="scss">
+
+.ntfy-stream {
+  .ntfy-stream-widget-title {
+    outline: 2px solid transparent;
+    border: 1px solid var(--outline-color);
+    border-radius: var(--curve-factor);
+    box-shadow: var(--item-shadow);
+    color: var(--item-text-color);
+    margin: .5rem;
+    padding: 0.3rem;
+    background: var(--item-background);
+    text-align: center;
+
+  }
+  .ntfy-stream-row {
+    color: var(--widget-text-color);
+    font-size: 1.1rem;
+    .ntfy-stream-title {
+      font-weight: bold;
+    }
+    &:not(:last-child) {
+      border-bottom: 1px dashed var(--widget-text-color);
+    }
+  }
+}
+</style>

--- a/src/components/Widgets/WidgetBase.vue
+++ b/src/components/Widgets/WidgetBase.vue
@@ -114,6 +114,7 @@ const COMPAT = {
   'nextcloud-system': 'NextcloudSystem',
   'nextcloud-user': 'NextcloudUser',
   'nextcloud-user-status': 'NextcloudUserStatus',
+  'ntfy-stream': 'NtfyStream',
   'pi-hole-stats': 'PiHoleStats',
   'pi-hole-stats-v6': 'PiHoleStatsV6',
   'pi-hole-top-queries': 'PiHoleTopQueries',


### PR DESCRIPTION
### Category
Widget

### Overview
Subscribes to topics on a **private** [ntfy](https://docs.ntfy.sh/) server, and shows _**new messages**_ as they arrive.

### Screenshot
<img width="524" height="132" alt="ntfy-widget" src="https://github.com/user-attachments/assets/52fbd77a-29c1-42b3-b20f-2f12a3e36144" />

### Testing

You need a private ntfy server. This widget should not be connected to a server that you do not control.

On your private server, create a topic, then configure the widget to subscribe to it and refresh your dashboard. When you publish a message to that topic, it will show in the widget without refreshing the dashboard.

The widget displays new messages after you refresh your dashboard page.

To test authentication, follow ntfy documentation.

### Additional Info
No schema changes
No breaking changes
No AI was used to create this widget.