### PR TITLE
Custom number formats for the custom-api widget

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -3346,10 +3346,11 @@ Each item in `mappings` accepts:
 --- | --- | --- | ---
 **`field`** | `string` | _Optional_ | Dot-path to the value, e.g. `path.to.key` or `items.0.name`. Omit to use the response root (useful with `size`)
 **`label`** | `string` | _Optional_ | Label shown beside the value
-**`format`** | `string` | _Optional_ | One of `text` (default), `number`, `percent`, `bytes`, `bitrate`, `date`, `relativeDate` or `size`
+**`format`** | `string` | _Optional_ | One of `text` (default), `number`, `percent`, `bytes`, `bitrate`, `duration`, `date`, `relativeDate` or `size`
 **`scale`** | `number` or `string` | _Optional_ | Multiply the value before formatting. A number or fraction string, e.g. `1024` or `1/16`
 **`prefix`** | `string` | _Optional_ | Text prepended to the formatted value
 **`suffix`** | `string` | _Optional_ | Text appended to the formatted value
+**`remap`** | `array` | _Optional_ | Swap raw values for display text, e.g. `0` → `Down`. Each entry has `value` and `to`; an entry with `any: true` matches everything else
 **`locale`** | `string` | _Optional_ | Locale for `number`/`percent`/`date`/`relativeDate`, e.g. `nl`. Defaults to the browser locale
 **`dateStyle`** | `string` | _Optional_ | For `date` format. One of `full`, `long` (default), `medium`, `short`
 **`timeStyle`** | `string` | _Optional_ | For `date` format. One of `full`, `long`, `medium`, `short`
@@ -3360,6 +3361,7 @@ Each item in `mappings` accepts:
 Notes:
 - **`percent`** treats the value as an already-computed percentage, so `42` is shown as `42%`
 - **`bytes`** and **`bitrate`** auto-select a unit: `1073741824` → `1 GB`, `2500000` → `2.5 Mbps`
+- **`duration`** shows seconds as a compact time: `3665` → `1h 1m`
 - **`scale`** is applied before formatting, useful for unit conversions — e.g. for an API reporting kilobytes, `scale: 1024` with `format: bytes`
 - **`size`** returns the number of items in an array (or keys in an object) — pair it with an omitted `field` to count the response root
 - For APIs that don't send CORS headers (most self-hosted services), set the widget-level `useProxy: true` to route the request through Dashy's server-side proxy

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -3346,7 +3346,10 @@ Each item in `mappings` accepts:
 --- | --- | --- | ---
 **`field`** | `string` | _Optional_ | Dot-path to the value, e.g. `path.to.key` or `items.0.name`. Omit to use the response root (useful with `size`)
 **`label`** | `string` | _Optional_ | Label shown beside the value
-**`format`** | `string` | _Optional_ | One of `text` (default), `number`, `percent`, `date`, `relativeDate` or `size`
+**`format`** | `string` | _Optional_ | One of `text` (default), `number`, `percent`, `bytes`, `bitrate`, `date`, `relativeDate` or `size`
+**`scale`** | `number` or `string` | _Optional_ | Multiply the value before formatting. A number or fraction string, e.g. `1024` or `1/16`
+**`prefix`** | `string` | _Optional_ | Text prepended to the formatted value
+**`suffix`** | `string` | _Optional_ | Text appended to the formatted value
 **`locale`** | `string` | _Optional_ | Locale for `number`/`percent`/`date`/`relativeDate`, e.g. `nl`. Defaults to the browser locale
 **`dateStyle`** | `string` | _Optional_ | For `date` format. One of `full`, `long` (default), `medium`, `short`
 **`timeStyle`** | `string` | _Optional_ | For `date` format. One of `full`, `long`, `medium`, `short`
@@ -3356,6 +3359,8 @@ Each item in `mappings` accepts:
 
 Notes:
 - **`percent`** treats the value as an already-computed percentage, so `42` is shown as `42%`
+- **`bytes`** and **`bitrate`** auto-select a unit: `1073741824` → `1 GB`, `2500000` → `2.5 Mbps`
+- **`scale`** is applied before formatting, useful for unit conversions — e.g. for an API reporting kilobytes, `scale: 1024` with `format: bytes`
 - **`size`** returns the number of items in an array (or keys in an object) — pair it with an omitted `field` to count the response root
 - For APIs that don't send CORS headers (most self-hosted services), set the widget-level `useProxy: true` to route the request through Dashy's server-side proxy
 
@@ -3376,6 +3381,24 @@ Notes:
       - field: pushed_at
         label: Last Push
         format: relativeDate
