### PR TITLE
Custom API widget

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -3297,9 +3297,66 @@ You can also use this widget to display an image, wither locally or from a remot
 
 ### API Response
 
-Directly output plain-text response from any API-enabled service.
+Display data from any HTTP/JSON API endpoint. Fetch a URL, then declaratively map response fields to labelled, formatted values.
+This was very much inspired by, and is broadly compatible with [Homepage's customapi widget](https://gethomepage.dev/widgets/services/customapi/)
 
-// Coming soon...
+#### Options
+
+**Field** | **Type** | **Required** | **Description**
+--- | --- | --- | ---
+**`url`** | `string` | Required | The full URL of the API endpoint to fetch
+**`refreshInterval`** | `number` | _Optional_ | How often to refetch, in milliseconds. Defaults to `10000` (10s). If omitted, the widget-level `updateInterval` (in seconds) is used instead
+**`username`** | `string` | _Optional_ | Username for HTTP basic auth
+**`password`** | `string` | _Optional_ | Password for HTTP basic auth
+**`method`** | `string` | _Optional_ | HTTP method, e.g. `GET` (default) or `POST`
+**`headers`** | `object` | _Optional_ | An object of custom request headers
+**`requestBody`** | `string` or `object` | _Optional_ | Request body for non-GET methods. Prefer an object (sent as JSON) — a raw string is JSON-encoded again, so don't pre-stringify
+**`display`** | `string` | _Optional_ | Layout for the fields: `block` (default, label and value on one row) or `list` (value stacked under the label)
+**`mappings`** | `array` | _Optional_ | The fields to display from the response (see below). If omitted, the raw response root is shown
+
+Each item in `mappings` accepts:
+
+**Field** | **Type** | **Required** | **Description**
+--- | --- | --- | ---
+**`field`** | `string` | _Optional_ | Dot-path to the value, e.g. `path.to.key` or `items.0.name`. Omit to use the response root (useful with `size`)
+**`label`** | `string` | _Optional_ | Label shown beside the value
+**`format`** | `string` | _Optional_ | One of `text` (default), `number`, `percent`, `date`, `relativeDate` or `size`
+**`locale`** | `string` | _Optional_ | Locale for `number`/`percent`/`date`/`relativeDate`, e.g. `nl`. Defaults to the browser locale
+**`dateStyle`** | `string` | _Optional_ | For `date` format. One of `full`, `long` (default), `medium`, `short`
+**`timeStyle`** | `string` | _Optional_ | For `date` format. One of `full`, `long`, `medium`, `short`
+**`style`** | `string` | _Optional_ | For `relativeDate` format. One of `long` (default), `short`, `narrow`
+**`numeric`** | `string` | _Optional_ | For `relativeDate` format. One of `always` (default) or `auto`
+**`additionalField`** | `object` | _Optional_ | A secondary value shown next to the main one. Accepts `field`, `format` (and its options), plus `color` — one of `theme`, `adaptive` (action colour from the value's sign: positive green, negative red), `black` or `white`
+
+Notes:
+- **`percent`** treats the value as an already-computed percentage, so `42` is shown as `42%`
+- **`size`** returns the number of items in an array (or keys in an object) — pair it with an omitted `field` to count the response root
+- For APIs that don't send CORS headers (most self-hosted services), set the widget-level `useProxy: true` to route the request through Dashy's server-side proxy
+
+#### Example
+
+```yaml
+- type: customapi
+  options:
+    url: https://api.github.com/repos/lissy93/dashy
+    refreshInterval: 60000
+    mappings:
+      - field: stargazers_count
+        label: Stars
+        format: number
+      - field: open_issues_count
+        label: Open Issues
+        format: number
+      - field: pushed_at
+        label: Last Push
+        format: relativeDate
+```
+
+#### Info
+
+- **CORS**: 🟠 Depends on target API (use `useProxy: true` if blocked)
+- **Auth**: 🟠 Optional (basic auth or custom headers)
+- **Price**: 🟢 Free
 
 ---
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -3310,7 +3310,7 @@ This was very much inspired by, and is broadly compatible with [Homepage's custo
 **`password`** | `string` | _Optional_ | Password for HTTP basic auth
 **`method`** | `string` | _Optional_ | HTTP method, e.g. `GET` (default) or `POST`
 **`headers`** | `object` | _Optional_ | An object of custom request headers
-**`requestBody`** | `string` or `object` | _Optional_ | Request body for non-GET methods. Prefer an object (sent as JSON) — a raw string is JSON-encoded again, so don't pre-stringify
+**`requestBody`** | `string` or `object` | _Optional_ | Request body for non-GET methods. Prefer an object. A raw string is JSON-encoded again, so don't pre-stringify
 **`display`** | `string` | _Optional_ | Layout for the fields: `block` (default, label and value on one row) or `list` (value stacked under the label)
 **`mappings`** | `array` | _Optional_ | The fields to display from the response (see below). If omitted, the raw response root is shown
 
@@ -3326,7 +3326,7 @@ Each item in `mappings` accepts:
 **`timeStyle`** | `string` | _Optional_ | For `date` format. One of `full`, `long`, `medium`, `short`
 **`style`** | `string` | _Optional_ | For `relativeDate` format. One of `long` (default), `short`, `narrow`
 **`numeric`** | `string` | _Optional_ | For `relativeDate` format. One of `always` (default) or `auto`
-**`additionalField`** | `object` | _Optional_ | A secondary value shown next to the main one. Accepts `field`, `format` (and its options), plus `color` — one of `theme`, `adaptive` (action colour from the value's sign: positive green, negative red), `black` or `white`
+**`additionalField`** | `object` | _Optional_ | A secondary value shown next to the main one. Accepts `field`, `format` (and its options), plus `color` - one of `theme`, `adaptive` (action colour from the value's sign: positive green, negative red), `black` or `white`
 
 Notes:
 - **`percent`** treats the value as an already-computed percentage, so `42` is shown as `42%`

--- a/src/components/Widgets/CustomApi.vue
+++ b/src/components/Widgets/CustomApi.vue
@@ -45,7 +45,12 @@ export default {
       Object.keys(userHeaders).forEach((key) => {
         resolved[key] = this.parseAsEnvVar(userHeaders[key]);
       });
-      return { ...this.authHeaders, ...resolved };
+      const headers = { ...this.authHeaders, ...resolved };
+      // Default a JSON content-type for body-bearing methods, unless the user set one
+      const hasBody = this.options.requestBody != null && this.method !== 'GET' && this.method !== 'HEAD';
+      const hasContentType = Object.keys(headers).some((k) => k.toLowerCase() === 'content-type');
+      if (hasBody && !hasContentType) headers['Content-Type'] = 'application/json';
+      return headers;
     },
     method() {
       return (this.options.method || 'GET').toUpperCase();

--- a/src/components/Widgets/CustomApi.vue
+++ b/src/components/Widgets/CustomApi.vue
@@ -1,0 +1,142 @@
+<template>
+  <div class="customapi-wrapper" :class="display">
+    <div class="row" v-for="(row, i) in results" :key="i">
+      <span class="lbl" v-if="row.label">{{ row.label }}</span>
+      <span class="val">
+        {{ row.value }}
+        <span
+          v-if="row.additional"
+          class="additional"
+          :class="`color-${row.additional.color || 'default'}`"
+        >{{ row.additional.value }}</span>
+      </span>
+    </div>
+  </div>
+</template>
+
+<script>
+import WidgetMixin from '@/mixins/WidgetMixin';
+import { resolveField, formatValue, adaptiveColor } from '@/utils/CustomApiHelpers';
+
+export default {
+  mixins: [WidgetMixin],
+  data() {
+    return {
+      results: [],
+    };
+  },
+  computed: {
+    url() {
+      return this.parseAsEnvVar(this.options.url);
+    },
+    /* Basic-auth header, when username and password are supplied */
+    authHeaders() {
+      if (this.options.username && this.options.password) {
+        const username = this.parseAsEnvVar(this.options.username);
+        const password = this.parseAsEnvVar(this.options.password);
+        return { Authorization: `Basic ${window.btoa(`${username}:${password}`)}` };
+      }
+      return {};
+    },
+    /* User headers (env-vars resolved) merged over the auth header */
+    mergedHeaders() {
+      const userHeaders = this.options.headers || {};
+      const resolved = {};
+      Object.keys(userHeaders).forEach((key) => {
+        resolved[key] = this.parseAsEnvVar(userHeaders[key]);
+      });
+      return { ...this.authHeaders, ...resolved };
+    },
+    method() {
+      return (this.options.method || 'GET').toUpperCase();
+    },
+    display() {
+      return this.options.display === 'list' ? 'list' : 'block';
+    },
+    mappings() {
+      const { mappings } = this.options;
+      return Array.isArray(mappings) && mappings.length ? mappings : [{ label: '', format: 'text' }];
+    },
+    /* Prefer homepage-style refreshInterval (ms), else fall back to native updateInterval (secs) */
+    updateInterval() {
+      const ms = this.options.refreshInterval;
+      if (ms === 0 || ms === false) return 0;
+      if (typeof ms === 'number' && ms >= 1000) return ms;
+      const secs = this.options.updateInterval;
+      if (typeof secs === 'boolean') return secs ? 30000 : 0;
+      if (typeof secs === 'number' && secs >= 2 && secs <= 7200) return secs * 1000;
+      return 10000;
+    },
+  },
+  methods: {
+    fetchData() {
+      if (!this.url) { this.error('A `url` is required'); this.finishLoading(); return; }
+      this.makeRequest(this.url, this.mergedHeaders, this.method, this.options.requestBody)
+        .then(this.processData)
+        .catch(() => { /* error already surfaced by the mixin */ });
+    },
+    /* Map each configured field to a labelled, formatted value */
+    processData(data) {
+      try {
+        this.results = this.mappings.map((m) => ({
+          label: m.label || '',
+          value: formatValue(resolveField(data, m.field), m, data),
+          additional: this.buildAdditional(m.additionalField, data),
+        }));
+      } catch (e) {
+        this.error('Failed to parse API response', e);
+      }
+    },
+    /* Resolve an optional secondary value; `adaptive` colour derives from the value's sign */
+    buildAdditional(field, data) {
+      if (!field) return null;
+      const raw = resolveField(data, field.field);
+      return {
+        value: formatValue(raw, field, data),
+        color: field.color === 'adaptive' ? adaptiveColor(raw) : (field.color || ''),
+      };
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.customapi-wrapper {
+  color: var(--widget-text-color);
+  .row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.25rem 0.1rem;
+    &:not(:last-child) {
+      border-bottom: 1px dashed var(--widget-text-color);
+    }
+    .lbl {
+      font-weight: bold;
+      margin-right: 0.5rem;
+    }
+    .val {
+      font-family: var(--font-monospace);
+      text-align: right;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      .additional {
+        margin-left: 0.5rem;
+        opacity: var(--dimming-factor);
+        &.color-theme { color: var(--primary); }
+        &.color-success { color: var(--success); }
+        &.color-warning { color: var(--warning); }
+        &.color-error { color: var(--error); }
+        &.color-info { color: var(--info); }
+        &.color-black { color: #000; }
+        &.color-white { color: #fff; }
+      }
+    }
+  }
+  &.list .row {
+    flex-direction: column;
+    align-items: flex-start;
+    .val { text-align: left; }
+  }
+}
+</style>

--- a/src/components/Widgets/WidgetBase.vue
+++ b/src/components/Widgets/WidgetBase.vue
@@ -66,6 +66,8 @@ const COMPAT = {
   'crypto-watch-list': 'CryptoWatchList',
   'custom-search': 'CustomSearch',
   'custom-list': 'CustomList',
+  customapi: 'CustomApi',
+  'custom-api': 'CustomApi',
   'cve-vulnerabilities': 'CveVulnerabilities',
   'domain-monitor': 'DomainMonitor',
   'drone-ci': 'DroneCi',

--- a/src/utils/CustomApiHelpers.js
+++ b/src/utils/CustomApiHelpers.js
@@ -1,0 +1,80 @@
+/* Field resolution and value formatting for the CustomApi widget */
+
+/* Get a nested value from an object by dot-path, e.g. 'a.b.0.c'. Empty path returns the root */
+export const resolveField = (obj, path) => {
+  if (!path) return obj;
+  return String(path).split('.').reduce((acc, key) => (acc == null ? acc : acc[key]), obj);
+};
+
+/* Map a value's sign to an action colour, for `color: adaptive` fields. Non-numeric stays neutral */
+export const adaptiveColor = (raw) => {
+  const n = Number(raw);
+  if (Number.isNaN(n)) return '';
+  if (n > 0) return 'success';
+  if (n < 0) return 'error';
+  return 'info';
+};
+
+/* Largest-first periods, used to pick a unit for relative dates */
+const RELATIVE_UNITS = [
+  { unit: 'year', secs: 31557600 },
+  { unit: 'month', secs: 2628000 },
+  { unit: 'week', secs: 604800 },
+  { unit: 'day', secs: 86400 },
+  { unit: 'hour', secs: 3600 },
+  { unit: 'minute', secs: 60 },
+  { unit: 'second', secs: 1 },
+];
+
+/* Format a date as relative to now, e.g. '2 days ago' or 'in 3 hours' */
+const formatRelativeDate = (raw, mapping, locale) => {
+  const time = new Date(raw).getTime();
+  if (Number.isNaN(time)) return String(raw);
+  const diffSecs = (time - Date.now()) / 1000;
+  const period = RELATIVE_UNITS.find((p) => Math.abs(diffSecs) >= p.secs)
+    || RELATIVE_UNITS[RELATIVE_UNITS.length - 1];
+  const rtf = new Intl.RelativeTimeFormat(locale, {
+    style: mapping.style || 'long',
+    numeric: mapping.numeric || 'always',
+  });
+  return rtf.format(Math.round(diffSecs / period.secs), period.unit);
+};
+
+/* Format a raw value per a mapping's `format`. `root` is the full response, used by `size` */
+export const formatValue = (raw, mapping = {}, root) => {
+  const format = mapping.format || 'text';
+  const locale = mapping.locale || navigator.language;
+
+  // `size` counts array elements / object keys (root when no field is given)
+  if (format === 'size') {
+    const target = mapping.field == null ? root : raw;
+    if (Array.isArray(target)) return String(target.length);
+    if (target && typeof target === 'object') return String(Object.keys(target).length);
+    return target == null ? '' : String(target);
+  }
+
+  if (raw == null) return '';
+
+  switch (format) {
+    case 'number': {
+      const n = Number(raw);
+      return Number.isNaN(n) ? String(raw) : new Intl.NumberFormat(locale).format(n);
+    }
+    case 'percent': {
+      const n = Number(raw);
+      return Number.isNaN(n) ? String(raw)
+        : new Intl.NumberFormat(locale, { style: 'percent', maximumFractionDigits: 2 }).format(n / 100);
+    }
+    case 'date': {
+      const date = new Date(raw);
+      if (Number.isNaN(date.getTime())) return String(raw);
+      const opts = { dateStyle: mapping.dateStyle || 'long' };
+      if (mapping.timeStyle) opts.timeStyle = mapping.timeStyle;
+      return new Intl.DateTimeFormat(locale, opts).format(date);
+    }
+    case 'relativeDate':
+      return formatRelativeDate(raw, mapping, locale);
+    default:
+      return String(raw);
+  }
+};

--- a/tests/components/customapi.test.js
+++ b/tests/components/customapi.test.js
@@ -1,0 +1,92 @@
+import {
+  describe, it, expect, beforeEach, afterEach, vi,
+} from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import CustomApi from '@/components/Widgets/CustomApi.vue';
+
+const response = {
+  name: 'dashy',
+  stars: 1234,
+  pushed_at: '2026-06-08T00:00:00Z',
+  items: [1, 2, 3],
+};
+
+vi.mock('@/utils/request', () => {
+  const fn = vi.fn(() => Promise.resolve({ data: response }));
+  fn.get = fn; fn.post = fn; fn.put = fn;
+  return { default: fn };
+});
+vi.mock('@/utils/logging/ErrorHandler', () => ({ default: vi.fn() }));
+
+/** Mount CustomApi with the given options object */
+function mountWidget(options) {
+  return shallowMount(CustomApi, { props: { options } });
+}
+
+describe('CustomApi widget', () => {
+  let wrapper;
+  afterEach(() => wrapper && wrapper.unmount());
+
+  it('renders a row per mapping with formatted values', async () => {
+    wrapper = mountWidget({
+      url: 'https://example.com',
+      mappings: [
+        { field: 'stars', label: 'Stars', format: 'number' },
+        { label: 'Item count', format: 'size', field: 'items' },
+      ],
+    });
+    await flushPromises();
+    const rows = wrapper.findAll('.row');
+    expect(rows).toHaveLength(2);
+    expect(wrapper.text()).toContain('Stars');
+    expect(wrapper.text()).toContain('1,234');
+    expect(wrapper.text()).toContain('3');
+  });
+
+  it('applies the list display class', () => {
+    wrapper = mountWidget({ url: 'https://example.com', display: 'list' });
+    expect(wrapper.find('.customapi-wrapper').classes()).toContain('list');
+  });
+
+  it('renders an additionalField with its colour class', async () => {
+    wrapper = mountWidget({
+      url: 'https://example.com',
+      mappings: [
+        { field: 'name', label: 'Repo', additionalField: { field: 'stars', color: 'theme' } },
+      ],
+    });
+    await flushPromises();
+    expect(wrapper.find('.additional').classes()).toContain('color-theme');
+  });
+
+  it('resolves an adaptive colour from the value sign', async () => {
+    wrapper = mountWidget({
+      url: 'https://example.com',
+      mappings: [
+        { field: 'name', label: 'Repo', additionalField: { field: 'stars', color: 'adaptive' } },
+      ],
+    });
+    await flushPromises();
+    // stars (1234) is positive -> success
+    expect(wrapper.find('.additional').classes()).toContain('color-success');
+  });
+
+  describe('updateInterval', () => {
+    it('defaults to 10s', () => {
+      wrapper = mountWidget({ url: 'https://example.com' });
+      expect(wrapper.vm.updateInterval).toBe(10000);
+    });
+    it('uses refreshInterval (ms) when given', () => {
+      wrapper = mountWidget({ url: 'https://example.com', refreshInterval: 30000 });
+      expect(wrapper.vm.updateInterval).toBe(30000);
+    });
+    it('falls back to native updateInterval (seconds)', () => {
+      wrapper = mountWidget({ url: 'https://example.com', updateInterval: 5 });
+      expect(wrapper.vm.updateInterval).toBe(5000);
+    });
+    it('returns 0 when refreshInterval is disabled', () => {
+      wrapper = mountWidget({ url: 'https://example.com', refreshInterval: 0 });
+      expect(wrapper.vm.updateInterval).toBe(0);
+    });
+  });
+});

--- a/tests/components/customapi.test.js
+++ b/tests/components/customapi.test.js
@@ -71,6 +71,27 @@ describe('CustomApi widget', () => {
     expect(wrapper.find('.additional').classes()).toContain('color-success');
   });
 
+  describe('mergedHeaders content-type', () => {
+    it('defaults to application/json for a body-bearing method', () => {
+      wrapper = mountWidget({ url: 'https://example.com', method: 'POST', requestBody: { a: 1 } });
+      expect(wrapper.vm.mergedHeaders['Content-Type']).toBe('application/json');
+    });
+    it('does not add a content-type for GET', () => {
+      wrapper = mountWidget({ url: 'https://example.com', requestBody: { a: 1 } });
+      const keys = Object.keys(wrapper.vm.mergedHeaders).map((k) => k.toLowerCase());
+      expect(keys).not.toContain('content-type');
+    });
+    it('respects a user-provided content-type', () => {
+      wrapper = mountWidget({
+        url: 'https://example.com',
+        method: 'POST',
+        requestBody: '<xml/>',
+        headers: { 'Content-Type': 'application/xml' },
+      });
+      expect(wrapper.vm.mergedHeaders['Content-Type']).toBe('application/xml');
+    });
+  });
+
   describe('updateInterval', () => {
     it('defaults to 10s', () => {
       wrapper = mountWidget({ url: 'https://example.com' });

--- a/tests/unit/customapi-helpers.test.js
+++ b/tests/unit/customapi-helpers.test.js
@@ -1,0 +1,100 @@
+import {
+  describe, it, expect, beforeEach, afterEach, vi,
+} from 'vitest';
+import { resolveField, formatValue, adaptiveColor } from '@/utils/CustomApiHelpers';
+
+describe('CustomApiHelpers - resolveField', () => {
+  it('resolves a nested dot-path', () => {
+    expect(resolveField({ a: { b: 1 } }, 'a.b')).toBe(1);
+  });
+
+  it('resolves array indices in the path', () => {
+    expect(resolveField({ a: [{ n: 'x' }] }, 'a.0.n')).toBe('x');
+  });
+
+  it('returns undefined for a missing path without throwing', () => {
+    expect(resolveField({ a: 1 }, 'a.b.c')).toBeUndefined();
+  });
+
+  it('returns the root when path is omitted', () => {
+    expect(resolveField('scalar')).toBe('scalar');
+  });
+
+  it('returns null when the object is null', () => {
+    expect(resolveField(null, 'a')).toBeNull();
+  });
+});
+
+describe('CustomApiHelpers - formatValue', () => {
+  it('text: null becomes an empty string', () => {
+    expect(formatValue(null, { format: 'text' })).toBe('');
+  });
+
+  it('text: coerces to string', () => {
+    expect(formatValue(5, { format: 'text' })).toBe('5');
+  });
+
+  it('number: formats with grouping', () => {
+    expect(formatValue(1234, { format: 'number', locale: 'en-US' })).toBe('1,234');
+  });
+
+  it('number: passes through non-numeric input', () => {
+    expect(formatValue('abc', { format: 'number', locale: 'en-US' })).toBe('abc');
+  });
+
+  it('percent: treats the value as an already-computed percentage', () => {
+    expect(formatValue(42, { format: 'percent', locale: 'en-US' })).toBe('42%');
+  });
+
+  it('date: formats a valid date', () => {
+    const out = formatValue('2026-06-10', { format: 'date', dateStyle: 'long', locale: 'en-US' });
+    expect(out).toMatch(/2026/);
+  });
+
+  it('date: passes through an invalid date', () => {
+    expect(formatValue('notadate', { format: 'date', locale: 'en-US' })).toBe('notadate');
+  });
+
+  it('size: counts array elements (root when field omitted)', () => {
+    expect(formatValue([1, 2, 3], { format: 'size' }, [1, 2, 3])).toBe('3');
+  });
+
+  it('size: counts object keys', () => {
+    expect(formatValue({ a: 1, b: 2 }, { format: 'size' }, { a: 1, b: 2 })).toBe('2');
+  });
+});
+
+describe('CustomApiHelpers - adaptiveColor', () => {
+  it('returns success for a positive value', () => {
+    expect(adaptiveColor(5)).toBe('success');
+  });
+  it('returns error for a negative value', () => {
+    expect(adaptiveColor(-2.4)).toBe('error');
+  });
+  it('returns info for zero', () => {
+    expect(adaptiveColor(0)).toBe('info');
+  });
+  it('returns no colour for non-numeric input', () => {
+    expect(adaptiveColor('online')).toBe('');
+  });
+});
+
+describe('CustomApiHelpers - relativeDate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-10T00:00:00Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('formats a past date', () => {
+    const out = formatValue('2026-06-08T00:00:00Z', { format: 'relativeDate', locale: 'en-US' });
+    expect(out).toBe('2 days ago');
+  });
+
+  it('formats a future date', () => {
+    const out = formatValue('2026-06-13T00:00:00Z', { format: 'relativeDate', locale: 'en-US' });
+    expect(out).toBe('in 3 days');
+  });
+});


### PR DESCRIPTION
### Category
Feature

### Overview
This PR creates a new widget, `custom-api` which can be configured to consume (almost) any JSON input from an upstream API or use specially built API endpoints, so that you can show data from third-parties within your dashboard even when a specific widget doesn't exist yet.

It's heavily inspired by how Homepage does this (https://gethomepage.dev/widgets/services/customapi/), so should make switchin to or from Dashy/Homepage quite easy. 

### Issue Number
Fixes #2191

### Additional Info

<details>

<summary>Example</summary>

<img width="670" height="1032" alt="image" src="https://github.com/user-attachments/assets/587de1c2-7af0-477f-b353-8f505ffe9318" />

```yaml
- name: CustomApi · GitHub & Finance
    icon: fas fa-chart-line
    widgets:
      # GitHub repo - number / relativeDate / date / size, additionalField (theme colour)
      - type: customapi
        label: Dashy on GitHub
        options:
          url: https://api.github.com/repos/lissy93/dashy
          refreshInterval: 60000
          mappings:
            - field: full_name
              label: Repo
            - field: stargazers_count
              label: Stars
              format: number
              additionalField:
                field: forks_count
                format: number
                color: theme
            - field: language
              label: Language
            - field: open_issues_count
              label: Open issues
              format: number
            - field: pushed_at
              label: Last push
              format: relativeDate
            - field: created_at
              label: Created
              format: date
              dateStyle: medium
            - field: topics
              label: Topics
              format: size

      - type: custom-api
        label: GitHub Profile
        updateInterval: 120
        options:
          url: https://api.github.com/users/lissy93
          display: list
          mappings:
            - field: login
              label: User
            - field: name
              label: Name
            - field: public_repos
              label: Public repos
              format: number
            - field: followers
              label: Followers
              format: number
              additionalField:
                field: following
                format: number
                color: adaptive
            - field: created_at
              label: Joined
              format: relativeDate

      # Crypto Fear & Greed Index — numeric string + a text classification beside it
      - type: customapi
        label: Crypto Fear & Greed
        options:
          url: https://api.alternative.me/fng/
          refreshInterval: 300000
          mappings:
            - field: data.0.value
              label: Index
              format: number
              additionalField:
                field: data.0.value_classification
                color: theme
            - field: data.0.value_classification
              label: Sentiment
```

</details>