### PR TITLE
Fixes XSS in workspace url param

### DIFF
--- a/src/views/Workspace.vue
+++ b/src/views/Workspace.vue
@@ -20,6 +20,7 @@ import WidgetView from '@/components/Workspace/WidgetView';
 import MultiTaskingWebComtent from '@/components/Workspace/MultiTaskingWebComtent';
 import Defaults from '@/utils/config/defaults';
 import ErrorHandler from '@/utils/logging/ErrorHandler';
+import { sanitizeUrl } from '@/utils/Sanitizer';
 
 export default {
   name: 'Workspace',
@@ -80,7 +81,7 @@ export default {
     getInitialUrl() {
       const route = this.$route;
       if (route.query && route.query.url) {
-        return decodeURI(route.query.url);
+        return sanitizeUrl(decodeURI(route.query.url)) || undefined;
       } else if (this.appConfig.workspaceLandingUrl) {
         return this.appConfig.workspaceLandingUrl;
       }


### PR DESCRIPTION
### Category
Security Fix

### Overview
As reported by @ixSly in [GHSA-58mp-4qr3-vmrc](https://github.com/lissy93/dashy/security/advisories/GHSA-58mp-4qr3-vmrc), an authenticated user could click a crafted link taking them to workspace view with ?url= param set which could pass a non-http iframe source.

No stored or zero-click issues identified, and a attacker would already need access to your instance to your network to use this vulnerability. 

This PR fixes the issue by fully sanitizing the param.

### Issue Number
GHSA-58mp-4qr3-vmrc