+```
+
+Or, human-readable disk usage from a [Glances](https://nicolargo.github.io/glances/) instance:
+
+```yaml
+- type: customapi
+  useProxy: true
+  options:
+    url: http://192.168.0.1:61208/api/4/fs
+    mappings:
+      - field: 0.mnt_point
+        label: Mount
+      - field: 0.used
+        label: Used
+        format: bytes
+      - field: 0.percent
+        label: Used %
+        format: percent
 ```
 
 #### Info

--- a/src/utils/CustomApiHelpers.js
+++ b/src/utils/CustomApiHelpers.js
@@ -1,5 +1,5 @@
 /* Field resolution and value formatting for the CustomApi widget */
-import { convertBytes, convertBitrate } from '@/utils/MiscHelpers';
+import { convertBytes, convertBitrate, convertDuration } from '@/utils/MiscHelpers';
 
 /* Get a nested value from an object by dot-path, e.g. 'a.b.0.c'. Empty path returns the root */
 export const resolveField = (obj, path) => {
@@ -50,6 +50,13 @@ const applyScale = (raw, scale) => {
   return (Number.isNaN(n) || !Number.isFinite(factor)) ? raw : n * factor;
 };
 
+/* Swap a value for a matching remap entry's `to`, e.g. 0 → 'Down'. `any: true` matches all */
+const applyRemap = (raw, remaps) => {
+  if (!Array.isArray(remaps)) return raw;
+  const match = remaps.find((r) => r && r.to !== undefined && (r.any || String(r.value) === String(raw)));
+  return match ? match.to : raw;
+};
+
 /* Format a raw value per a mapping's `format`. `root` is the full response, used by `size` */
 const applyFormat = (raw, mapping, root) => {
   const format = mapping.format || 'text';
@@ -64,10 +71,11 @@ const applyFormat = (raw, mapping, root) => {
   }
 
   if (raw == null) return '';
-  const value = applyScale(raw, mapping.scale);
+  const value = applyScale(applyRemap(raw, mapping.remap), mapping.scale);
 
   switch (format) {
-    case 'number': {
+    case 'number':
+    case 'float': {
       const n = Number(value);
       return Number.isNaN(n) ? String(value) : new Intl.NumberFormat(locale).format(n);
     }
@@ -81,6 +89,10 @@ const applyFormat = (raw, mapping, root) => {
       const n = Number(value);
       if (Number.isNaN(n)) return String(value);
       return format === 'bytes' ? convertBytes(n) : convertBitrate(n);
+    }
+    case 'duration': {
+      const n = Number(value);
+      return Number.isNaN(n) ? String(value) : convertDuration(n);
     }
     case 'date': {
       const date = new Date(value);

--- a/src/utils/CustomApiHelpers.js
+++ b/src/utils/CustomApiHelpers.js
@@ -1,4 +1,5 @@
 /* Field resolution and value formatting for the CustomApi widget */
+import { convertBytes, convertBitrate } from '@/utils/MiscHelpers';
 
 /* Get a nested value from an object by dot-path, e.g. 'a.b.0.c'. Empty path returns the root */
 export const resolveField = (obj, path) => {
@@ -40,8 +41,17 @@ const formatRelativeDate = (raw, mapping, locale) => {
   return rtf.format(Math.round(diffSecs / period.secs), period.unit);
 };
 
+/* Multiply a numeric value by a mapping's `scale` — a number or fraction string like '1/16' */
+const applyScale = (raw, scale) => {
+  if (!scale) return raw;
+  const n = Number(raw);
+  const [top, bottom = 1] = String(scale).split('/').map(Number);
+  const factor = top / bottom;
+  return (Number.isNaN(n) || !Number.isFinite(factor)) ? raw : n * factor;
+};
+
 /* Format a raw value per a mapping's `format`. `root` is the full response, used by `size` */
-export const formatValue = (raw, mapping = {}, root) => {
+const applyFormat = (raw, mapping, root) => {
   const format = mapping.format || 'text';
   const locale = mapping.locale || navigator.language;
 
@@ -54,27 +64,40 @@ export const formatValue = (raw, mapping = {}, root) => {
   }
 
   if (raw == null) return '';
+  const value = applyScale(raw, mapping.scale);
 
   switch (format) {
     case 'number': {
-      const n = Number(raw);
-      return Number.isNaN(n) ? String(raw) : new Intl.NumberFormat(locale).format(n);
+      const n = Number(value);
+      return Number.isNaN(n) ? String(value) : new Intl.NumberFormat(locale).format(n);
     }
     case 'percent': {
-      const n = Number(raw);
-      return Number.isNaN(n) ? String(raw)
+      const n = Number(value);
+      return Number.isNaN(n) ? String(value)
         : new Intl.NumberFormat(locale, { style: 'percent', maximumFractionDigits: 2 }).format(n / 100);
     }
+    case 'bytes':
+    case 'bitrate': {
+      const n = Number(value);
+      if (Number.isNaN(n)) return String(value);
+      return format === 'bytes' ? convertBytes(n) : convertBitrate(n);
+    }
     case 'date': {
-      const date = new Date(raw);
-      if (Number.isNaN(date.getTime())) return String(raw);
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return String(value);
       const opts = { dateStyle: mapping.dateStyle || 'long' };
       if (mapping.timeStyle) opts.timeStyle = mapping.timeStyle;
       return new Intl.DateTimeFormat(locale, opts).format(date);
     }
     case 'relativeDate':
-      return formatRelativeDate(raw, mapping, locale);
+      return formatRelativeDate(value, mapping, locale);
     default:
-      return String(raw);
+      return String(value);
   }
+};
+
+/* Formatted value, wrapped with any `prefix`/`suffix` */
+export const formatValue = (raw, mapping = {}, root) => {
+  const out = applyFormat(raw, mapping, root);
+  return out === '' ? out : `${mapping.prefix || ''}${out}${mapping.suffix || ''}`;
 };

--- a/src/utils/MiscHelpers.js
+++ b/src/utils/MiscHelpers.js
@@ -97,14 +97,22 @@ export const capitalize = (str) => {
   return words.replace(/\w\S*/g, (w) => (w.replace(/^\w/, (c) => c.toUpperCase())));
 };
 
-/* Given a mem size in bytes, will return it in appropriate unit */
-export const convertBytes = (bytes, decimals = 2) => {
-  if (bytes === 0) return '0 Bytes';
-  const k = 1024;
-  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${parseFloat((bytes / (k ** i)).toFixed(decimals))} ${sizes[i]}`;
+/* Scales a value into the largest fitting unit from `sizes`, at base `k` */
+const convertToUnit = (value, k, sizes, decimals) => {
+  const magnitude = Math.floor(Math.log(Math.abs(value)) / Math.log(k));
+  const i = Math.min(Math.max(magnitude, 0), sizes.length - 1);
+  return `${parseFloat((value / (k ** i)).toFixed(decimals))} ${sizes[i]}`;
 };
