### PR TITLE
Support for automatic background OIDC token renewal

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -502,6 +502,29 @@ Dashy's server reads `auth.oidc` from `conf.yml` at boot, lazily fetches the OID
 
 Your IdP must include `groups` / `roles` in the id_token, not only the access token, for the admin check to work (most IdPs do this when the `groups` scope is requested).
 
+
+### Silent token renewal
+
+By default, when your access token expires Dashy sends you back through the provider's login page to get a new one. On a long-lived session this is visible as a brief flash of the sign-out button and a reload. Setting `enableSilentRenew: true` avoids it: Dashy requests a refresh token and uses it to renew the session in the background, before the token expires, with no interactive round-trip.
+
+```yaml
+    oidc:
+      clientId: dashy
+      endpoint: 'https://your-oidc-provider.example.com'
+      scope: 'openid profile email groups'
+      adminGroup: admin
+      enableSilentRenew: true
+```
+
+Notes:
+- It is opt-in and off by default. With it off, nothing changes, existing setups are unaffected.
+- **Your provider must support the `offline_access` scope.** When this is on, Dashy adds `offline_access` to the scope it requests at sign-in, so the provider issues a refresh token. Most providers support this (Authentik, Keycloak, Authelia, Okta, Auth0, Entra/Azure AD). A few do not, most notably **Google**, which uses `access_type=offline` instead and will reject the scope. Do not enable this flag against a provider that rejects `offline_access`, as it would break the interactive sign-in too. If unsure, test sign-in after enabling it.
+- The provider's client/app may also need to be allowed to issue refresh tokens to a public (PKCE) client. In Authentik this is automatic once `offline_access` is an allowed scope.
+- If a silent renewal fails for any reason (no refresh token issued, refresh token expired or revoked, the provider returns no fresh id_token, a provider error), Dashy falls back to the normal interactive sign-in. Renewal can save a round-trip, but the interactive flow always remains the safety net.
+- Renewal is driven by the access token's lifetime. If your provider issues an id_token with a much shorter lifetime than the access token, renewal may lag; keeping the two lifetimes equal (the common default) works best.
+- With multiple tabs open against a provider that rotates refresh tokens on use, tabs can briefly contend for the refresh token; the affected tab simply falls back to interactive sign-in. This is inherent to browser-based refresh tokens, not specific to Dashy.
+
+
 ---
 
 ## authentik

--- a/docs/authentication/authelia-oidc.md
+++ b/docs/authentication/authelia-oidc.md
@@ -241,6 +241,37 @@ If Authelia uses a self-signed cert, Dashy's server has to trust it before it ca
 Everything should now be fully configured and working 🎉
 When you load Dashy, you'll be redirected to Authelia's login page. After signing in, you'll land back on Dashy's homepage with full access, and all of Dashy's client, server and asset endpoints will be locked behind authentication.
 
+### Silent token renewal (optional)
+
+By default, when your token expires Dashy sends you back through Authelia's login to get a new one. Set `enableSilentRenew: true` to have Dashy refresh the session quietly in the background instead, using a refresh token:
+
+```yaml
+    oidc:
+      clientId: dashy
+      endpoint: https://authelia.lvh.me:9091
+      adminGroup: admins
+      scope: openid profile email groups
+      enableSilentRenew: true
+```
+
+Dashy adds the `offline_access` scope to its request automatically, but Authelia only issues a refresh token if the client is allowed to. Add `offline_access` to the client's `scopes` and `refresh_token` to its `grant_types`:
+
+```yaml
+    clients:
+      - client_id: dashy
+        scopes:
+          - openid
+          - profile
+          - email
+          - groups
+          - offline_access
+        grant_types:
+          - authorization_code
+          - refresh_token
+```
+
+It's off by default, and if a refresh ever fails Dashy falls back to the normal sign-in. See [silent token renewal](../authentication.md#silent-token-renewal) for the full notes and caveats.
+
 ---
 
 ## 4. Groups and Visibility

