### PR TITLE
Adds auth.logoutRedirectUrl config option

### DIFF
--- a/docs/authentication/header-auth.md
+++ b/docs/authentication/header-auth.md
@@ -9,6 +9,7 @@ Use this when you already run something like [Authelia](https://www.authelia.com
 - [Configure Dashy](#configure-dashy)
 - [Configure your proxy](#configure-your-proxy)
 - [Logging out](#logging-out)
+- [Example: oauth2-proxy and nginx](#example-oauth2-proxy-and-nginx)
 - [Troubleshooting](#troubleshooting)
 - [Security notes](#security-notes)
 - [How it works](#how-it-works)
@@ -63,6 +64,124 @@ appConfig:
 Logging out then sends the browser to that URL, where the proxy can destroy its session.
 
 The specific endpoint depends on your proxy, but for oauth2-proxy it's usually `/oauth2/sign_out` with an `rd` query param to chain your identity provider's logout, e.g. `/oauth2/sign_out?rd=https://sso.example.com/logout` (the `rd` domain must be in oauth2-proxy's `whitelist_domains`).
+
+---
+
+
+## Example: oauth2-proxy and nginx
+
+The following example was from [@vmario89](https://github.com/vmario89) (in [#2233](https://github.com/lissy93/dashy/issues/2233#issuecomment-4924556178)).
+
+[oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) handles login against any OIDC or OAuth2 provider (Synology SSO here). nginx checks each request against its `/oauth2/auth` endpoint, then forwards the username to Dashy as `X-Remote-User`.
+
+Dashy config, on top of [the setup above](#configure-dashy). The whitelist is loopback because nginx proxies to Dashy on `127.0.0.1:4000`:
+
+```yaml
+appConfig:
+  auth:
+    logoutRedirectUrl: https://dashy.example.com/oauth2/sign_out?rd=https://sso.example.com/logout
+    headerAuth:
+      userHeader: X-Remote-User
+      proxyWhitelist:
+        - 127.0.0.1
+        - '::1'
+        - '::ffff:127.0.0.1'
+```
+
+<details>
+<summary>oauth2-proxy config</summary>
+
+```ini
+provider              = "oidc"
+oidc_issuer_url       = "https://login.synology.nas/webman/sso"
+oidc_jwks_url         = "https://login.synology.nas/webman/sso/openid-jwks.json"
+scope                 = "openid profile email"
+oidc_email_claim      = "sub"
+client_id             = "<client-id>"
+client_secret         = "<client-secret>"
+cookie_secret         = "<secret>"   # openssl rand -base64 32
+cookie_name           = "cookie_dashy"
+cookie_domains        = ".example.com"
+cookie_secure         = true
+email_domains         = [ "*" ]
+http_address          = "127.0.0.1:4180"
+upstreams             = [ "static://200" ]
+set_xauthrequest      = true
+whitelist_domains     = [ "dashy.example.com", "login.synology.nas" ]
+```
+
+And a systemd unit to run it:
+
+```ini
+[Unit]
+Description=OAuth2 Proxy (Dashy)
+After=network.target
+
+[Service]
+User=oauth2proxy
+Group=oauth2proxy
+ExecStart=/opt/oauth2-proxy/oauth2-proxy --config=/etc/oauth2-proxy/dashy.cfg --trusted-proxy-ip=127.0.0.1/32
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+</details>
+
+The load-bearing options:
+
+- `set_xauthrequest = true` - returns the username on auth responses (`X-Auth-Request-User`) for nginx to pick up
+- `upstreams = [ "static://200" ]` - oauth2-proxy only answers auth checks here; nginx proxies to Dashy itself
+- `whitelist_domains` - must include the `rd=` logout domain, or the redirect is dropped
+- `--trusted-proxy-ip` - makes oauth2-proxy trust the `X-Forwarded-*` headers nginx sets
+
+<details>
+<summary>nginx site config</summary>
+
+```nginx
+map $auth_user $auth_user_local {
+    ""                  "";
+    ~^(?<lp>[^@]+)@.*   $lp;
+    default             $auth_user;
+}
+
+server {
+    server_name dashy.example.com;
+    # TLS config here
+
+    location / {
+        auth_request /oauth2/auth;
+        auth_request_set $auth_user $upstream_http_x_auth_request_user;
+        proxy_set_header X-Remote-User $auth_user_local;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        error_page 401 = /oauth2/sign_in;
+        proxy_pass http://127.0.0.1:4000;
+    }
+
+    location /oauth2/ {
+        proxy_pass http://127.0.0.1:4180;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Auth-Request-Redirect $request_uri;
+        proxy_set_header Content-Length "";
+        proxy_pass_request_body off;
+    }
+}
+```
+
+</details>
+
+`auth_request_set` reads the username from oauth2-proxy's response, and the `map` strips `@domain` from it, since oauth2-proxy forwards an email but Dashy matches the bare names in `auth.users`.
+
+---
 
 ## Troubleshooting
 

--- a/docs/authentication/header-auth.md
+++ b/docs/authentication/header-auth.md
@@ -8,6 +8,7 @@ Use this when you already run something like [Authelia](https://www.authelia.com
 
 - [Configure Dashy](#configure-dashy)
 - [Configure your proxy](#configure-your-proxy)
+- [Logging out](#logging-out)
 - [Troubleshooting](#troubleshooting)
 - [Security notes](#security-notes)
 - [How it works](#how-it-works)
@@ -49,6 +50,20 @@ Two things the proxy has to do:
 
 The whitelist is the security boundary, so Dashy must only be reachable through the proxy. If someone can hit Dashy directly and their IP happens to be whitelisted, they can forge the header. See [Security notes](#security-notes).
 
+## Logging out
+
+Dashy's logout button only clears Dashy's own session. Your session at the proxy stays alive, so the next page load signs you straight back in. To end both, point `logoutRedirectUrl` at your proxy's sign-out endpoint:
+
+```yaml
+appConfig:
+  auth:
+    logoutRedirectUrl: https://dashy.example.com/oauth2/sign_out
+```
+
+Logging out then sends the browser to that URL, where the proxy can destroy its session.
+
+The specific endpoint depends on your proxy, but for oauth2-proxy it's usually `/oauth2/sign_out` with an `rd` query param to chain your identity provider's logout, e.g. `/oauth2/sign_out?rd=https://sso.example.com/logout` (the `rd` domain must be in oauth2-proxy's `whitelist_domains`).
+
 ## Troubleshooting
 
 #### 401 "Unauthorized - not from trusted proxy"
@@ -64,7 +79,7 @@ The proxy sent a username with no matching entry in `auth.users`. Add a user who
 That user's `type` isn't `admin`. Saving is admin-only, so set `type: admin` on their entry.
 
 #### Logging out just logs me back in
-Expected. Logout clears Dashy's cookie, but you're still signed in at the proxy, so the next page load re-authenticates from the header. To fully sign out, log out at the proxy.
+Expected with the default config. Logout clears Dashy's cookie, but you're still signed in at the proxy, so the next page load re-authenticates from the header. Set `logoutRedirectUrl` to your proxy's sign-out endpoint to end both sessions — see [Logging out](#logging-out).
 
 ## Security notes
 

--- a/docs/authentication/other-auth-methods.md
+++ b/docs/authentication/other-auth-methods.md
@@ -31,7 +31,7 @@ See the [Authelia docs](https://www.authelia.com/docs/) for the full setup guide
 
 **Authentik** is heavier but gives you a proper admin UI, built-in OIDC/SAML support, and user self-service (password resets, enrollment flows, etc). Good if you want a single identity provider across many apps. See the [authentik Docker Compose install](https://docs.goauthentik.io/docs/installation/docker-compose) to get started, and the [authentik guide](./authentik.md) for Dashy-specific OIDC config.
 
-**OAuth2 Proxy** ([docs](https://oauth2-proxy.github.io/oauth2-proxy/)) is a thin forward-auth layer that puts any OIDC or OAuth2 provider (Google, GitHub, your own IdP) in front of apps that can't do it themselves. Point it at Dashy's [header auth](./header-auth.md) and it forwards the authenticated username, so you get provider login without Dashy needing to reach the provider directly.
+**OAuth2 Proxy** ([docs](https://oauth2-proxy.github.io/oauth2-proxy/)) is a thin forward-auth layer that puts any OIDC or OAuth2 provider (Google, GitHub, your own IdP) in front of apps that can't do it themselves. Point it at Dashy's [header auth](./header-auth.md) and it forwards the authenticated username, so you get provider login without Dashy needing to reach the provider directly. See the [oauth2-proxy example](./header-auth.md#example-oauth2-proxy-and-nginx) for the full nginx setup.
 
 ## Zero-trust tunnels
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -156,14 +156,6 @@ For more info, see the[Multi-Page docs](/docs/pages-and-sections.md#multi-page-s
 
 ## `appConfig.auth` _(optional)_
 
-> [!NOTE]
-> Since the auth is initiated in the main app entry point (for security), a rebuild is required to apply changes to the auth configuration.
-> Run `yarn build` in the root directory, then restart the server.
-
-> [!WARNING]
-> Built-in auth should **not be used** for security-critical applications, or if your Dashy instance is publicly accessible.
-> For these, it is recommended to use an [alternate authentication method](/docs/authentication.md#alternative-authentication-methods).
-
 **Field** | **Type** | **Required**| **Description**
 --- | --- | --- | ---
 **`users`** | `array` | _Optional_ | An array of objects containing usernames and hashed passwords. If this is not provided, then authentication will be off by default, and you will not need any credentials to access the app. See [`appConfig.auth.users`](#appconfigauthusers-optional). <br>**Note** this method of authentication is handled on the client side, so for security critical situations, it is recommended to use an [alternate authentication method](/docs/authentication.md#alternative-authentication-methods).
@@ -174,6 +166,7 @@ For more info, see the[Multi-Page docs](/docs/pages-and-sections.md#multi-page-s
 **`enableOidc`** | `boolean` | _Optional_ | If set to `true`, then authentication using OIDC will be enabled. Note that you need to have a configured OIDC server and configure it with `auth.oidc`. Defaults to `false`
 **`oidc`** | `object` | _Optional_ | Config options to point Dash to your OIDC configuration. Request `enableOidc: true`. See [`auth.oidc`](#appconfigauthoidc-optional) for more info
 **`enableGuestAccess`** | `boolean` | _Optional_ | When set to `true`, an unauthenticated user will be able to access the dashboard, with read-only access, without having to login. Requires `auth.users` to be configured. Defaults to `false`.
+**`logoutRedirectUrl`** | `string` | _Optional_ | URL to redirect the user to after logging out (useful with [header auth](/docs/authentication/header-auth.md#logging-out), where you also need to end the session on your auth proxy)
 
 For more info, see the **[Authentication Docs](/docs/authentication.md)**
 

--- a/services/config-validator.js
+++ b/services/config-validator.js
@@ -4,6 +4,7 @@
  */
 
 const fs = require('fs'); // For opening + reading files
+const path = require('path'); // For resolving the config file path
 const yaml = require('js-yaml'); // For parsing YAML
 const Ajv = require('ajv'); // For validating with schema
 
@@ -101,7 +102,8 @@ const printFileReadError = (e) => {
 let config = {};
 
 try { // Try to open and parse the YAML file
-  config = yaml.load(fs.readFileSync(`./${process.env.USER_DATA_DIR || 'user-data'}/conf.yml`, 'utf8'));
+  const confPath = path.resolve(__dirname, '..', process.env.USER_DATA_DIR || 'user-data', 'conf.yml');
+  config = yaml.load(fs.readFileSync(confPath, 'utf8'));
   validate(config);
 } catch (e) { // Something went very wrong...
   setIsValidVariable(false);

--- a/src/components/Settings/AuthButtons.vue
+++ b/src/components/Settings/AuthButtons.vue
@@ -24,7 +24,7 @@
 <script>
 import router from '@/router';
 import Keys from '@/utils/StoreMutations';
-import { logout as registerLogout } from '@/utils/auth/Auth';
+import { logout as registerLogout, getLogoutRedirectUrl } from '@/utils/auth/Auth';
 import { getKeycloakAuth, isKeycloakEnabled } from '@/utils/auth/KeycloakAuth';
 import { getOidcAuth, isOidcEnabled } from '@/utils/auth/OidcAuth';
 import { localStorageKeys, userStateEnum } from '@/utils/config/defaults';
@@ -72,7 +72,11 @@ export default {
       registerLogout();
       this.$store.commit(Keys.AUTH_CHANGED);
       this.$toast(this.$t('login.logout-message'));
-      setTimeout(() => router.push({ path: '/login' }), 500);
+      const redirectUrl = getLogoutRedirectUrl();
+      setTimeout(() => {
+        if (redirectUrl) window.location.href = redirectUrl;
+        else router.push({ path: '/login' });
+      }, 500);
     },
     keycloakLogout() {
       const keycloak = getKeycloakAuth();

--- a/src/utils/auth/Auth.js
+++ b/src/utils/auth/Auth.js
@@ -2,6 +2,7 @@ import sha256 from 'crypto-js/sha256';
 import ConfigAccumulator from '@/utils/config/ConfigAccumalator';
 import ErrorHandler from '@/utils/logging/ErrorHandler';
 import { cookieKeys, localStorageKeys, userStateEnum } from '@/utils/config/defaults';
+import getApiAuthHeader from '@/utils/auth/getApiAuthHeader';
 import { isKeycloakEnabled } from '@/utils/auth/KeycloakAuth';
 import { isOidcEnabled } from '@/utils/auth/OidcAuth';
 
@@ -67,6 +68,7 @@ export const getCookieToken = () => {
 };
 
 export const makeBasicAuthHeaders = () => {
+  if (getApiAuthHeader()) return {};
   const token = getCookieToken();
   const bearerAuth = (token && token.length > 5) ? `Bearer ${token}` : null;
 

--- a/src/utils/auth/Auth.js
+++ b/src/utils/auth/Auth.js
@@ -183,6 +183,12 @@ export const logout = () => {
   localStorage.removeItem(localStorageKeys.USERNAME);
 };
 
+/* Returns the URL to redirect to after logout if set */
+export const getLogoutRedirectUrl = () => {
+  const auth = getAppConfig().auth || {};
+  return auth.logoutRedirectUrl || null;
+};
+
 /**
  * If correctly logged in as a valid, authenticated user,
  * then returns the user object for the current user

--- a/src/utils/config/ConfigSchema.json
+++ b/src/utils/config/ConfigSchema.json
@@ -573,6 +573,11 @@
               "default": false,
               "description": "If set to true, an unauthenticated user will be able to have read-only access to dashboard, without needing to login. Requires auth to be configured."
             },
+            "logoutRedirectUrl": {
+              "title": "Logout Redirect URL",
+              "type": "string",
+              "description": "If set, the logout button will redirect here after logging out. Useful with header auth / to end auth proxy session"
+            },
             "users": {
               "title": "Users",
               "type": "array",

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -84,6 +84,7 @@ import {
   isLoggedIn,
   logout,
   isGuestAccessEnabled,
+  getLogoutRedirectUrl,
 } from '@/utils/auth/Auth';
 
 export default {
@@ -183,7 +184,12 @@ export default {
       logout();
       this.status = 'success';
       this.message = 'Logging out...';
-      this.refreshPage();
+      const redirectUrl = getLogoutRedirectUrl();
+      if (redirectUrl) {
+        setTimeout(() => { window.location.href = redirectUrl; }, 250);
+      } else {
+        this.refreshPage();
+      }
     },
     /* Logged in user redirects to home page */
     stayLoggedIn() {


### PR DESCRIPTION
### Category
Feature

### Overview
Adds a new `auth.logoutRedirectUrl`, which if set will be redirected to when the user clicks the logout button.

This was intended mostly for header/proxy auth, so that after logout you can send the browser to the proxy's logout page where it can destroy the session.

Example usage:


```yaml
appConfig:
  auth:
    logoutRedirectUrl: https://dashy.example.com/oauth2/sign_out?rd=https://sso.example.com/logout
```


### Issue Number
Fixes #2233