+
+/* Given a mem size in bytes, will return it in appropriate unit */
+export const convertBytes = (bytes, decimals = 2) => (
+  convertToUnit(bytes, 1024, ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'], decimals)
+);
+
+/* Given a rate in bits per second, will return it in appropriate unit */
+export const convertBitrate = (bits, decimals = 2) => (
+  convertToUnit(bits, 1000, ['bps', 'Kbps', 'Mbps', 'Gbps', 'Tbps', 'Pbps'], decimals)
+);
 
 /* Round a number to thousands, millions, billions or trillions and suffix
  * with K, M, B or T respectively, e.g. 4_294_967_295 => 4.3B */

--- a/src/utils/MiscHelpers.js
+++ b/src/utils/MiscHelpers.js
@@ -114,6 +114,18 @@ export const convertBitrate = (bits, decimals = 2) => (
   convertToUnit(bits, 1000, ['bps', 'Kbps', 'Mbps', 'Gbps', 'Tbps', 'Pbps'], decimals)
 );
 
+/* Given a number of seconds returns more human duration, like '6d 9h' or '4m 20s' */
+export const convertDuration = (seconds) => {
+  let rest = Math.round(Math.abs(seconds));
+  const parts = [];
+  [['d', 86400], ['h', 3600], ['m', 60], ['s', 1]].forEach(([unit, size]) => {
+    const amount = Math.floor(rest / size);
+    rest -= amount * size;
+    if (amount) parts.push(`${amount}${unit}`);
+  });
+  return parts.slice(0, 2).join(' ') || '0s';
+};
+
 /* Round a number to thousands, millions, billions or trillions and suffix
  * with K, M, B or T respectively, e.g. 4_294_967_295 => 4.3B */
 export const formatNumber = (number, decimals = 1) => {

--- a/tests/unit/customapi-helpers.test.js
+++ b/tests/unit/customapi-helpers.test.js
@@ -75,12 +75,9 @@ describe('CustomApiHelpers - formatValue', () => {
     expect(formatValue('abc', { format: 'bytes' })).toBe('abc');
   });
 
-  it('bytes: handles zero and values below one unit', () => {
+  it('bytes: handles zero, fractional and negative values', () => {
     expect(formatValue(0, { format: 'bytes' })).toBe('0 Bytes');
     expect(formatValue(0.5, { format: 'bytes' })).toBe('0.5 Bytes');
-  });
-
-  it('bytes: keeps the sign of negative values', () => {
     expect(formatValue(-1073741824, { format: 'bytes' })).toBe('-1 GB');
   });
 

--- a/tests/unit/customapi-helpers.test.js
+++ b/tests/unit/customapi-helpers.test.js
@@ -42,6 +42,10 @@ describe('CustomApiHelpers - formatValue', () => {
     expect(formatValue('abc', { format: 'number', locale: 'en-US' })).toBe('abc');
   });
 
+  it('float: is an alias of number', () => {
+    expect(formatValue(1234.5, { format: 'float', locale: 'en-US' })).toBe('1,234.5');
+  });
+
   it('percent: treats the value as an already-computed percentage', () => {
     expect(formatValue(42, { format: 'percent', locale: 'en-US' })).toBe('42%');
   });
@@ -82,6 +86,31 @@ describe('CustomApiHelpers - formatValue', () => {
 
   it('bitrate: auto-selects a readable unit', () => {
     expect(formatValue(2500000, { format: 'bitrate' })).toBe('2.5 Mbps');
+  });
+
+  it('duration: shows seconds as a compact time', () => {
+    expect(formatValue(93784, { format: 'duration' })).toBe('1d 2h');
+    expect(formatValue(330, { format: 'duration' })).toBe('5m 30s');
+    expect(formatValue(0, { format: 'duration' })).toBe('0s');
+  });
+
+  it('duration: passes through non-numeric input', () => {
+    expect(formatValue('abc', { format: 'duration' })).toBe('abc');
+  });
+
+  it('remap: swaps a matching value', () => {
+    const remap = [{ value: 0, to: 'Down' }, { value: 1, to: 'Up' }];
+    expect(formatValue(1, { format: 'text', remap })).toBe('Up');
+    expect(formatValue('1', { format: 'text', remap })).toBe('Up');
+  });
+
+  it('remap: `any` acts as a catch-all', () => {
+    const remap = [{ value: 0, to: 'Down' }, { any: true, to: 'Unknown' }];
+    expect(formatValue(7, { format: 'text', remap })).toBe('Unknown');
+  });
+
+  it('remap: leaves unmatched values alone', () => {
+    expect(formatValue(7, { format: 'text', remap: [{ value: 0, to: 'Down' }] })).toBe('7');
   });
 
   it('scale: multiplies by a numeric factor before formatting', () => {

--- a/tests/unit/customapi-helpers.test.js
+++ b/tests/unit/customapi-helpers.test.js
@@ -62,6 +62,48 @@ describe('CustomApiHelpers - formatValue', () => {
   it('size: counts object keys', () => {
     expect(formatValue({ a: 1, b: 2 }, { format: 'size' }, { a: 1, b: 2 })).toBe('2');
   });
+
+  it('bytes: auto-selects a readable unit', () => {
+    expect(formatValue(1073741824, { format: 'bytes' })).toBe('1 GB');
+  });
+
+  it('bytes: passes through non-numeric input', () => {
+    expect(formatValue('abc', { format: 'bytes' })).toBe('abc');
+  });
+
+  it('bytes: handles zero and values below one unit', () => {
+    expect(formatValue(0, { format: 'bytes' })).toBe('0 Bytes');
+    expect(formatValue(0.5, { format: 'bytes' })).toBe('0.5 Bytes');
+  });
+
+  it('bytes: keeps the sign of negative values', () => {
+    expect(formatValue(-1073741824, { format: 'bytes' })).toBe('-1 GB');
+  });
+
+  it('bitrate: auto-selects a readable unit', () => {
+    expect(formatValue(2500000, { format: 'bitrate' })).toBe('2.5 Mbps');
+  });
+
+  it('scale: multiplies by a numeric factor before formatting', () => {
+    expect(formatValue(2, { format: 'number', scale: 1024, locale: 'en-US' })).toBe('2,048');
+  });
+
+  it('scale: accepts a fraction string', () => {
+    expect(formatValue(32, { format: 'number', scale: '1/16', locale: 'en-US' })).toBe('2');
+  });
+
+  it('scale: ignores an invalid factor', () => {
+    expect(formatValue(5, { format: 'number', scale: 'abc', locale: 'en-US' })).toBe('5');
+    expect(formatValue(5, { format: 'number', scale: '1/0', locale: 'en-US' })).toBe('5');
+  });
+
+  it('prefix and suffix wrap the formatted value', () => {
+    expect(formatValue(42, { format: 'number', prefix: '$', suffix: ' USD', locale: 'en-US' })).toBe('$42 USD');
+  });
+
+  it('prefix/suffix are skipped when the value is empty', () => {
+    expect(formatValue(null, { format: 'text', suffix: ' TB' })).toBe('');
+  });
 });
 
 describe('CustomApiHelpers - adaptiveColor', () => {


### PR DESCRIPTION
### Category
Feature

### Overview
Adds support for formatting the values returned by the API.
you can now show raw API numbers as readable sizes, speeds or durations (like 1 GB, 2.5 Mbps or 1d 4h), convert units with scale, add a prefix/suffix, and remap raw values into friendly text (e.g. 0 → Down).

see the updated docs for usage

### Issue Number
Fixes #2232