--- a/docs/authentication/authentik.md
+++ b/docs/authentication/authentik.md
@@ -219,6 +219,21 @@ If Authentik runs on a different host or behind a reverse proxy, make sure `endp
 Everything should now be fully configured and working 🎉
 When you load Dashy, you'll be redirected to Authentik's login page. After signing in you will land back on Dashy's homepage with full access, and all of Dashy's client, server and asset endpoints will be locked behind authentication.
 
+### Silent token renewal (optional)
+
+By default, when your token expires Dashy sends you back through Authentik's login to get a new one. Set `enableSilentRenew: true` to have Dashy refresh the session quietly in the background instead, using a refresh token:
+
+```yaml
+    oidc:
+      clientId: dashy
+      endpoint: https://auth.example.com/application/o/dashy/
+      adminGroup: dashy-admins
+      scope: openid profile email groups
+      enableSilentRenew: true
+```
+
+Dashy adds the `offline_access` scope to its request automatically. Authentik ships an `offline_access` scope mapping by default, so just make sure it's listed under the provider's **Advanced protocol settings > Selected Scopes**. It's off by default, and if a refresh ever fails Dashy falls back to the normal sign-in. See [silent token renewal](../authentication.md#silent-token-renewal) for the full notes and caveats.
+
 ---
 
 ## 4. Groups and Visibility

--- a/docs/authentication/pocketid.md
+++ b/docs/authentication/pocketid.md
@@ -175,6 +175,21 @@ If Pocket ID runs behind a reverse proxy, make sure `endpoint` and `APP_URL` agr
 Everything should now be fully configured and working 🎉
 When you load Dashy, you'll be redirected to Pocket ID's sign-in page. Authenticate with your passkey (or paste a one-time code), and you'll land back on Dashy with full access. All of Dashy's client, server and asset endpoints will be locked behind authentication.
 
+### Silent token renewal (optional)
+
+By default, when your token expires Dashy sends you back through Pocket ID's login to get a new one. Set `enableSilentRenew: true` to have Dashy refresh the session quietly in the background instead, using a refresh token:
+
+```yaml
+    oidc:
+      clientId: 268a3701-e9ec-41f6-bad5-87c78ce87c94
+      endpoint: http://localhost:1411
+      adminGroup: admins
+      scope: openid profile email groups
+      enableSilentRenew: true
+```
+
+Dashy adds the `offline_access` scope to its request automatically, and Pocket ID issues a refresh token for it, so nothing needs changing on the Pocket ID side. It's off by default, and if a refresh ever fails Dashy falls back to the normal sign-in. See [silent token renewal](../authentication.md#silent-token-renewal) for the full notes and caveats.
+
 ---
 
 ## 4. Groups and Visibility

--- a/docs/authentication/zitadel.md
+++ b/docs/authentication/zitadel.md
@@ -245,6 +245,21 @@ If Zitadel runs on a different host or behind a reverse proxy, make sure `endpoi
 Everything should now be fully configured and working 🎉
 When you load Dashy, you'll be redirected to Zitadel's login page. After signing in, you'll land back on Dashy's homepage with full access, and all of Dashy's client, server and asset endpoints will be locked behind authentication.
 
