### PR TITLE
Re-check host blocklist on redirects and in status-check

### DIFF
--- a/services/cors-proxy.js
+++ b/services/cors-proxy.js
@@ -5,19 +5,7 @@
  */
 
 const request = require('./request');
-
-// List of hosts to disallow by default, for cloud instances
-// Covers AWS, Azure, GCP, DO, Hetzner, Oracle, etc on IPv4/6
-const BLOCKED_HOSTS = new Set([
-  '169.254.169.254',
-  '::ffff:a9fe:a9fe',
-  'fd00:ec2::254',
-  'metadata.google.internal',
-  '100.100.100.200',
-]);
-
-// Operator escape hatch, set this env var to bypass all proxy restrictions
-const restrictionsDisabled = !!process.env.DANGEROUSLY_DISABLE_PROXY_RESTRICTIONS;
+const { validateTargetUrl } = request;
 
 // If reference to env var is present, substitute for env var value if set
 const PLACEHOLDER_RE = /\b(?:DASHY_|VITE_APP_|VUE_APP_)\w+/g;
@@ -41,31 +29,6 @@ const substituteEnv = (val) => {
     return out;
   }
   return val;
-};
-
-// Validate the target URL against scheme and host policies
-// Returns { ok: true } on success, or { ok: false, status, error } on rejection
-const validateTargetUrl = (raw) => {
-  if (restrictionsDisabled) return { ok: true };
-  let url;
-  try { url = new URL(raw); } catch (e) {
-    return { ok: false, status: 400, error: 'Target-URL is not a valid URL' };
-  }
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    return { ok: false, status: 400, error: 'Target-URL must use http:// or https://' };
-  }
-  // url.hostname includes brackets for IPv6 (e.g. '[fd00:ec2::254]') - strip em
-  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
-  if (BLOCKED_HOSTS.has(host)) {
-    return {
-      ok: false,
-      status: 403,
-      error: `Target-URL host '${host}' is blocked by the CORS proxy. `
-        + 'This address is reserved for cloud instance metadata services. '
-        + 'To bypass, set DANGEROUSLY_DISABLE_PROXY_RESTRICTIONS=true.',
-    };
-  }
-  return { ok: true };
 };
 
 const handler = (req, res) => {
@@ -115,6 +78,7 @@ const handler = (req, res) => {
     headers,
     timeout: 30000,
     maxResponseSize: 10 * 1024 * 1024, // 10 MB
+    validateUrl: validateTargetUrl,
   };
 
   // Make the request, and respond with result

--- a/services/request.js
+++ b/services/request.js
@@ -13,6 +13,44 @@ const https = require('https');
 const zlib = require('zlib');
 const { URL } = require('url');
 
+// List of hosts to disallow by default, for cloud instances
+// Covers AWS, Azure, GCP, DO, Hetzner, Oracle, etc on IPv4/6
+const BLOCKED_HOSTS = new Set([
+  '169.254.169.254',
+  '::ffff:a9fe:a9fe',
+  'fd00:ec2::254',
+  'metadata.google.internal',
+  '100.100.100.200',
+]);
+
+// Operator escape hatch, set this env var to bypass all proxy restrictions
+const restrictionsDisabled = !!process.env.DANGEROUSLY_DISABLE_PROXY_RESTRICTIONS;
+
+// Validate a target URL against scheme and host policies
+// Returns { ok: true } on success, or { ok: false, status, error } on rejection
+const validateTargetUrl = (raw) => {
+  if (restrictionsDisabled) return { ok: true };
+  let url;
+  try { url = new URL(raw); } catch (e) {
+    return { ok: false, status: 400, error: 'Target-URL is not a valid URL' };
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return { ok: false, status: 400, error: 'Target-URL must use http:// or https://' };
+  }
+  // url.hostname includes brackets for IPv6 (e.g. '[fd00:ec2::254]') - strip em
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (BLOCKED_HOSTS.has(host)) {
+    return {
+      ok: false,
+      status: 403,
+      error: `Target-URL host '${host}' is blocked by the CORS proxy. `
+        + 'This address is reserved for cloud instance metadata services. '
+        + 'To bypass, set DANGEROUSLY_DISABLE_PROXY_RESTRICTIONS=true.',
+    };
+  }
+  return { ok: true };
+};
+
 class RequestError extends Error {
   constructor(message, {
     response, code, errno, timeout,
@@ -63,6 +101,7 @@ function request(config) {
     timeout = 0,
     maxResponseSize = 0,
     httpsAgent,
+    validateUrl,
   } = config;
 
   return new Promise((resolve, reject) => {
@@ -73,6 +112,15 @@ function request(config) {
       } catch (e) {
         reject(new RequestError(`Invalid URL: ${targetUrl}`));
         return;
+      }
+
+      // Re-apply the host policy on every hop, so redirects can't reach a blocked host
+      if (validateUrl) {
+        const verdict = validateUrl(targetUrl);
+        if (verdict && verdict.ok === false) {
+          reject(new RequestError(verdict.error, { code: 'EBLOCKED' }));
+          return;
+        }
       }
 
       const isHttps = parsed.protocol === 'https:';
@@ -236,3 +284,4 @@ request.put = (url, data, config = {}) => request({ ...config, method: 'PUT', ur
 
 module.exports = request;
 module.exports.RequestError = RequestError;
+module.exports.validateTargetUrl = validateTargetUrl;

--- a/services/status-check.js
+++ b/services/status-check.js
@@ -4,6 +4,7 @@
  * endpoint, and then resolve the response status code, time taken, and short message
  */
 const request = require('./request');
+const { validateTargetUrl } = request;
 
 /* Determines if successful from the HTTP response code */
 const getResponseType = (code, validCodes) => {
@@ -39,6 +40,7 @@ const makeRequest = (url, options, render) => {
     maxRedirects,
     timeout: 10000,
     httpsAgent: { rejectUnauthorized: !enableInsecure },
+    validateUrl: validateTargetUrl,
   })
     .then((response) => {
       const statusCode = response.status;

--- a/tests/server/cors-proxy.test.js
+++ b/tests/server/cors-proxy.test.js
@@ -165,6 +165,17 @@ describe('CORS proxy error classification', () => {
     expect(res.body.error.type).toBe('upstream_error');
   });
 
+  it('blocks a redirect to a metadata host (does not follow it)', async () => {
+    handler = (req, res) => {
+      res.statusCode = 302;
+      res.setHeader('location', 'http://169.254.169.254/latest/meta-data/');
+      res.end();
+    };
+    const res = await request(app).get('/cors-proxy').set('Target-URL', targetUrl);
+    expect(res.body.error.code).toBe('EBLOCKED');
+    expect(res.body.error.message).toContain('blocked');
+  });
+
 });
 
 // Verify the request.js → cors-proxy timeout contract end-to-end. The proxy


### PR DESCRIPTION
### Category
Sec hardening

### Overview
Adds redirect checking to prevent cors endpoint accessing blocked URLs/IPs. Extended this functionality to the status check endpoint too.

### Issue Number
[GHSA-9ccw-3f4f-c4w2](https://github.com/lissy93/dashy/security/advisories/GHSA-9ccw-3f4f-c4w2)

### Additional Info
N/A
