### PR TITLE
Fixes image widget update cache

### DIFF
--- a/src/components/Widgets/ImageWidget.vue
+++ b/src/components/Widgets/ImageWidget.vue
@@ -40,7 +40,9 @@ export default {
     },
     /* Generate a URL param, to be updated in order to re-fetch image */
     updatePathParam() {
-      return this.updateCount ? `#dashy-update-${this.updateCount}` : '';
+      if (!this.updateCount || !this.options.imagePath) return '';
+      const separator = this.options.imagePath.includes('?') ? '&' : '?';
+      return `${separator}dashy-update=${this.updateCount}`;
     },
   },
   methods: {


### PR DESCRIPTION
### Category
Bugfix

### Overview
Image widget wasn't updating image when interval set or update called
Replaces the `#` part of the image URL with query param (`?`/`&`) so new image requested, correct cache bust.

### Issue Number
Fixes #2151

