### PR TITLE
Adds missing newwindow target for nav links

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -86,7 +86,7 @@ The following file provides a reference of all supported configuration options.
 --- | --- | --- | ---
 **`title`** | `string` |  Required | The text to display on the link button
 **`path`** | `string` | Required | The URL to navigate to when clicked. Can be relative (e.g. `/about`) or absolute (e.g. `https://example.com` or `http://192.168.1.1`)
-**`target`** | `string` |  _Optional_ | The opening method (external links only). Can be either `newtab`, `sametab`, `top` or `parent`. Defaults to `newtab`
+**`target`** | `string` |  _Optional_ | The opening method (external links only). Can be either `newtab`, `sametab`, `newwindow`, `top` or `parent`. Defaults to `newtab`
 
 **[⬆️ Back to Top](#configuring)**
 

--- a/src/components/PageStrcture/Nav.vue
+++ b/src/components/PageStrcture/Nav.vue
@@ -27,7 +27,7 @@
           :title="link.title"
           class="nav-item"
           rel="noopener noreferrer"
-          @click="closeIfBurger"
+          @click="onLinkClick(link, $event)"
         >{{ link.title }}</a>
       </template>
     </nav>
@@ -36,7 +36,9 @@
 
 <script>
 import IconBurger from '@/assets/interface-icons/burger-menu.svg';
-import { buildAllLinks, isHttpUrl, resolveLinkTarget } from '@/utils/NavLinks';
+import {
+  buildAllLinks, isHttpUrl, openLink, resolveLinkTarget,
+} from '@/utils/NavLinks';
 
 const MOBILE_QUERY = '(max-width: 599px)';
 
@@ -87,6 +89,7 @@ export default {
       if (!this.$el.contains(e.target)) this.isOpen = false;
     },
     closeIfBurger() { if (this.showBurger) this.isOpen = false; },
+    onLinkClick(link, e) { openLink(link, e); this.closeIfBurger(); },
     isHttpUrl,
     resolveLinkTarget,
   },

--- a/src/components/Settings/NavLinksSwitcher.vue
+++ b/src/components/Settings/NavLinksSwitcher.vue
@@ -10,7 +10,7 @@
         :href="link.path" :target="resolveLinkTarget(link)"
         class="nav-link" role="menuitem"
         rel="noopener noreferrer"
-        @click="$emit('close')">
+        @click="onLinkClick(link, $event)">
         {{ link.title }}
       </a>
     </template>
@@ -18,7 +18,9 @@
 </template>
 
 <script>
-import { buildAllLinks, isHttpUrl, resolveLinkTarget } from '@/utils/NavLinks';
+import {
+  buildAllLinks, isHttpUrl, openLink, resolveLinkTarget,
+} from '@/utils/NavLinks';
 
 export default {
   name: 'NavLinksSwitcher',
@@ -30,7 +32,11 @@ export default {
       return buildAllLinks(this.$store, this.$route, nav);
     },
   },
-  methods: { isHttpUrl, resolveLinkTarget },
+  methods: {
+    isHttpUrl,
+    resolveLinkTarget,
+    onLinkClick(link, e) { openLink(link, e); this.$emit('close'); },
+  },
 };
 </script>
 

--- a/src/utils/NavLinks.js
+++ b/src/utils/NavLinks.js
@@ -13,6 +13,15 @@ export const resolveLinkTarget = (link) => {
   return '_blank';
 };
 
+/* Intercept click to open the link in a separate popup window when configured */
+export const openLink = (link, event) => {
+  if (link && link.target === 'newwindow') {
+    event.preventDefault();
+    const { width, height } = window.screen;
+    window.open(link.path, '_blank', `width=${width},height=${height},noopener,noreferrer`);
+  }
+};
+
 /* Combined list of user-defined nav links + visible sub-pages for the current
  * view. Each entry: { path, title, target? }. Empty list means nothing to show. */
 export const buildAllLinks = (store, route, extraLinks = []) => {


### PR DESCRIPTION
### Category
Feature

### Overview
Adds support the `target: newwindow` option for nav links.

### Issue Number
Fixes #2146

