### PR TITLE
Update security and privacy docs

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,35 +1,42 @@
+# Security Policy
 
-Security is taken very seriously
+Thanks for helping keep Dashy and the people who use it safe. If you've found something that could put users at risk, I really appreciate you taking the time to let me know.
 
-## Supported Versions
-The current versions, and previous minor versions and / or the past 5 versions are supported. Releases either older than 5 versions, or from the last major version are no longer maintained or monitored, and hence the security of which cannot be guaranteed.
+## Reporting a security issue
+If you think you've found a security problem, please securely reach-out, either:
+- Open a [security advisory](https://github.com/lissy93/dashy/security/advisories/new) here on GitHub
+- Or email me at `security@as93.net` (PGP: [`E10EE533A8E5D6F6E231BBCD4C8DEAFFCE3B8D03`](https://keys.openpgp.org/vks/v1/by-fingerprint/E10EE533A8E5D6F6E231BBCD4C8DEAFFCE3B8D03))
 
-## Keeping your Instance of Dashy Secure
-See [Docs: Management - Security](/docs/management.md#securing)
+> [!IMPORTANT]
+> Please do not report active security issues via public means, without first giving us 30 days to fix it.
 
-## Reporting a Security Issue
-If you think you've found a critical issue, please send an email to `security@as93.net`, to encrypt it, you can use [`E10EE533A8E5D6F6E231BBCD4C8DEAFFCE3B8D03`](https://keys.openpgp.org/vks/v1/by-fingerprint/E10EE533A8E5D6F6E231BBCD4C8DEAFFCE3B8D03). You should receive a response within 48 hours.
+Please write in English only.<br>
+I'll usually get back to you within 48 hours, and give you a timeline for a fix (if applicable) - typically <30 days<br>
+Once it's confirmed and fixed, I'm happy to credit you in the release notes if you'd like.
 
-All non-critical issues can be raised as a ticket.
+## What to include
+To help me track it down quickly, it helps if you can include:
+- What kind of issue it is (for example XSS, SQL injection, and so on)
+- The source files or code involved, with a tag, branch or commit if you have one
+- Any config needed to reproduce it
+- Steps to reproduce
+- A proof of concept, if you have one
+- What an attacker could actually do with it
 
-Please include the following information:
-- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-- Full paths of source file(s) related to the manifestation of the issue
-- The location of the affected source code (tag/branch/commit or direct URL)
-- Any special configuration required to reproduce the issue
-- Step-by-step instructions to reproduce the issue
-- Proof-of-concept or exploit code (if possible)
-- Impact of the issue, including how an attacker might exploit the issue
+## Supported versions
+The latest minor and patch versions are supported. Previous major versions (e.g. 3.x.x and below) don't receive official security updates.
 
-This info will help with finding and fixing the issue.
+## Keeping your own instance secure
+Dashy's security posture and features are outlined in our [security docs](https://dashy.to/docs/security).
+A lot of security comes down to how and where you deploy Dashy, so we've also documented some self-hosting best practices in the [management guide](https://dashy.to/docs/management/).
 
-Please use only English.
+## What not to report here
+We get a LOT of false positives security reports, usually from AI scans. Be sure to verify your findings.
 
-## Issues That Should Not Be Raised
-Please do not raise issues in this repo which relate to Vue or Vue CLI, we're already using the latest versions of these dependencies, so any issues here to be taken up with Vue. The same applies to other dev dependencies that are at the latest version.
+Please don't report issues which:
+- Are not security issues (these can be raised as issue instead)
+- Already have an open security advisory
+- Are only vulnerable due to insecure deployment
+- Are documented as known-limitations or false positives
 
-## Known Issues
-
-> **01/09/2021** - [Inefficient Regular Expression Complexity](https://www.huntr.dev/bounties/1e8f07fc-c384-4ff9-8498-0690de2e8c31/) in Axios (Re: [CWE-1333](https://cwe.mitre.org/data/definitions/1333.html)).
-
-This ReDos vuln, was raised and fixed by @ready-research in Axios in August 2021. The issue was resolved in [`5b45711`](https://github.com/axios/axios/commit/5b457116e31db0e88fede6c428e969e87f290929), but Snyk sometime just takes a while to show updates. Dashy is using the latest version of Axios, and so is not affected by this issue.
+Please don't over-state findings (like attaching an inflated CVS score). If a report is too many inaccurate or exaggerated findings, but still has valid findings, then I then need to go and create a fresh, valid report to publish (instead of publishing yours). This is inconvenient for both of us.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -30,6 +30,10 @@ The latest minor and patch versions are supported. Previous major versions (e.g.
 Dashy's security posture and features are outlined in our [security docs](https://dashy.to/docs/security).
 A lot of security comes down to how and where you deploy Dashy, so we've also documented some self-hosting best practices in the [management guide](https://dashy.to/docs/management/).
 
+## Safe harbor
+If you research and report in good faith, following this policy, I won't pursue legal action against you.
+Just keep your testing to your own instance, don't access or disrupt anyone else's data, and give us time to fix things before going public.
+
 ## What not to report here
 We get a LOT of false positives security reports, usually from AI scans. Be sure to verify your findings.
 

--- a/README.md
+++ b/README.md
@@ -621,7 +621,8 @@ If you're new to web development, I've put together a short [list of resources](
 - 🗞️ [Release Workflow](/docs/release-workflow.md) - Info about releases, CI and automated tasks
 
 #### Misc
-- 🔐 [Privacy & Security](/docs/privacy.md) - List of requests, potential issues, and security resources
+- 🔐 [Privacy](/docs/privacy.md) - List of all network requests and data storage
+- 🛡️ [Security](/docs/security.md) - Security features, threat model, and hardening resources
 - 📄 [License](/LICENSE) - Copy of the MIT License
 - 📏 [Code of Conduct](/.github/CODE_OF_CONDUCT.md) - Contributor Covenant Code of Conduct
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,4 +1,4 @@
-# Privacy & Security
+# Privacy
 
 Dashy was built with privacy in mind.
 Self-hosting your own apps and services is a great way to protect yourself from the mass data collection employed by big tech companies, and Dashy was designed to make self-hosting easier.
@@ -8,40 +8,34 @@ Dashy operates on the premise, that:
 - All code is 100% open source, clearly documented and intended to be easily auditable
 - Privacy-respecting by default. No premium features, analytics, tracking or ads
 
-This document outlines all network requests, data storage requirements, security configurations and data handling processes. 
+This document outlines all network requests, data storage requirements and data handling processes. See also the [security docs](/docs/security.md).
 
 > [!TIP]
 > Btw (shameless plug), if you care about your privacy, you might also like [awesome-privacy](https://github.com/Lissy93/awesome-privacy/)!<br>
 
 ## Contents
 
-- Privacy
-  - [Browser Storage](#browser-storage)
-  - [External Requests](#external-requests)
-    - [Icons](#icons)
-    - [Themes](#themes)
-    - [Status Checking](#status-checking)
-    - [Update Checks](#update-checks)
-    - [Cloud Backup](#cloud-backup)
-    - [Web Search](#web-search)
-    - [Initialization Page](#initialization-page)
-    - [Anonymous Error Reporting](#anonymous-error-reporting)
-    - [Widgets](#widgets)
-- Security
-  - [Dependencies](#dependencies)
-  - [Securing your Environment](#securing-your-environment)
-  - [Security Features](#security-features)
-  - [Threat Model](#threat-model)
-  - [Known Limitations](#known-limitations)
-  - [Update & Patch Policy](#update--patch-policy)
-  - [Reporting a Security Issue](#reporting-a-security-issue)
+- [Browser Storage](#browser-storage)
+- [Single Sign-On](#single-sign-on)
+- [External Requests](#external-requests)
+  - [Icons](#icons)
+  - [Themes](#themes)
+  - [Status Checking](#status-checking)
+  - [Update Checks](#update-checks)
+  - [Cloud Backup](#cloud-backup)
+  - [Web Search](#web-search)
+  - [Initialization Page](#initialization-page)
+  - [Anonymous Error Reporting](#anonymous-error-reporting)
+  - [Widgets](#widgets)
+  - [Proxied Requests](#proxied-requests)
+- [Server-Side Data](#server-side-data)
 
 ---
 
 ## Browser Storage
 
 In order for user preferences to be persisted some data is stored locally in your browsers storage.
-No personal info is kept here, none of this data can be accessed by other domains, no data is ever sent to any server without your prior consent, and all data is removed when no longer needed unless you delete it sooner.
+Aside from your username and login tokens (only when auth is enabled), no personal info is kept here. None of this data can be accessed by other domains, no data is ever sent to any server without your prior consent, and you can view or delete it at any time.
 
 The following section outlines all data that is stored in the browsers, as cookies, session storage or local storage.
 
@@ -50,41 +44,62 @@ The following section outlines all data that is stored in the browsers, as cooki
 > [Cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies) will expire after their pre-defined lifetime.
 > Dashy uses cookies for authentication, when enabled.
 
-- `AUTH_TOKEN` - A unique token, generated from a hash of users credentials, to verify they are authenticated. Only used when auth is enabled.
+- `dashyAuthToken` - A unique token, generated from a hash of users credentials, to verify they are authenticated. Only used when auth is enabled.
 
 ### Session Storage
 
 > [Session storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) is deleted when the current session ends (tab / window is closed).
-> Dashy uses session storage service worker status and error list.
+> Dashy uses session storage for the error log, and a few short-lived flags that prevent redirect loops.
 
-- `SW_STATUS` - The current status of any service workers
-- `ERROR_LOG` - List of recent errors
+- `errorLog` - List of recent errors
+- `dashy.oidc.signin-attempt` - Timestamp of the last SSO login attempt, prevents redirect loops
+- `dashy.oidc.silent-attempt` - Timestamp of the last silent token renewal, prevents renewal loops
+- `dashy.sub-config-reload-attempt` - Timestamp of the last config reload after re-authenticating
+- `dashy-auth-proxy-reloaded` - Flag so service worker changes only trigger one page refresh
 
 ### Local Storage
 
 > [Local storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) is persisted between sessions, and only deleted when manually removed.
 > Dashy can use local storage to keep track of your preferences.
 
-- `LANGUAGE` - The locale to show app text in
-- `HIDE_INFO_NOTIFICATION` - Set to true once user dismissed welcome message, so that it's not shown again
-- `LAYOUT_ORIENTATION` - Preferred section layout, either auto, horizontal, vertical or masonry
-- `COLLAPSE_STATE` - Remembers which sections are collapsed
-- `ICON_SIZE` - Size of items, either small, medium or large
-- `THEME` - Users applied theme
-- `CUSTOM_COLORS` - Any color modifications made to a given theme
-- `BACKUP_ID` - If a backup has been made, the ID is stored here
-- `BACKUP_HASH` - A unique hash of the previous backups meta data
-- `HIDE_SETTINGS` - Lets user hide or show the settings menu
-- `USERNAME` - If user logged in, store username. Only used to show welcome message, not used for auth
-- `CONF_SECTIONS` - Array of sections, only used when user applies changes locally
-- `PAGE_INFO` - Config page info, only used when user applies changes locally
-- `APP_CONFIG` - App config, only used when user applies changes locally
-- `MOST_USED` - If smart sort is used to order items by most used, store open count
-- `LAST_USED` - If smart sort is used to order items by last used, store timestamps
+- `language` - The locale to show app text in
+- `hideWelcomeHelpers` - Set to true once user dismissed welcome message, so that it's not shown again
+- `layoutOrientation` - Preferred section layout, either auto, horizontal, vertical or masonry
+- `collapseState` - Remembers which sections are collapsed
+- `iconSize` - Size of items, either small, medium or large
+- `theme` - Users applied theme
+- `customColors` - Any color modifications made to a given theme
+- `backupId` - If a backup has been made, the ID is stored here
+- `backupHash` - A unique hash of the previous backups meta data
+- `hideSettings` - Lets user hide or show the settings menu
+- `username` - If user logged in, store username. Only used to show welcome message, not used for auth
+- `confSections` - Array of sections, only used when user applies changes locally
+- `confPages` - Array of additional pages, only used when user applies changes locally
+- `pageInfo` - Config page info, only used when user applies changes locally
+- `appConfig` - App config, only used when user applies changes locally
+- `mostUsed` - If smart sort is used to order items by most used, store open count
+- `lastUsed` - If smart sort is used to order items by last used, store timestamps
+- `disableCriticalWarning` - Set once user dismisses the config error warning, so it's not shown again
+- `isAdmin` - Whether the logged in user is an admin, used to show or hide config options in the UI
+- `keycloakInfo` - Your groups and roles from your SSO provider, used to determine which sections you can see
+- `idToken` - Your OIDC ID token, used to authenticate your requests to the server (see [Single Sign-On](#single-sign-on))
+- `oidc.user:...` - Your OIDC session, including tokens and basic profile info (see [Single Sign-On](#single-sign-on))
+
+### Service Worker Cache
+
+If you've enabled the service worker (with `appConfig.enableServiceWorker`), the app's assets are cached in your browser's cache storage, so Dashy loads faster and can work offline. This is just a copy of the app itself, not your data. It's disabled by default, and you can clear the cache in the same place as your other site data (see below).
 
 ### Deleting Stored Data
 
-You can manually view and delete session storage, local storage and cookies at anytime. First [open](/docs/troubleshooting.md#how-to-open-browser-console) your browsers developer tools (usually <kbd>F12</kbd>), then under the Application tab select the storage category. Here you will see a list of stored data, and you can select any item and delete it.
+You can manually view and delete session storage, local storage, cache storage and cookies at anytime. First [open](/docs/troubleshooting.md#how-to-open-browser-console) your browsers developer tools (usually <kbd>F12</kbd>), then under the Application tab select the storage category. Here you will see a list of stored data, and you can select any item and delete it.
+
+---
+
+## Single Sign-On
+
+If you've configured Keycloak or another OIDC provider, the login flow happens directly between your browser and your identity provider. No third parties are involved, and Dashy never sees or stores your password.
+
+After you log in, your tokens and some basic profile info (username, groups and roles) are kept in local storage, so you stay logged in between visits and the server can verify your requests. The exact keys are listed under [Local Storage](#local-storage) above. Logging out clears them all.
 
 ---
 
@@ -100,23 +115,31 @@ If either any of your sections, items or themes are using icons from font-awesom
 
 #### Material Design Icons
 
-If either any of your sections, items or themes are mdi icons, then it will be automatically enabled. But you can also manually enable or disable it by setting `appConfig.enableMaterialDesignIcons` to `true` / `false`. Requests are made directly to Material-Design-Icons CDN, for more info, see the [Material Design Icons Website](https://materialdesignicons.com/).
+If either any of your sections, items or themes are mdi icons, then it will be automatically enabled. But you can also manually enable or disable it by setting `appConfig.enableMaterialDesignIcons` to `true` / `false`. The icon font is loaded from the jsDelivr CDN, for more info, see the [jsDelivr Privacy Policy](https://www.jsdelivr.com/terms/privacy-policy).
 
 #### Favicon Fetching
 
 If an item's icon is set to `favicon`, then it will be auto-fetched from the corresponding URL. Since not all websites have their icon located at `/favicon.ico`, and if they do, it's often very low resolution (like `16 x 16 px`). Therefore, the default behavior is for Dashy to check if the URL is public, and if so will use an API to fetch the favicon. For self-hosted services, the favicon will be fetched from the default path, and no external requests will be made.
 
-The default favicon API is [allesedv.com](https://favicon.allesedv.com/), but this can be changed by setting `appConfig.faviconApi` to an alternate source (`iconhorse`, `faviconkit`, `besticon`, `duckduckgo`, `google` and `allesedv` are supported). If you do not want to use any API, then you can set this property to `local`, and the favicon will be fetched from the default path. For hosted services, this will still incur an external request.
+The default favicon API is [allesedv.com](https://favicon.allesedv.com/), but this can be changed by setting `appConfig.faviconApi` to an alternate source (`iconhorse`, `faviconkit`, `besticon`, `duckduckgo`, `yandex`, `google`, `webmasterapi`, `mcapi` and `allesedv` are supported). If you do not want to use any API, then you can set this property to `local`, and the favicon will be fetched from the default path. For hosted services, this will still incur an external request.
 
 #### Generative Icons
 
-If an item has the icon set to `generative`, then an external request it made to [Dice Bear](https://dicebear.com/) to fetch the uniquely generated icon. The URL of a given service is used as the key for generating the icon, but it is first hashed and encoded for basic privacy. For more info, please reference the [Dicebear Privacy Policy](https://avatars.dicebear.com/legal/privacy-policy)
+If an item has the icon set to `generative`, then an external request is made to [DiceBear](https://dicebear.com/) to fetch the uniquely generated icon. The URL of a given service is used as the key for generating the icon, but it is first hashed and encoded for basic privacy. For more info, please reference the [DiceBear Privacy Policy](https://www.dicebear.com/legal/privacy-policy/)
 
 As a fallback, if Dicebear fails, then [Evatar](https://evatar.io/) is used.
 
 #### Self-Hosted Icons
 
 If an item's icon uses the `sh-` prefix, icons are fetched from the [selfh.st icons](https://selfh.st/icons/) CDN at `https://cdn.jsdelivr.net/gh/selfhst/icons`. This only applies when you explicitly use the `sh-` prefix for an icon.
+
+#### Simple Icons
+
+If an item's icon uses the `si-` prefix, brand icons are fetched from [Simple Icons](https://simpleicons.org/), via the unpkg CDN at `https://unpkg.com/simple-icons`. This only applies when you explicitly use the `si-` prefix for an icon.
+
+#### Dashboard Icons
+
+If an item's icon uses the `hl-` prefix, icons are fetched from [homarr-labs/dashboard-icons](https://github.com/homarr-labs/dashboard-icons), via the jsDelivr CDN. This only applies when you explicitly use the `hl-` prefix for an icon.
 
 #### Other Icons
 
@@ -182,13 +205,16 @@ Dashy supports [Widgets](/docs/widgets.md) for displaying dynamic content. Below
 | | `http://ip-api.com/json` | [IP-API Privacy Policy](https://ip-api.com/docs/legal) |
 | | `https://api.ipgeolocation.io/ipgeo` | [IPGeoLocation Privacy Policy](https://ipgeolocation.io/privacy.html) |
 | [IP Blacklist](/docs/widgets.md#ip-blacklist) | `https://api.blacklistchecker.com` | [Blacklist Checker Privacy Policy](https://blacklistchecker.com/privacy) |
+| | `https://api.ipify.org` | [ipify](https://www.ipify.org/) |
 | [Domain Monitor](/docs/widgets.md#domain-monitor) | `https://api.whoapi.com` | [WhoAPI Privacy Policy](https://whoapi.com/privacy-policy/) |
 | [Crypto Watch List](/docs/widgets.md#crypto-watch-list) / [Token Price History](/docs/widgets.md#crypto-token-price-history) | `https://api.coingecko.com` | [CoinGecko Privacy Policy](https://www.coingecko.com/en/privacy) |
 | [Wallet Balance](/docs/widgets.md#wallet-balance) | `https://api.blockcypher.com/` | [BlockCypher Privacy Policy](https://www.blockcypher.com/privacy.html) |
+| | `https://www.bitcoinqrcodemaker.com` | [Bitcoin QR Code Maker](https://www.bitcoinqrcodemaker.com/) |
 | [Code::Stats](/docs/widgets.md#code-stats) | `https://codestats.net` | [Code::Stats Privacy Policy](https://codestats.net/tos#privacy) |
 | [addy.io](/docs/widgets.md#addyio) | `https://app.addy.io` | [addy.io Privacy Policy](https://addy.io/privacy/) |
 | [Vulnerability Feed](/docs/widgets.md#vulnerability-feed) | `https://services.nvd.nist.gov/rest/json/cves/2.0` | [NIST Privacy Policy](https://www.nist.gov/privacy-policy) |
 | [Exchange Rate](/docs/widgets.md#exchange-rates) | `https://v6.exchangerate-api.com` | [ExchangeRateAPI Privacy Policy](https://www.exchangerate-api.com/terms) |
+| | `https://raw.githubusercontent.com/Lissy93/currency-flags` | [GitHub's Privacy Policy](https://docs.github.com/en/github/site-policy/github-privacy-statement) |
 | [Public Holidays](/docs/widgets.md#public-holidays) | `https://kayaposoft.com` | [jurajmajer/enrico](https://github.com/jurajmajer/enrico) |
 | [Covid-19 Status](/docs/widgets.md#covid-19-status) | `https://disease.sh/v3/covid-19` | [disease-sh/api](https://github.com/disease-sh/api) |
 | [Sports Scores](/docs/widgets.md#sports-scores) | `https://thesportsdb.com` | No Policy Available |
@@ -196,155 +222,33 @@ Dashy supports [Widgets](/docs/widgets.md) for displaying dynamic content. Below
 | [Mullvad Status](/docs/widgets.md#mullvad-status) | `https://am.i.mullvad.net` | [Mullvad Privacy Policy](https://mullvad.net/en/help/privacy-policy/) |
 | [TFL Status](/docs/widgets.md#tfl-status) | `https://api.tfl.gov.uk` | [TFL Privacy Policy](https://tfl.gov.uk/corporate/privacy-and-cookies/) |
 | [Stock Price History](/docs/widgets.md#stock-price-history) | `https://www.alphavantage.co` | [AlphaVantage Privacy Policy](https://www.alphavantage.co/privacy/) |
-| [ETH Gas Prices](/docs/widgets.md#eth-gas-prices) | `https://ethgas.watch` | [wslyvh/ethgaswatch](https://github.com/wslyvh/ethgaswatch) |
+| [ETH Gas Prices](/docs/widgets.md#eth-gas-prices) | `https://www.ethgastracker.com` | [EthGasTracker](https://www.ethgastracker.com/) |
 | [Joke](/docs/widgets.md#joke) | `https://v2.jokeapi.dev` | [SV443's Privacy Policy](https://sv443.net/privacypolicy/en) |
-| [Chuck Norris Jokes](/docs/widgets.md#chuck-norris-jokes) | `https://api.chucknorris.io` | No Policy Available |
-| [XKCD Comic](/docs/widgets.md#xkcd-comic) | `https://xkcd.vercel.app` | [XKCD](https://xkcd.com) |
+| [Chuck Norris Jokes](/docs/widgets.md#chuck-norris-quotes) | `https://api.chucknorris.io` | No Policy Available |
+| [XKCD Comic](/docs/widgets.md#xkcd-comics) | `https://xkcd.vercel.app` | [XKCD](https://xkcd.com) |
 | [Flight Data](/docs/widgets.md#flight-data) | `https://aerodatabox.p.rapidapi.com` | [AeroDataBox Privacy Policy](https://www.aerodatabox.com/#h.p_CXtIYZWF_WQd) |
-| [Astronomy Picture of the Day](/docs/widgets.md#astronomy-picture-of-the-day) | `https://apod.as93.net` | [NASA's Privacy Policy](https://www.nasa.gov/about/highlights/HP_Privacy.html) |
+| [Astronomy Picture of the Day](/docs/widgets.md#astronomy-picture-of-the-day) | `https://apod.as93.net` | [NASA's Privacy Policy](https://www.nasa.gov/privacy/) (via a proxy run by Dashy's author) |
 | [GitHub Trending](/docs/widgets.md#github-trending) | `https://trend.doforce.xyz` | No Policy Available |
 | [GitHub Profile Stats](/docs/widgets.md#github-profile-stats) | `https://github-readme-stats.vercel.app` | [GitHub's Privacy Policy](https://docs.github.com/en/github/site-policy/github-privacy-statement) |
 | [Healthchecks Status](/docs/widgets.md#healthchecks-status) | `https://healthchecks.io` | [Health-Checks Privacy Policy](https://healthchecks.io/privacy/) |
-| [Hacker News Trending](/docs/widgets.md#hacker-news-trending) | `https://hacker-news.firebaseio.com` | [Y Combinator Privacy Policy](https://www.ycombinator.com/legal#privacy) |
-| [Minecraft Server Status](/docs/widgets.md#minecraft-server-status) | `https://api.mcsrvstat.us` | No Policy Available |
-| [MVG](/docs/widgets.md#mvg) | `https://www.mvg.de/api/fib/v2/` | No Policy Available |
-| [RescueTime](/docs/widgets.md#rescue-time) | `https://www.rescuetime.com` | [RescueTime Privacy Policy](https://www.rescuetime.com/privacy) |
+| [Hacker News Trending](/docs/widgets.md#hackernews-trending) | `https://hacker-news.firebaseio.com` | [Y Combinator Privacy Policy](https://www.ycombinator.com/legal#privacy) |
+| [Minecraft Server Status](/docs/widgets.md#minecraft-server) | `https://api.mcsrvstat.us` | No Policy Available |
+| | `https://mc-heads.net` | [MC Heads](https://mc-heads.net/) |
+| [MVG Departure](/docs/widgets.md#mvg-departure) / [MVG Connection](/docs/widgets.md#mvg-connection) | `https://www.mvg.de/api/fib/v2/` | No Policy Available |
+| [RescueTime](/docs/widgets.md#rescuetime-overview) | `https://www.rescuetime.com` | [RescueTime Privacy Policy](https://www.rescuetime.com/privacy) |
 
 Note: There are also many widgets that connect to self-hosted services (such as Pi-hole, AdGuard, Glances, Nextcloud, Proxmox, Uptime Kuma, etc.). These only make requests to your own configured server addresses and do not contact any third-party services.
 
----
+### Proxied Requests
 
-## Dependencies
+Some widget requests are made by the Dashy server, rather than your browser. If a widget is set to use the proxy (with `useProxy: true`), the request is sent to your Dashy server, which forwards it on to the target and passes the response back. This is needed for services which don't allow cross-origin requests. It also means the target sees your server's IP address, not your browser's. Any headers you've configured for that widget are included in the forwarded request.
 
-As with most web projects, Dashy relies on several [dependencies](https://github.com/Lissy93/dashy/blob/master/docs/credits.md#dependencies-).
-
-Dependencies can introduce security vulnerabilities, but since all these packages are open source any issues are usually very quickly spotted. Dashy is using Snyk for dependency security monitoring, and you can see [the latest report here](https://snyk.io/test/github/lissy93/dashy). If any issue is detected by Snyk, a note about it will appear at the top of the Readme, and will usually be fixed within 48 hours.
-
-Note that packages listed under `devDependencies` section are only used for building the project, and are not included in the production environment.
+Status checks and ping checks are also made from the server. If you don't use any of these features, you can disable the endpoints entirely by setting the `DISABLE_PROXY_ENDPOINTS=true` environment variable.
 
 ---
 
-## Securing your Environment
+## Server-Side Data
 
-There is very little complexity involved with Dashy, and therefore the attack surface is reasonably small, but it is still important to follow best practices for all your self-hosted apps:
+Everything the Dashy server stores is kept in your `user-data` directory: your config file(s), plus a timestamped copy of the previous config, saved to `user-data/config-backups` each time you update the config through the UI. If you don't want these backups, set the `DISABLE_CONFIG_BACKUPS=true` environment variable. Old backups aren't cleaned up automatically, so if you've removed something sensitive from your config, remember to clear them out too.
 
-- **Use SSL/HTTPS** for securing traffic in transit, see [Management Docs: SSL Certificates](/docs/management.md#ssl-certificates)
-- **Configure authentication** to prevent unauthorized access, see [Authentication Docs](/docs/authentication.md). For internet-facing instances, use [Keycloak](/docs/authentication.md#keycloak), [OIDC](/docs/authentication.md#oidc), or an [alternative server-side method](/docs/authentication.md#alternative-authentication-methods)
-- **Place behind a reverse proxy** if exposing to the internet, see [Management Docs: Network Exposure](/docs/management.md#network-exposure)
-- **Harden your containers** if running in Docker, see [Management Docs: Container Security](/docs/management.md#container-security)
-- **Keep Dashy and your system up-to-date** to ensure known vulnerabilities are patched
-- **Configure firewall rules** to restrict access to only necessary ports and networks
-- **Use a VPN** for private access without exposing Dashy to the public internet
-- **Follow [Docker security best practices](https://docs.docker.com/engine/security/)** including running as non-root, limiting capabilities, and using read-only volumes
-
----
-
-## Security Features
-
-### Subresource Integrity
-
-[Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) or SRI is a security feature that enables browsers to verify that resources they fetch are delivered without unexpected manipulation. It works by allowing you to provide a cryptographic hash that a fetched resource must match. This prevents the app from loading any resources that have been manipulated, by verifying the files hashes. It safeguards against the risk of an attacker injecting arbitrary malicious content into any files served up via a CDN.
-
-Dashy supports SRI, and it is recommended to enable this if you are hosting your dashboard via a public CDN. To enable SRI, set the `INTEGRITY` environmental variable to `true`.
-
-### SSL
-
-Native SSL support is enabled, for setup instructions, see the [Management Docs](/docs/management.md#ssl-certificates)
-
-### Authentication
-
-Dashy supports built-in auth, server-based SSO using Keycloak or any OIDC provider, and header-based authentication for reverse proxy setups. Full details of which, along with alternate authentication methods can be found in the [Authentication Docs](/docs/authentication.md). If your dashboard is exposed to the internet and/ or contains any sensitive info it is strongly recommended to configure access control with Keycloak, OIDC, or another server-side method.
-
-### Configuration Lockdown
-
-Dashy provides several options to restrict what users can modify:
-
-- `appConfig.preventWriteToDisk` - Prevents config changes from being saved to the server
-- `appConfig.preventLocalSave` - Prevents config changes from being saved to browser storage
-- `appConfig.disableConfiguration` - Hides the config UI from all users
-- `appConfig.disableConfigurationForNonAdmin` - Hides the config UI for non-admin users
-
-These can be combined with the `admin` and `normal` user roles to give fine-grained control. Admin users can save config changes, while normal users have read-only access. For more details, see the [Authentication Docs: Permissions](/docs/authentication.md#permissions).
-
-### Disabling Features
-
-You may wish to disable features that you don't want to use, if they involve storing data in the browser or making network requests.
-- To disable smart-sort (uses local storage), set `appConfig.disableSmartSort: true`
-- To disable update checks (makes external request to GH), set `appConfig.disableUpdateChecks: true`
-- To disable web search (redirect to external / internal content), set `appConfig.webSearch.disableWebSearch: true`
-- To keep status checks disabled (external / internal requests), set `appConfig.statusCheck: false`
-- To keep ping checks disabled (external / internal requests), set `appConfig.pingCheckEnabled: false`
-- To keep font-awesome icons disabled (external requests), set `appConfig.enableFontAwesome: false`
-- To keep error reporting disabled (external requests and data collection), set `appConfig.enableErrorReporting: false`
-- To keep the service worker disabled (stores cache of app in browser data), set `appConfig.enableServiceWorker: false`
-
----
-
-## Threat Model
-
-Dashy is a statically-hosted dashboard application, designed to be self-hosted on a private network. This threat model outlines the intended deployment context, trust boundaries, known risks and accepted trade-offs, to help users assess whether Dashy is appropriate for their environment.
-
-### Intended Deployment
-
-Dashy is designed to run on a **private local network** (e.g. a home lab), accessed by a **small number of trusted users**. It is a convenience tool for organizing links to self-hosted services - it is not designed to protect sensitive resources or act as an access control layer.
-
-If exposed to the internet, Dashy **must** be placed behind a reverse proxy with server-side authentication (e.g. Authelia, Authentik, Cloudflare Access). The built-in client-side auth is a convenience feature for private networks, not a security boundary.
-
-### Trust Boundaries
-
-| Boundary | Trusted Side | Untrusted Side |
-|---|---|---|
-| Local network | LAN users, self-hosted services | The public internet |
-| Config file (`conf.yml`) | Server admin who writes the config | End users who view the dashboard |
-| Browser storage | The current browser session | Other domains, other users of the same device |
-| CORS proxy / status checks | Configured target URLs (set by admin) | Arbitrary URLs (if auth is not enabled) |
-
-### Assets
-
-| Asset | Description | Storage |
-|---|---|---|
-| Dashboard configuration | Service URLs, section layout, app settings | `conf.yml` on server, optionally cached in browser localStorage |
-| User credentials | SHA-256 password hashes, Keycloak/OIDC client IDs | `conf.yml` on server |
-| API keys | Keys for widget services (weather, stocks, etc.) | `conf.yml` on server or environment variables |
-| Auth tokens | Session token derived from credentials | Browser cookie (`dashyAuthToken`) |
-| User preferences | Theme, layout, language, collapsed sections | Browser localStorage |
-
-### When Dashy is NOT the Right Choice
-
-- You need a **multi-tenant** dashboard with per-user audit trails
-- You are deploying on the **public internet without a reverse proxy**
-- Your dashboard contains **secrets or credentials** that must be protected from all users who can reach the server
-- You require **FIPS-compliant** or **SOC 2** certified software
-
----
-
-## Known Limitations
-
-| Report | Response |
-|---|---|
-| "Client-side auth can be bypassed via browser dev tools" | Correct (only if neither `ENABLE_HTTP_AUTH` is set, nor any other auth mode). Client-side auth is a convenience for private networks, not a security boundary. Use server-side auth for untrusted environments. |
-| "CORS proxy can make requests to internal services" | Correct. The CORS proxy is designed to reach services on your network. It is protected by auth middleware when auth is enabled. Do not expose Dashy without auth on an untrusted network. |
-| "Status checks can be used for SSRF" | Status check target URLs are set by the server admin in `conf.yml`, not by end users. If auth is enabled, the endpoint is protected. |
-| "Password hashes are stored in plaintext in conf.yml" | They are SHA-256 hashes, not plaintext passwords. The config file should be readable only by the server admin, and protected by HTTP auth when served. |
-| "localStorage/cookies are not encrypted" | Browser storage is scoped to the origin and inaccessible to other domains. On a shared device, use your browser's profile isolation. |
-| "No CSRF protection" | Dashy's state-changing operations (config save) are protected by auth middleware. CSRF is a low risk on a private network dashboard. |
-| "Docker container runs as root" | The container is sandboxed. For hardened deployments, override with `--user` flag or configure in your Docker Compose file as described in the [container security docs](/docs/management.md#container-security). |
-| "Auth cookie is not HttpOnly/Secure" | The token is needed by client-side JavaScript for auth state. On a private network over plain HTTP, the `Secure` flag would break auth. Use HTTPS + a reverse proxy to add these flags if needed. |
-| "Iframe/embed widget can load arbitrary URLs" | The widget config is written by the server admin, not end users. If you don't trust your config authors, disable the config editor with `disableConfiguration`. |
-| "RSS widget renders HTML content" | RSS content is sanitized with DOMPurify before rendering. Script tags, event handlers and other dangerous elements are stripped. |
-| "No Content-Security-Policy headers" | CSP should be configured at the reverse proxy layer, since the correct policy depends on which widgets and icon CDNs you use. Dashy can't set a universal CSP that works for all configurations. |
-| "Config backups are not encrypted at rest" | Backups are stored server-side alongside the original config. If an attacker has filesystem access, they already have `conf.yml`. Encryption at rest is the responsibility of the host OS/volume. |
-| "No rate limiting on endpoints" | Rate limiting should be applied at the reverse proxy layer, where it can be tuned per-deployment. Dashy is not designed to be directly exposed to untrusted traffic. |
-
----
-
-## Update & Patch Policy
-
-We follow Semantic Versioning for all releases. Security fixes are shipped as patch releases as quickly as possible and are published via immutable Git tags and Docker image tags. Users are encouraged to pin to a specific version in production and monitor releases on GitHub for security updates. The `:latest` Docker tag is provided for convenience but should not be relied on in production environments.
-
----
-
-## Reporting a Security Issue
-
-Please see our [Security.md](https://github.com/Lissy93/dashy/?tab=security-ov-file) doc for how to report issues.
-We have an actively monitored security mailbox supporting PGP, as well as a GitHub Advisories vulnerability reporting program.
+There are no access logs, no analytics and no telemetry. The server prints some status info to the console, but doesn't write any log files.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -33,6 +33,7 @@
 
 ## Misc
 
-- [Privacy & Security](/docs/privacy.md) - List of requests, potential issues, and security resources
+- [Privacy](/docs/privacy.md) - List of all network requests and data storage
+- [Security](/docs/security.md) - Security features, threat model, and hardening resources
 - [License](/LICENSE) - Copy of the MIT License
 - [Code of Conduct](/.github/CODE_OF_CONDUCT.md) - Contributor Covenant Code of Conduct

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,228 @@
+# Security
+
+## Contents
+
+- [Dependencies](#dependencies)
+- [Securing your Environment](#securing-your-environment)
+- [Security Features](#security-features)
+  - [Verifiable Releases](#verifiable-transparent-releases)
+  - [Supply Chain](#supply-chain)
+  - [Subresource Integrity](#subresource-integrity)
+  - [SSL](#ssl)
+  - [Authentication](#authentication)
+  - [Configuration Lockdown](#configuration-lockdown)
+  - [Disabling Features](#disabling-features)
+  - [Docker Security](#docker-images)
+- [Threat Model](#threat-model)
+  - [Intended Deployment](#intended-deployment)
+  - [Trust Boundaries](#trust-boundaries)
+  - [Assets](#assets)
+  - [When Dashy is NOT the Right Choice](#when-dashy-is-not-the-right-choice)
+- [Update & Patch Policy](#update--patch-policy)
+- [Known Limitations](#known-limitations)
+- [Reporting a Security Issue](#reporting-a-security-issue)
+- [Non-Issues](#non-issues)
+  - [False Positives](#false-positives)
+  - [Out-of-Scope](#out-of-scope)
+
+---
+
+## Dependencies
+
+Like most web projects, Dashy builds on a number of open source [dependencies](/docs/credits.md#dependencies). We keep a close eye on them, to ensure the distributed app is always safe from known issues.
+
+Every package is pinned in a lockfile and installed with integrity checks, so builds are reproducible and nothing gets silently swapped out. Dependabot raises update PRs weekly (covering packages, GitHub Actions, Docker and dev containers). We also have a CI gate for whenever the lockfile changes, to block the merging of any dep with any known issue. Builds are also scanned with Trivy, commits are checked for leaked secrets with TruffleHog, and the CI workflows themselves are linted and zizmor audited.
+
+Releases and Docker images are published with signed build provenance and an SBOM, so you can verify that what you're running really did come from us. The `:latest` docker image is updated at a minimum weekly, so dependencies are up-to-date.
+
+---
+
+## Securing your Environment
+
+There is very little complexity involved with Dashy, and therefore the attack surface is reasonably small, but it is still important to follow best practices for all your self-hosted apps:
+
+- **Use SSL/HTTPS** for securing traffic in transit, see [Management Docs: SSL Certificates](/docs/management.md#ssl-certificates)
+- **Configure authentication** to prevent unauthorized access, see [Authentication Docs](/docs/authentication.md). For internet-facing instances, use [Keycloak](/docs/authentication.md#keycloak), [OIDC](/docs/authentication.md#oidc), or an [alternative server-side method](/docs/authentication.md#alternative-authentication-methods)
+- **Place behind a reverse proxy** if exposing to the internet, see [Management Docs: Network Exposure](/docs/management.md#network-exposure)
+- **Harden your containers** if running in Docker, see [Management Docs: Container Security](/docs/management.md#container-security)
+- **Keep Dashy and your system up-to-date** to ensure known vulnerabilities are patched
+- **Configure firewall rules** to restrict access to only necessary ports and networks
+- **Use a VPN** for private access without exposing Dashy to the public internet
+- **Follow [Docker security best practices](https://docs.docker.com/engine/security/)** including running as non-root, limiting capabilities, and using read-only volumes
+
+---
+
+## Security Features
+
+### Verifiable Transparent Releases
+
+Every release is built in the open by GitHub Actions, never by hand. Each build produces a signed provenance attestation (keyless, tied to GitHub's OIDC identity), so you can confirm that the copy of Dashy you're running was built by our CI, from this repo, and hasn't been altered since. Release tarballs also ship with a SHA256 checksum.
+
+You can browse every attestation on the [attestations page](https://github.com/lissy93/dashy/attestations), or verify a download yourself with `gh attestation verify`.
+
+### Supply Chain
+
+Each build also publishes a Software Bill of Materials (SBOM), a full manifest of every package that went into the app. Together with the provenance above, that gives you an auditable record of exactly what is inside. Images are scanned for known vulnerabilities with Trivy before they go out, and our dependencies are monitored continuously (see [Dependencies](#dependencies)).
+
+### Subresource Integrity
+
+[Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) or SRI is a security feature that enables browsers to verify that resources they fetch are delivered without unexpected manipulation. It works by allowing you to provide a cryptographic hash that a fetched resource must match. This prevents the app from loading any resources that have been manipulated, by verifying the files hashes. It safeguards against the risk of an attacker injecting arbitrary malicious content into any files served up via a CDN.
+
+Dashy supports SRI, and it is recommended to enable this if you are hosting your dashboard via a public CDN. To enable SRI, set the `INTEGRITY` environmental variable to `true`.
+
+### SSL
+
+Native SSL support is enabled, for setup instructions, see the [Management Docs](/docs/management.md#ssl-certificates)
+
+### Authentication
+
+Dashy supports built-in auth, server-based SSO using Keycloak or any OIDC provider, and header-based authentication for reverse proxy setups. Full details of which, along with alternate authentication methods can be found in the [Authentication Docs](/docs/authentication.md). If your dashboard is exposed to the internet and/ or contains any sensitive info it is strongly recommended to configure access control with Keycloak, OIDC, or another server-side method.
+
+### Configuration Lockdown
+
+Dashy provides several options to restrict what users can modify:
+
+- `appConfig.preventWriteToDisk` - Prevents config changes from being saved to the server
+- `appConfig.preventLocalSave` - Prevents config changes from being saved to browser storage
+- `appConfig.disableConfiguration` - Hides the config UI from all users
+- `appConfig.disableConfigurationForNonAdmin` - Hides the config UI for non-admin users
+
+These can be combined with the `admin` and `normal` user roles to give fine-grained control. Admin users can save config changes, while normal users have read-only access. For more details, see [Built-In Auth: User Roles](/docs/authentication/built-in.md#user-roles--visibility).
+
+### Disabling Features
+
+You may wish to disable features that you don't want to use, if they involve storing data in the browser or making network requests.
+- To disable smart-sort (uses local storage), set `appConfig.disableSmartSort: true`
+- To disable update checks (makes external request to GH), set `appConfig.disableUpdateChecks: true`
+- To disable web search (redirect to external / internal content), set `appConfig.webSearch.disableWebSearch: true`
+- To keep status checks disabled (external / internal requests), set `appConfig.statusCheck: false`
+- To keep ping checks disabled (external / internal requests), set `appConfig.pingCheckEnabled: false`
+- To keep font-awesome icons disabled (external requests), set `appConfig.enableFontAwesome: false`
+- To keep error reporting disabled (external requests and data collection), set `appConfig.enableErrorReporting: false`
+- To keep the service worker disabled (stores cache of app in browser data), set `appConfig.enableServiceWorker: false`
+
+### Docker Images
+
+The official image follows container best practices out of the box:
+- Runs as a non-root user by default
+- Minimal Alpine base, with npm removed from the final image to reduce the attack surface
+- Multi-stage build, so only runtime files ship, with no build tooling or source
+- Scanned with Trivy for known vulnerabilities before every publish
+- Published to GHCR with signed build provenance and an attested SBOM, viewable on the [attestations page](https://github.com/lissy93/dashy/attestations)
+
+To lock things down further, such as read-only volumes and dropped capabilities, see the [container security docs](/docs/management.md#container-security).
+
+---
+
+## Threat Model
+
+Dashy is a statically-hosted dashboard application, designed to be self-hosted on a private network. This threat model outlines the intended deployment context, trust boundaries, known risks and accepted trade-offs, to help users assess whether Dashy is appropriate for their environment.
+
+### Intended Deployment
+
+Dashy is designed to run on a **private local network** (e.g. a home lab), accessed by a **small number of trusted users**. It is a convenience tool for organizing links to self-hosted services - it is not designed to protect sensitive resources or act as an access control layer.
+
+If exposed to the internet, Dashy **must** be placed behind a reverse proxy with server-side authentication (e.g. Authelia, Authentik, Cloudflare Access). The built-in client-side auth is a convenience feature for private networks, not a security boundary.
+
+### Trust Boundaries
+
+| Boundary | Trusted Side | Untrusted Side |
+|---|---|---|
+| Local network | LAN users, self-hosted services | The public internet |
+| Config file (`conf.yml`) | Server admin who writes the config | End users who view the dashboard |
+| Browser storage | The current browser session | Other domains, other users of the same device |
+| CORS proxy / status checks | Configured target URLs (set by admin) | Arbitrary URLs (if auth is not enabled) |
+
+### Assets
+
+| Asset | Description | Storage |
+|---|---|---|
+| Dashboard configuration | Service URLs, section layout, app settings | `conf.yml` on server, optionally cached in browser localStorage |
+| User credentials | SHA-256 password hashes, Keycloak/OIDC client IDs | `conf.yml` on server |
+| API keys | Keys for widget services (weather, stocks, etc.) | `conf.yml` on server or environment variables |
+| Auth tokens | Session token derived from credentials | Browser cookie (`dashyAuthToken`) |
+| User preferences | Theme, layout, language, collapsed sections | Browser localStorage |
+
+### When Dashy is NOT the Right Choice
+
+- You need a **multi-tenant** dashboard with per-user audit trails
+- You are deploying on the **public internet without a reverse proxy**
+- Your dashboard contains **secrets or credentials** that must be protected from all users who can reach the server
+- You require **FIPS-compliant** or **SOC 2** certified software
+
+---
+
+## Update & Patch Policy
+
+We follow Semantic Versioning for all releases. Security fixes are shipped as patch releases as quickly as possible and are published via immutable Git tags and Docker image tags. Users are encouraged to pin to a specific version in production and monitor releases on GitHub for security updates. The `:latest` Docker tag is provided for convenience but should not be relied on in production environments.
+
+---
+
+## Known Limitations
+
+| Report | Response |
+|---|---|
+| "Client-side auth can be bypassed via browser dev tools" | Correct (only if neither `ENABLE_HTTP_AUTH` is set, nor any other auth mode). Client-side auth is a convenience for private networks, not a security boundary. Use server-side auth for untrusted environments. |
+| "CORS proxy can make requests to internal services" | Correct. It is built to reach services on your network, and is behind auth when enabled. To turn it off entirely, set `DISABLE_PROXY_ENDPOINTS=true`. |
+| "Status checks can be used for SSRF" | Target URLs are set by the admin in `conf.yml`, not end users, and the endpoint needs auth when enabled. Set `DISABLE_PROXY_ENDPOINTS=true` to disable it. |
+| "Password hashes are stored in plaintext in conf.yml" | They are SHA-256 hashes, not plaintext passwords. The config file should be readable only by the server admin, and protected by HTTP auth when served. |
+| "localStorage/cookies are not encrypted" | Browser storage is scoped to the origin and inaccessible to other domains. On a shared device, use your browser's profile isolation. |
+| "No CSRF protection" | Dashy's state-changing operations (config save) are protected by auth middleware. CSRF is a low risk on a private network dashboard. |
+| "Docker container runs as root" | It runs as the non-root `node` user by default. To lock it down further, drop capabilities or set a custom `--user`, see the [container security docs](/docs/management.md#container-security). |
+| "Auth cookie is not HttpOnly/Secure" | The token is needed by client-side JavaScript for auth state. On a private network over plain HTTP, the `Secure` flag would break auth. Use HTTPS + a reverse proxy to add these flags if needed. |
+| "Iframe/embed widget can load arbitrary URLs" | The widget config is written by the server admin, not end users. If you don't trust your config authors, disable the config editor with `disableConfiguration`. |
+| "RSS widget renders HTML content" | RSS content is sanitized with DOMPurify before rendering. Script tags, event handlers and other dangerous elements are stripped. |
+| "No Content-Security-Policy headers" | CSP should be configured at the reverse proxy layer, since the correct policy depends on which widgets and icon CDNs you use. Dashy can't set a universal CSP that works for all configurations. |
+| "Config backups are not encrypted at rest" | Backups are stored server-side alongside the original config. If an attacker has filesystem access, they already have `conf.yml`. Encryption at rest is the responsibility of the host OS/volume. |
+| "No rate limiting on endpoints" | Rate limiting should be applied at the reverse proxy layer, where it can be tuned per-deployment. Dashy is not designed to be directly exposed to untrusted traffic. |
+| "A non-admin user can recompute an admin token under `ENABLE_HTTP_AUTH`" | Correct. Any logged-in user can read the config and other users' hashes, so `admin` is not a hard boundary here. Use OIDC or Keycloak for real admin separation. |
+
+---
+
+## Reporting a Security Issue
+
+Please see our [Security.md](https://github.com/Lissy93/dashy/?tab=security-ov-file) doc for how to report issues.
+We have an actively monitored security mailbox supporting PGP, as well as a GitHub Advisories vulnerability reporting program.
+
+---
+
+## Non-Issues
+
+### False Positives
+
+These are reported regularly, usually by automated scanners. Each has been checked and found not to be exploitable.
+
+| Report | Response |
+|---|---|
+| Ping and status checks allow command injection | The host goes to pingman, which runs `spawn('ping', ...)` with no shell, so `;`, `|`, `$()` and backticks are inert. It is one trailing argument, so no extra flags either. |
+| The CORS proxy can read arbitrary environment variables | Only `DASHY_`, `VITE_APP_` prefixes are read. The client `VITE_APP_` vars are already in the bundle, and `DASHY_` is opt-in. Unprefixed secrets stay unreachable. |
+| `enableInsecure` disables TLS certificate verification | Opt-in per status check, for internal services with self-signed certs, and it only affects that one request. Leave `statusCheckAllowInsecure` unset to keep verification on. |
+| OIDC does not pin the JWT algorithm (alg confusion or `none`) | Verification uses a remote JWKS, so jose rejects none and symmetric algorithms. The issuer and group claims come from a signature-verified token, so a user cannot forge them. |
+| `yaml.load()` allows code execution on parse | In js-yaml 4.x (we use `^4.2.0`) `load` is the safe loader. It does not instantiate custom types, so parsing a config file cannot execute code. |
+| Prototype pollution via the config API's Object.assign | `Object.assign` is a shallow set, so a `__proto__` key reparents only that object and is dropped on dump. `Object.prototype` is untouched, and the API is admin-gated behind `ENABLE_API`. |
+| Path traversal via the config filename | The save and API write paths run `filename` through `path.basename()` and a `.yml`-only regex, so separators, `..` and null bytes are rejected and writes stay inside the data dir. |
+| A committed .env file leaks secrets | `.env` is a fully commented template with no real values. Real secrets go in `.env.local` (gitignored), and the Docker build copies an explicit allowlist, so `.env` never ships. |
+| system-info and healthz disclose host details | `system-info` is behind the same auth as every endpoint (open only in zero-auth mode). `healthz` is intentionally open for orchestrators, and version plus uptime is standard there. |
+| The http to https redirect uses the `Host` header (open redirect) | A forged Host only redirects the attacker's own request back to itself, so there is no cross-user effect. It is only active when you mount certs and enable the redirect. |
+
+### Out-of-Scope
+
+We do get a LOT of AI-submitted reports for things which come down to deployment decisions (e.g. not enabling auth).
+The following list is the most reported non-issues. They are out-of-scope, since they're: 1. the expected behaviour,  2. already clearly documented, and 3. not exploitable in practice.
+
+#### Endpoints are unauthenticated
+Dashy ships with no auth configured out-of-the-box. So until you enable or setup auth, all pages and endpoints will be reachable without credentials. That's intentional, as it allows you to put Dashy behind your existing auth setup without hassle. Once an auth system of your choice has been (correctly) configured, all unauthenticated requests will then be rejected.
+
+✅ **Solution**: Enable authentication. See the [authentication docs](https://dashy.to/docs/authentication/) for instructions.
+
+#### The proxy / status / ping can reach localhost and private IPs
+The CORS proxy, status-check and ping-check features are *meant* to reach internal and private addresses. Their use case is to let your widgets and service status checks talk the other services you have running within your LAN securely.
+
+These are opt-in requests (you configure widgets or other features to use them). But if you still don't want the proxy reaching internal hosts, don't expose it unauthenticated, or set firewall rules to control what can and cannot be called.
+
+✅ **Solution**: Configure firewall rules, or disable these endpoints entirely with the `DISABLE_PROXY_ENDPOINTS=true` env var
+
+#### Config write leads to stored code execution
+Widgets execute user-controlled code. The code for these widgets live in your YAML config, which can be updated by admins with the config-manager save endpoint. It's the expected functionality that admins can update the config, and add widgets here.
+
+✅ **Solution**: Enable auth, and set `appConfig.disableConfigurationForNonAdmin: true`. Or, disable config saving entirely with `appConfig.preventWriteToDisk: true`


### PR DESCRIPTION
### Category
Docs

### Overview
Split out the security and privacy docs into separate pages
Updated contact details, and added safe harbour to security.md
Makes it clearer what is a no-op/non-issue/out-of-scope for commonly reported security issues
Listed security features and configurations in the security docs
Writes out our dependency management system

### Issue Number
N/A

But there have been 9 security advisories in the past 2 days, all saying "Dashy allows public access if authentication not enabled" (🤦‍♀️). I'm hoping that these docs will make it clearer that this would be a deployment decision and not a security vulnerability within Dashy.

