### PR TITLE
Small option to disable proxy endpoint, oidc server, extend prevent write

### DIFF
--- a/docs/authentication/oidc.md
+++ b/docs/authentication/oidc.md
@@ -29,6 +29,7 @@ appConfig:
       adminRole: dashy-admin             # Or grant admin by role instead
       enableSilentRenew: true            # Refresh the session in the background before it expires
       # allowedIssuers: []               # Only for multi-tenant providers to override discovery document
+      # disableServerSideCheck: false    # Leave as false / unset. Setting to true makes auth just client-side
 ```
 
 Because Dashy is a SPA, a [public client](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1) registration with PKCE is needed.
@@ -69,11 +70,22 @@ Set `enableGuestAccess: true` to let people view the dashboard read-only without
 
 If you turn on the service worker for offline use (`enableServiceWorker: true`), turn on `enableAuthProxyCompat: true` as well. Without it, when your session expires the cached app can keep showing the old page instead of letting the login redirect through. With it on, Dashy spots the expired session on load, drops the service worker, and reloads so you can sign in again.
 
+
+
 ## How server-side enforcement works
 
 Dashy's server reads `auth.oidc` from `conf.yml` at boot, lazily fetches the OIDC discovery doc + JWKS from your `endpoint`, then verifies the `id_token` the SPA attaches to every API call as `Authorization: Bearer <id_token>`. Tokens that fail signature / issuer / audience / expiry verification are rejected with `401`. Write endpoints (`POST /config-manager/save`) additionally require the `adminGroup` (or `adminRole`) to be present in the token's `groups` / `roles` claims, and non-admins receive `403`. Unauthenticated requests for `/conf.yml` get a stripped response containing only the `auth` block plus a minimal `pageInfo`, just enough for the SPA to bootstrap the login flow. The full config is only served to authenticated users.
 
 Your IdP must include `groups` / `roles` in the id_token, not only the access token, for the admin check to work (most IdPs do this when the `groups` scope is requested).
+
+### Opting out of server-side enforcement
+
+> [!CAUTION]
+> This is not recommended (on untrusted networks), as it allows users to bypass all the server-side protection.
+
+Set `disableServerSideCheck: true` under `auth.oidc` to turn off the server-side enforcement. 
+This should only be done in a trusted environment, or where you've got your own protections in place or for when server-side verification isn't supported by your provider. It makes OIDC become a purely client-side login page.
+
 
 ## Silent token renewal
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -214,6 +214,7 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 **`scope`** | `string` | Required | The scope(s) to request from the OIDC provider
 **`enableSilentRenew`** | `boolean` | _Optional_ | If set to `true`, your session is silently renewed in the background before it expires (only works for providers which support the `offline_access` scope)
 **`allowedIssuers`** | `array` | _Optional_ | List of issuer URLs to accept tokens from. Needed for multi-tenant providers (e.g. Microsoft Entra) where the token issuer differs from the configured `endpoint`. If unset, the issuer from the discovery document is used
+**`disableServerSideCheck`** | `boolean` | _Optional_ | If `true`, the server skips token verification and endpoint protection, so OIDC is client-side only. Not recommended. Defaults to `false`
 
 **[⬆️ Back to Top](#configuring)**
 

--- a/docs/management.md
+++ b/docs/management.md
@@ -359,6 +359,8 @@ When Dashy runs in server mode (the default Docker setup), it exposes several AP
 
 The CORS proxy (`/cors-proxy`) is worth calling out specifically: it forwards requests from the Dashy server to external URLs, so widgets can reach APIs that don't set CORS headers. On a private network this is harmless, but on an internet-exposed instance without auth, it could be abused as an open proxy. Always enable authentication if your instance is reachable from untrusted networks.
 
+If you don't use widgets or status checks, you can disable the endpoints which make outbound requests (`/status-check`, `/ping-check` and `/cors-proxy`) entirely, by setting the `DISABLE_PROXY_ENDPOINTS=true` environmental variable. They will then respond with a 403 error, and never make an external request.
+
 **[⬆️ Back to Top](#management)**
 
 ---

--- a/services/app.js
+++ b/services/app.js
@@ -268,6 +268,9 @@ const app = express()
   }))
   // POST Endpoint used to save config, by writing config file to disk
   .use(ENDPOINTS.save, protectConfig, requireAdmin, method('POST', (req, res) => {
+    if (config?.appConfig?.preventWriteToDisk) {
+      return res.status(403).json({ error: 'Editing config has been disabled by your administrator' });
+    }
     let responded = false;
     const respond = (jsonBody) => {
       if (responded || res.headersSent) return;

--- a/services/app.js
+++ b/services/app.js
@@ -275,9 +275,14 @@ const app = express()
     const respond = (jsonBody) => {
       if (responded || res.headersSent) return;
       responded = true;
-      try { // Only update in-memory config when disk write succeeds
-        if (JSON.parse(jsonBody).success === true) config = req.body.config;
-      } catch (e) { /* unparseable body, config is unchanged */ }
+      try { // Only update in-memory config when a root conf.yml write succeeds
+        const target = (typeof req.body.filename === 'string' && req.body.filename)
+          ? path.basename(req.body.filename) : 'conf.yml';
+        if (JSON.parse(jsonBody).success === true && target === 'conf.yml') {
+          const parsed = yaml.load(req.body.config);
+          if (parsed && typeof parsed === 'object') config = parsed;
+        }
+      } catch (e) { /* unparseable body or YAML, config is unchanged */ }
       try { res.end(jsonBody); } catch (e) { /* response stream gone */ }
     };
     saveConfig(req.body, respond).catch((e) => {

--- a/services/app.js
+++ b/services/app.js
@@ -216,6 +216,12 @@ function requireAdmin(req, res, next) {
 /* A middleware function for Connect, that filters requests based on method type */
 const method = (m, mw) => (req, res, next) => (req.method === m ? mw(req, res, next) : next());
 
+/* Kill switch for endpoints that make outbound requests (DISABLE_PROXY_ENDPOINTS=true) */
+const proxyEndpointsGate = (req, res, next) => {
+  if (process.env.DISABLE_PROXY_ENDPOINTS !== 'true') return next();
+  return res.status(403).json({ error: 'This feature has been disabled by your administrator' });
+};
+
 const app = express()
   .get(ENDPOINTS.health, (req, res) => {
     res.set('Cache-Control', 'no-store').status(200).json({
@@ -229,7 +235,7 @@ const app = express()
   // Load middlewares for parsing JSON, and supporting HTML5 history routing
   .use(express.json({ limit: '1mb' }))
   // GET endpoint to run status of a given URL with GET request
-  .use(ENDPOINTS.statusCheck, protectConfig, requireAuth, method('GET', (req, res) => {
+  .use(ENDPOINTS.statusCheck, proxyEndpointsGate, protectConfig, requireAuth, method('GET', (req, res) => {
     try {
       statusCheck(req.url, (results) => {
         if (!res.headersSent) {
@@ -245,7 +251,7 @@ const app = express()
     }
   }))
   // GET endpoint to run ping of a given URL with GET request
-  .use(ENDPOINTS.pingCheck, protectConfig, requireAuth, method('GET', (req, res) => {
+  .use(ENDPOINTS.pingCheck, proxyEndpointsGate, protectConfig, requireAuth, method('GET', (req, res) => {
     try {
       pingCheck(req.url, (results) => {
         if (!res.headersSent) {
@@ -285,7 +291,7 @@ const app = express()
     }
   }))
   // GET for accessing non-CORS API services
-  .use(ENDPOINTS.corsProxy, protectConfig, requireAuth, (req, res) => {
+  .use(ENDPOINTS.corsProxy, proxyEndpointsGate, protectConfig, requireAuth, (req, res) => {
     try {
       corsProxy(req, res);
     } catch (e) {

--- a/services/auth-oidc.js
+++ b/services/auth-oidc.js
@@ -22,6 +22,10 @@ function loadOidcSettings(authConfig) {
   if (!authConfig || typeof authConfig !== 'object') return null;
 
   if (authConfig.enableOidc && authConfig.oidc) {
+    if (authConfig.oidc.disableServerSideCheck) {
+      console.warn('[auth-oidc] disableServerSideCheck is set, skipping auth check'); // eslint-disable-line no-console
+      return null;
+    }
     const {
       endpoint, clientId, adminGroup, adminRole, allowedIssuers,
     } = authConfig.oidc;

--- a/src/utils/config/ConfigSchema.json
+++ b/src/utils/config/ConfigSchema.json
@@ -672,6 +672,12 @@
                   "type": "array",
                   "items": { "type": "string" },
                   "description": "List of issuer URLs to accept tokens from, overriding the issuer in the discovery document. Only needed for multi-tenant providers where the token issuer differs from the configured endpoint"
+                },
+                "disableServerSideCheck": {
+                  "title": "Disable Server-Side Check",
+                  "type": "boolean",
+                  "default": false,
+                  "description": "If set to true, the server skips token verification and endpoint protection, making OIDC client-side only. Not recommended"
                 }
               }
             },

--- a/tests/server/auth-oidc.test.js
+++ b/tests/server/auth-oidc.test.js
@@ -50,4 +50,8 @@ describe('loadOidcSettings allowedIssuers', () => {
     expect(loadOidcSettings({ ...base, oidc: { ...base.oidc, allowedIssuers: [] } }).allowedIssuers).toBe(null);
     expect(loadOidcSettings({ ...base, oidc: { ...base.oidc, allowedIssuers: 'nope' } }).allowedIssuers).toBe(null);
   });
+
+  it('returns null when disableServerSideCheck is set', () => {
+    expect(loadOidcSettings({ ...base, oidc: { ...base.oidc, disableServerSideCheck: true } })).toBe(null);
+  });
 });

--- a/tests/server/conf-no-server-check.test.js
+++ b/tests/server/conf-no-server-check.test.js
@@ -1,0 +1,59 @@
+// @vitest-environment node
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { load as yamlLoad } from 'js-yaml';
+import { describe, it, expect, beforeAll } from 'vitest';
+import request from 'supertest';
+
+const CONF = `appConfig:
+  auth:
+    enableOidc: true
+    oidc:
+      endpoint: https://example.test/
+      clientId: dashy-test
+      disableServerSideCheck: true
+pageInfo:
+  title: My Dashboard
+sections:
+  - name: Internal Services
+    items:
+      - title: secret-host
+        url: http://10.0.0.5
+`;
+
+let app;
+let tmpDir;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dashy-no-check-test-'));
+  fs.writeFileSync(path.join(tmpDir, 'conf.yml'), CONF);
+  fs.writeFileSync(path.join(tmpDir, 'sub.yml'), 'pageInfo:\n  title: Sub\n');
+  process.env.USER_DATA_DIR = tmpDir;
+  delete require.cache[require.resolve('../../services/app')];
+  delete require.cache[require.resolve('../../services/auth-oidc')];
+  app = require('../../services/app');
+});
+
+describe('OIDC with disableServerSideCheck', () => {
+  it('serves the full, unstripped conf.yml without auth', async () => {
+    const res = await request(app).get('/conf.yml');
+    expect(res.status).toBe(200);
+    const body = yamlLoad(res.text);
+    expect(body._bootstrap).toBeUndefined();
+    expect(body.sections).toHaveLength(1);
+    expect(body.pageInfo.title).toBe('My Dashboard');
+  });
+
+  it('serves non-root yml files without auth', async () => {
+    const res = await request(app).get('/sub.yml');
+    expect(res.status).toBe(200);
+  });
+
+  it('does not reject API routes on an invalid Bearer token', async () => {
+    const res = await request(app)
+      .get('/status-check')
+      .set('Authorization', 'Bearer not-a-real-token');
+    expect(res.status).not.toBe(401);
+  });
+});


### PR DESCRIPTION
### Category
Feature

### Overview
A couple of small changes and config options:
- If disable config write is enabled (with `preventWriteToDisk`), then return early server-side
- Fixes the server's in-memory updating of config after save
- Adds optional `disableServerSideCheck` for OIDC (for users who implement this themself or elsewhere)
- Adds optional `DISABLE_PROXY_ENDPOINTS` to turn off all proxy, status check and ping endpoints


### Issue Number
N/A