+### Silent token renewal (optional)
+
+By default, when your token expires Dashy sends you back through Zitadel's login to get a new one. Set `enableSilentRenew: true` to have Dashy refresh the session quietly in the background instead, using a refresh token:
+
+```yaml
+    oidc:
+      clientId: "1234567890123456789"
+      endpoint: http://zitadel.lvh.me:8080
+      adminGroup: admins
+      scope: openid profile email
+      enableSilentRenew: true
+```
+
+Dashy adds the `offline_access` scope to its request automatically. For Zitadel to issue a refresh token, open the application's **Configuration** and make sure the **Refresh Token** grant type is enabled. It's off by default, and if a refresh ever fails Dashy falls back to the normal sign-in. See [silent token renewal](../authentication.md#silent-token-renewal) for the full notes and caveats.
+
 ---
 
 ## 4. Groups and Visibility

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -219,6 +219,7 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 **`adminRole`** | `string` | _Optional_ | The role that will be considered as admin.
 **`adminGroup`** | `string` | _Optional_ | The group that will be considered as admin.
 **`scope`** | `string` | Required | The scope(s) to request from the OIDC provider
+**`enableSilentRenew`** | `boolean` | _Optional_ | If set to `true`, your session is silently renewed in the background before it expires (only works for providers which support the `offline_access` scope)
 
 **[⬆️ Back to Top](#configuring)**
 

--- a/src/main.js
+++ b/src/main.js
@@ -67,7 +67,8 @@ const handleAuthFailure = (provider, err) => {
 
 router.isReady().then(() => {
   if (isOidcEnabled()) {
-    initOidcAuth().then(mount).catch((e) => handleAuthFailure('OIDC', e));
+    initOidcAuth().then((reloading) => { if (!reloading) mount(); })
+      .catch((e) => handleAuthFailure('OIDC', e));
   } else if (isKeycloakEnabled()) {
     initKeycloakAuth().then(mount).catch((e) => handleAuthFailure('Keycloak', e));
   } else if (isHeaderAuthEnabled()) {

--- a/src/utils/auth/OidcAuth.js
+++ b/src/utils/auth/OidcAuth.js
@@ -11,6 +11,19 @@ import $store from '@/store';
 const SIGNIN_GUARD_KEY = 'dashy.oidc.signin-attempt';
 const SIGNIN_GUARD_THRESHOLD_MS = 5 * 1000;
 
+// Guard so a silently-refreshed but still-rejected token can't reload in a loop
+const SILENT_RENEW_GUARD_KEY = 'dashy.oidc.silent-attempt';
+const SILENT_RENEW_GUARD_THRESHOLD_MS = 30 * 1000;
+const recentlySilentRenewed = () => {
+  try {
+    const last = Number(sessionStorage.getItem(SILENT_RENEW_GUARD_KEY)) || 0;
+    return Date.now() - last < SILENT_RENEW_GUARD_THRESHOLD_MS;
+  } catch { return false; }
+};
+const markSilentRenewAttempt = () => {
+  try { sessionStorage.setItem(SILENT_RENEW_GUARD_KEY, String(Date.now())); } catch { /* ignore */ }
+};
+
 /* Return a same-origin path to navigate back to after IdP, or just `/` */
 const safeReturnTo = (raw) => {
   if (typeof raw !== 'string') return '/';
@@ -41,6 +54,7 @@ class OidcAuth {
       scope,
       adminGroup,
       adminRole,
+      enableSilentRenew,
     } = auth.oidc;
     if (typeof clientId === 'number' && !Number.isSafeInteger(clientId)) {
       ErrorHandler(
@@ -49,18 +63,24 @@ class OidcAuth {
         + 'Wrap it in quotes in your conf.yml (e.g. clientId: "12345") to force it be a string.',
       );
     }
+    const baseScope = scope || 'openid profile email roles groups';
+    // Get refresh token (needed for silent renewal)
+    const requestedScope = enableSilentRenew && !baseScope.split(' ').includes('offline_access')
+      ? `${baseScope} offline_access`
+      : baseScope;
     const settings = {
       userStore: new WebStorageStateStore({ store: window.localStorage }),
       authority: endpoint,
       client_id: String(clientId),
       redirect_uri: `${window.location.origin}`,
       response_type: 'code',
-      scope: scope || 'openid profile email roles groups',
+      scope: requestedScope,
       response_mode: 'query',
       filterProtocolClaims: true,
       loadUserInfo: true,
     };
 
+    this.silentRenewEnabled = Boolean(enableSilentRenew);
     this.adminGroup = adminGroup;
     this.adminRole = adminRole;
     this.userManager = new UserManager(settings);
@@ -111,17 +131,25 @@ class OidcAuth {
 
     const user = await this.userManager.getUser();
     if (user === null) {
-      if (!isOidcGuestAccessEnabled()) await this.redirectToIdp();
-      return;
+      if (isOidcGuestAccessEnabled()) return false;
+      await this.redirectToIdp();
+      return true;
     }
 
     // Server returned an unauthenticated bootstrap config
     // Cached id_token is expired / invalid, wipe it and re-authenticate
+    // Try a quiet refresh, else redirect user to their login form
     if ($store.state.rootConfig?._bootstrap?.authenticated === false) {
+      if (this.silentRenewEnabled && user.refresh_token
+        && !recentlySilentRenewed() && await this.trySilentRenew()) {
+        markSilentRenewAttempt();
+        setTimeout(() => window.location.reload(), 250);
+        return true;
+      }
       await this.userManager.removeUser();
       localStorage.removeItem(localStorageKeys.ID_TOKEN);
       await this.redirectToIdp();
-      return;
+      return true;
     }
 
     this.persistUserInfo(user);
@@ -131,7 +159,30 @@ class OidcAuth {
       setTimeout(() => window.location.reload(), 500);
       return true;
     }
+    // Keep token fresh in the background, once session is valid
+    this.startBackgroundRenew(user);
     return false;
+  }
+
+  /* Attempts to renew session with refresh token
+   * returns true on success, or false to trigger redirect to login page */
+  async trySilentRenew() {
+    try {
+      const previousToken = localStorage.getItem(localStorageKeys.ID_TOKEN);
+      const user = await this.userManager.signinSilent();
+      if (user?.id_token && user.id_token !== previousToken) {
+        this.persistUserInfo(user);
+        return true;
+      }
+    } catch (err) {
+      statusErrorMsg('OIDC', 'Silent token renewal failed, using interactive sign-in', err);
+    }
+    return false;
+  }
+
+  /* Start OIDC background renewal for confirmed sessions if enabled */
+  startBackgroundRenew(user) {
+    if (this.silentRenewEnabled && user?.refresh_token) this.userManager.startSilentRenew();
   }
 
   /* Redirect to the IdP for interactive sign-in
@@ -175,6 +226,7 @@ class OidcAuth {
   }
 
   async logout() {
+    this.userManager.stopSilentRenew();
     localStorage.removeItem(localStorageKeys.USERNAME);
     localStorage.removeItem(localStorageKeys.KEYCLOAK_INFO);
     localStorage.removeItem(localStorageKeys.ISADMIN);

--- a/src/utils/auth/OidcAuth.js
+++ b/src/utils/auth/OidcAuth.js
@@ -78,6 +78,8 @@ class OidcAuth {
     });
   }
 
+  /* Returns true when a same-page reload is scheduled, signalling the caller
+   * to skip mounting the throwaway frame the reload would immediately discard. */
   async login() {
     const hadValidToken = Boolean(getApiAuthHeader());
     const url = new URL(window.location.href);
@@ -104,7 +106,7 @@ class OidcAuth {
       const returnTo = safeReturnTo(callbackUser.state);
       toast(i18n.global.t('login.authenticated-redirecting'), { type: 'success' });
       setTimeout(() => window.location.replace(returnTo), 600);
-      return;
+      return true;
     }
 
     const user = await this.userManager.getUser();
@@ -127,7 +129,9 @@ class OidcAuth {
     if (!hadValidToken && getApiAuthHeader()) {
       toast(i18n.global.t('login.authenticated-redirecting'), { type: 'success' });
       setTimeout(() => window.location.reload(), 500);
+      return true;
     }
+    return false;
   }
 
   /* Redirect to the IdP for interactive sign-in

--- a/src/utils/config/ConfigSchema.json
+++ b/src/utils/config/ConfigSchema.json
@@ -655,7 +655,13 @@
                     "title": "OIDC Scope",
                     "type": "string",
                     "description": "The scope(s) to request from the OIDC provider"
-                  }
+                  },
+                "enableSilentRenew": {
+                  "title": "Enable Silent Token Renewal",
+                  "type": "boolean",
+                  "default": false,
+                  "description": "If set to true, Dashy automatically renews your session in the background before it expires. Requires your OIDC provider to issue refresh tokens"
+                }
               }
             },
             "enableHeaderAuth": {


### PR DESCRIPTION
### Category
Feature

### Overview
As reported [here](https://github.com/lissy93/dashy/discussions/2173#discussioncomment-17230406) by @Amethysta0013, the re-auth flow is quite "clunky". Previously, once a token was invalid (expired), the user would be sent back to the login screen, re-authenticate and then come back to Dashy again. 

This PR adds support for automatic token renewal, which happens silently in the background shortly before their id_token expires. 

This is only supported for OIDC providers which support the `offline_access` scope.

To use it, you need to enable `appConfig.auth.oidc.enableSilentRenew` option, set to `true`. This is documented in the authentication docs, plus the config schema.

While here, i also fixed a lil bug which shows a flash of the "Sign out" button during the re-auth flow.

### Issue Number
N/A - discussion thread was at https://github.com/lissy93/dashy/discussions/2173#discussioncomment-17230406

