### PR TITLE
Server protects yaml as well as yml

### DIFF
--- a/services/app.js
+++ b/services/app.js
@@ -280,9 +280,9 @@ const app = express()
       safeEnd(res, errBody(e));
     }
   }))
-  // Middleware to serve any .yml files in USER_DATA_DIR with optional protection
+  // Middleware to serve any .yml/.yaml files in USER_DATA_DIR with optional protection
   // Note: returns stripped version if auth configured but not yet authenticated
-  .get('/*.yml', bootstrapAuth, (req, res) => {
+  .get(/\.ya?ml$/i, bootstrapAuth, (req, res) => {
     const ymlFile = req.path.split('/').pop();
     const filePath = path.resolve(rootDir, process.env.USER_DATA_DIR || 'user-data', ymlFile);
     if (authIsConfigured) {

--- a/tests/server/conf-strip.test.js
+++ b/tests/server/conf-strip.test.js
@@ -32,6 +32,7 @@ beforeAll(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dashy-strip-test-'));
   fs.writeFileSync(path.join(tmpDir, 'conf.yml'), FULL_CONF);
   fs.writeFileSync(path.join(tmpDir, 'sub.yml'), 'pageInfo:\n  title: Sub\n');
+  fs.writeFileSync(path.join(tmpDir, 'sub.yaml'), 'pageInfo:\n  title: Sub\n');
   process.env.USER_DATA_DIR = tmpDir;
   delete require.cache[require.resolve('../../services/app')];
   delete require.cache[require.resolve('../../services/auth-oidc')];
@@ -69,6 +70,11 @@ describe('OIDC strip behaviour for /conf.yml', () => {
     const res = await request(app)
       .get('/sub.yml')
       .set('Authorization', 'Bearer not-a-real-token');
+    expect(res.status).toBe(401);
+  });
+
+  it('requires valid auth for non-root yaml files (not bypassed via static)', async () => {
+    const res = await request(app).get('/sub.yaml');
     expect(res.status).toBe(401);
   });
 


### PR DESCRIPTION
### Category
Bugfix / Security

### Overview
There was a bug, whereby: if you use OIDC for auth, and update your config locations via custom env vars to use `.yaml` instead of `.yml` then auth will not work.

Note that while this was opened as a security advisory, and I will publish the advisory or transparency and to trigger updates, this issue doesn't actually have any way to exploit, and so is a no-op. 

### Issue Number
Thanks @huslayer826 for reporting this, in [GHSA-7v4p-jf7g-wpg7](https://github.com/lissy93/dashy/security/advisories/GHSA-7v4p-jf7g-wpg7)!


