### PR TITLE
:sparkles: Added ability to sort items by Provider and by Item ID

### DIFF
--- a/src/utils/SortItems.js
+++ b/src/utils/SortItems.js
@@ -10,6 +10,15 @@ const byTitle = (items) => [...items].sort(
   (a, b) => ((a.title || '').toLowerCase() > (b.title || '').toLowerCase() ? 1 : -1),
 );
 
+const byProvider = (items) => [...items].sort(
+  (a, b) => ((a.provider || '').toLowerCase() > (b.provider || '').toLowerCase() ? 1 : -1),
+);
+
+const byID = (items) => [...items].sort(
+  (a, b) => ((a.id || '').toLowerCase() > (b.id || '').toLowerCase() ? 1 : -1),
+);
+
+
 const byUsage = (items, key) => {
   const counts = readUsage(key);
   const get = (item) => counts[item.id] || 0;
@@ -25,12 +34,16 @@ const shuffled = (items) => items
 export default function sortItems(items, order, sectionTitle = '') {
   const list = Array.isArray(items) ? items.slice() : [];
   const ord = order || defaultSortOrder;
-  if (ord === 'default') return list;
-  if (ord === 'alphabetical') return byTitle(list);
-  if (ord === 'reverse-alphabetical') return byTitle(list).reverse();
-  if (ord === 'most-used') return byUsage(list, localStorageKeys.MOST_USED);
-  if (ord === 'last-used') return byUsage(list, localStorageKeys.LAST_USED);
-  if (ord === 'random') return shuffled(list);
+  if (ord === 'Default') return list;
+  if (ord === 'Alphabetical') return byTitle(list);
+  if (ord === 'Alphabetical reverse') return byTitle(list).reverse();
+  if (ord === 'Most-used') return byUsage(list, localStorageKeys.MOST_USED);
+  if (ord === 'Last-used') return byUsage(list, localStorageKeys.LAST_USED);
+  if (ord === 'Provider') return byProvider(list);
+  if (ord === 'Provider reverse') return byProvider(list).reverse();
+  if (ord === 'Item ID') return byID(list);
+  if (ord === 'Item ID reverse') return byID(list).reverse();
+  if (ord === 'Random') return shuffled(list);
   ErrorHandler(`Unknown Sort order '${ord}'${sectionTitle ? ` under '${sectionTitle}'` : ''}`);
   return list;
 }

--- a/src/utils/SortItems.js
+++ b/src/utils/SortItems.js
@@ -10,6 +10,11 @@ const byTitle = (items) => [...items].sort(
   (a, b) => ((a.title || '').toLowerCase() > (b.title || '').toLowerCase() ? 1 : -1),
 );
 
+const byUsage = (items, key) => {
+  const counts = readUsage(key);
+  const get = (item) => counts[item.id] || 0;
+  return [...items].reverse().sort((a, b) => (get(a) < get(b) ? 1 : -1));
+};
 const byProvider = (items) => [...items].sort(
   (a, b) => ((a.provider || '').toLowerCase() > (b.provider || '').toLowerCase() ? 1 : -1),
 );
@@ -17,13 +22,6 @@ const byProvider = (items) => [...items].sort(
 const byID = (items) => [...items].sort(
   (a, b) => ((a.id || '').toLowerCase() > (b.id || '').toLowerCase() ? 1 : -1),
 );
-
-
-const byUsage = (items, key) => {
-  const counts = readUsage(key);
-  const get = (item) => counts[item.id] || 0;
-  return [...items].reverse().sort((a, b) => (get(a) < get(b) ? 1 : -1));
-};
 
 const shuffled = (items) => items
   .map((value) => ({ value, sort: Math.random() }))
@@ -34,16 +32,16 @@ const shuffled = (items) => items
 export default function sortItems(items, order, sectionTitle = '') {
   const list = Array.isArray(items) ? items.slice() : [];
   const ord = order || defaultSortOrder;
-  if (ord === 'Default') return list;
-  if (ord === 'Alphabetical') return byTitle(list);
-  if (ord === 'Alphabetical reverse') return byTitle(list).reverse();
-  if (ord === 'Most-used') return byUsage(list, localStorageKeys.MOST_USED);
-  if (ord === 'Last-used') return byUsage(list, localStorageKeys.LAST_USED);
-  if (ord === 'Provider') return byProvider(list);
-  if (ord === 'Provider reverse') return byProvider(list).reverse();
-  if (ord === 'Item ID') return byID(list);
-  if (ord === 'Item ID reverse') return byID(list).reverse();
-  if (ord === 'Random') return shuffled(list);
+  if (ord === 'default') return list;
+  if (ord === 'alphabetical') return byTitle(list);
+  if (ord === 'reverse-alphabetical') return byTitle(list).reverse();
+  if (ord === 'most-used') return byUsage(list, localStorageKeys.MOST_USED);
+  if (ord === 'last-used') return byUsage(list, localStorageKeys.LAST_USED);
+  if (ord === 'random') return shuffled(list);
+  if (ord === 'provider') return byProvider(list);
+  if (ord === 'provider-reverse') return byProvider(list).reverse();
+  if (ord === 'itemID') return byID(list);
+  if (ord === 'itemID-reverse') return byID(list).reverse();
   ErrorHandler(`Unknown Sort order '${ord}'${sectionTitle ? ` under '${sectionTitle}'` : ''}`);
   return list;
 }

--- a/src/utils/SortItems.js
+++ b/src/utils/SortItems.js
@@ -40,8 +40,8 @@ export default function sortItems(items, order, sectionTitle = '') {
   if (ord === 'random') return shuffled(list);
   if (ord === 'provider') return byProvider(list);
   if (ord === 'provider-reverse') return byProvider(list).reverse();
-  if (ord === 'itemID') return byID(list);
-  if (ord === 'itemID-reverse') return byID(list).reverse();
+  if (ord === 'item-id') return byID(list);
+  if (ord === 'item-id-reverse') return byID(list).reverse();
   ErrorHandler(`Unknown Sort order '${ord}'${sectionTitle ? ` under '${sectionTitle}'` : ''}`);
   return list;
 }

--- a/src/utils/config/ConfigSchema.json
+++ b/src/utils/config/ConfigSchema.json
@@ -909,8 +909,8 @@
                   "reverse-alphabetical",
                   "provider",
                   "provider-reverse",
-                  "itemID",
-                  "itemID-reverse",
+                  "item-id",
+                  "item-id-reverse",
                   "random"
                 ],
                 "default": "default",

--- a/src/utils/config/ConfigSchema.json
+++ b/src/utils/config/ConfigSchema.json
@@ -55,54 +55,78 @@
                 "default": false,
                 "description": "If set to true, page will be visible for logged in users, but not for guests"
               },
+              "showForGroups": {
+                "title": "Show for Groups",
+                "type": "array",
+                "description": "Page will be hidden from all users except those with one or more of these SSO groups",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the group that will be able to view this page"
+                }
+              },
+              "hideForGroups": {
+                "title": "Hide for Groups",
+                "type": "array",
+                "description": "Page will be hidden from users with any of these SSO groups",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the group that will not be able to view this page"
+                }
+              },
+              "showForRoles": {
+                "title": "Show for Roles",
+                "type": "array",
+                "description": "Page will be hidden from all users except those with one or more of these SSO roles",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the role that will be able to view this page"
+                }
+              },
+              "hideForRoles": {
+                "title": "Hide for Roles",
+                "type": "array",
+                "description": "Page will be hidden from users with any of these SSO roles",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the role that will not be able to view this page"
+                }
+              },
               "showForKeycloakUsers": {
-                "title": "Show for select Keycloak groups or roles",
+                "title": "Show for Groups/Roles (legacy)",
                 "type": "object",
-                "description": "Configure the Keycloak groups or roles that will have access to this page",
+                "description": "Legacy form of showForGroups and showForRoles",
                 "additionalProperties": false,
                 "properties": {
                   "groups": {
-                    "title": "Show for Groups",
                     "type": "array",
-                    "description": "Page will be hidden from all users except those with one or more of these groups",
                     "items": {
-                      "type": "string",
-                      "description": "Name of the group that will be able to view this page"
+                      "type": "string"
                     }
                   },
                   "roles": {
-                    "title": "Show for Roles",
                     "type": "array",
-                    "description": "Page will be hidden from all users except those with one or more of these roles",
                     "items": {
-                      "type": "string",
-                      "description": "Name of the role that will be able to view this page"
+                      "type": "string"
                     }
                   }
                 }
               },
               "hideForKeycloakUsers": {
-                "title": "Hide for select Keycloak groups or roles",
+                "title": "Hide for Groups/Roles (legacy)",
                 "type": "object",
-                "description": "Configure the Keycloak groups or roles that will not have access to this page",
+                "description": "Legacy form of hideForGroups and hideForRoles",
                 "additionalProperties": false,
                 "properties": {
                   "groups": {
-                    "title": "Hide for Groups",
                     "type": "array",
-                    "description": "Page will be hidden from users with any of these groups",
                     "items": {
-                      "type": "string",
-                      "description": "name of the group that will not be able to view this page"
+                      "type": "string"
                     }
                   },
                   "roles": {
-                    "title": "Hide for Roles",
                     "type": "array",
-                    "description": "Page will be hidden from users with any of roles",
                     "items": {
-                      "type": "string",
-                      "description": "name of the role that will not be able to view this page"
+                      "type": "string"
                     }
                   }
                 }
@@ -878,16 +902,16 @@
                 "title": "Sort By",
                 "type": "string",
                 "enum": [
-                  "Default",
-                  "Most-used",
-                  "Last-used",
-                  "Alphabetical",
-                  "Alphabetical reverse",
-                  "Provider",
-                  "Provider reverse",
-                  "Item ID",
-                  "Item ID reverse",
-                  "Random"
+                  "default",
+                  "most-used",
+                  "last-used",
+                  "alphabetical",
+                  "reverse-alphabetical",
+                  "provider",
+                  "provider-reverse",
+                  "itemID",
+                  "itemID-reverse",
+                  "random"
                 ],
                 "default": "default",
                 "description": "How to sort items within the section. By default items are displayed in the order in which they are listed in within the config"
@@ -989,54 +1013,78 @@
                 "default": false,
                 "description": "If set to true, section will be visible for logged in users, but not for guests"
               },
+              "showForGroups": {
+                "title": "Show for Groups",
+                "type": "array",
+                "description": "Section will be hidden from all users except those with one or more of these SSO groups",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the group that will be able to view this section"
+                }
+              },
+              "hideForGroups": {
+                "title": "Hide for Groups",
+                "type": "array",
+                "description": "Section will be hidden from users with any of these SSO groups",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the group that will not be able to view this section"
+                }
+              },
+              "showForRoles": {
+                "title": "Show for Roles",
+                "type": "array",
+                "description": "Section will be hidden from all users except those with one or more of these SSO roles",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the role that will be able to view this section"
+                }
+              },
+              "hideForRoles": {
+                "title": "Hide for Roles",
+                "type": "array",
+                "description": "Section will be hidden from users with any of these SSO roles",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the role that will not be able to view this section"
+                }
+              },
               "showForKeycloakUsers": {
-                "title": "Show for select Keycloak groups or roles",
+                "title": "Show for Groups/Roles (legacy)",
                 "type": "object",
-                "description": "Configure the Keycloak groups or roles that will have access to this section",
+                "description": "Legacy form of showForGroups and showForRoles",
                 "additionalProperties": false,
                 "properties": {
                   "groups": {
-                    "title": "Show for Groups",
                     "type": "array",
-                    "description": "Section will be hidden from all users except those with one or more of these groups",
                     "items": {
-                      "type": "string",
-                      "description": "Name of the group that will be able to view this section"
+                      "type": "string"
                     }
                   },
                   "roles": {
-                    "title": "Show for Roles",
                     "type": "array",
-                    "description": "Section will be hidden from all users except those with one or more of these roles",
                     "items": {
-                      "type": "string",
-                      "description": "Name of the role that will be able to view this section"
+                      "type": "string"
                     }
                   }
                 }
               },
               "hideForKeycloakUsers": {
-                "title": "Hide for select Keycloak groups or roles",
+                "title": "Hide for Groups/Roles (legacy)",
                 "type": "object",
-                "description": "Configure the Keycloak groups or roles that will not have access to this section",
+                "description": "Legacy form of hideForGroups and hideForRoles",
                 "additionalProperties": false,
                 "properties": {
                   "groups": {
-                    "title": "Hide for Groups",
                     "type": "array",
-                    "description": "Section will be hidden from users with any of these groups",
                     "items": {
-                      "type": "string",
-                      "description": "name of the group that will not be able to view this section"
+                      "type": "string"
                     }
                   },
                   "roles": {
-                    "title": "Hide for Roles",
                     "type": "array",
-                    "description": "Section will be hidden from users with any of roles",
                     "items": {
-                      "type": "string",
-                      "description": "name of the role that will not be able to view this section"
+                      "type": "string"
                     }
                   }
                 }
@@ -1129,54 +1177,78 @@
                       "default": false,
                       "description": "If set to true, item will be visible for logged in users, but not for guests"
                     },
+                    "showForGroups": {
+                      "title": "Show for Groups",
+                      "type": "array",
+                      "description": "Item will be hidden from all users except those with one or more of these SSO groups",
+                      "items": {
+                        "type": "string",
+                        "description": "Name of the group that will be able to view this item"
+                      }
+                    },
+                    "hideForGroups": {
+                      "title": "Hide for Groups",
+                      "type": "array",
+                      "description": "Item will be hidden from users with any of these SSO groups",
+                      "items": {
+                        "type": "string",
+                        "description": "Name of the group that will not be able to view this item"
+                      }
+                    },
+                    "showForRoles": {
+                      "title": "Show for Roles",
+                      "type": "array",
+                      "description": "Item will be hidden from all users except those with one or more of these SSO roles",
+                      "items": {
+                        "type": "string",
+                        "description": "Name of the role that will be able to view this item"
+                      }
+                    },
+                    "hideForRoles": {
+                      "title": "Hide for Roles",
+                      "type": "array",
+                      "description": "Item will be hidden from users with any of these SSO roles",
+                      "items": {
+                        "type": "string",
+                        "description": "Name of the role that will not be able to view this item"
+                      }
+                    },
                     "showForKeycloakUsers": {
-                      "title": "Show for select Keycloak groups or roles",
+                      "title": "Show for Groups/Roles (legacy)",
                       "type": "object",
-                      "description": "Configure the Keycloak groups or roles that will have access to this item",
+                      "description": "Legacy form of showForGroups and showForRoles",
                       "additionalProperties": false,
                       "properties": {
                         "groups": {
-                          "title": "Show for Groups",
                           "type": "array",
-                          "description": "Item will be hidden from all users except those with one or more of these groups",
                           "items": {
-                            "type": "string",
-                            "description": "Name of the group that will be able to view this item"
+                            "type": "string"
                           }
                         },
                         "roles": {
-                          "title": "Show for Roles",
                           "type": "array",
-                          "description": "Item will be hidden from all users except those with one or more of these roles",
                           "items": {
-                            "type": "string",
-                            "description": "Name of the role that will be able to view this item"
+                            "type": "string"
                           }
                         }
                       }
                     },
                     "hideForKeycloakUsers": {
-                      "title": "Hide for select Keycloak groups or roles",
+                      "title": "Hide for Groups/Roles (legacy)",
                       "type": "object",
-                      "description": "Configure the Keycloak groups or roles that will not have access to this item",
+                      "description": "Legacy form of hideForGroups and hideForRoles",
                       "additionalProperties": false,
                       "properties": {
                         "groups": {
-                          "title": "Hide for Groups",
                           "type": "array",
-                          "description": "Item will be hidden from users with any of these groups",
                           "items": {
-                            "type": "string",
-                            "description": "name of the group that will not be able to view this item"
+                            "type": "string"
                           }
                         },
                         "roles": {
-                          "title": "Hide for Roles",
                           "type": "array",
-                          "description": "Item will be hidden from users with any of roles",
                           "items": {
-                            "type": "string",
-                            "description": "name of the role that will not be able to view this item"
+                            "type": "string"
                           }
                         }
                       }

--- a/src/utils/config/ConfigSchema.json
+++ b/src/utils/config/ConfigSchema.json
@@ -878,12 +878,16 @@
                 "title": "Sort By",
                 "type": "string",
                 "enum": [
-                  "default",
-                  "most-used",
-                  "last-used",
-                  "alphabetical",
-                  "reverse-alphabetical",
-                  "random"
+                  "Default",
+                  "Most-used",
+                  "Last-used",
+                  "Alphabetical",
+                  "Alphabetical reverse",
+                  "Provider",
+                  "Provider reverse",
+                  "Item ID",
+                  "Item ID reverse",
+                  "Random"
                 ],
                 "default": "default",
                 "description": "How to sort items within the section. By default items are displayed in the order in which they are listed in within the config"


### PR DESCRIPTION
### Category
Feature

### Overview
Added ability to sort items by Provider and by Item ID.
Also redid the spelling of the sorting choices with uppercases.

### Issue Number
none

### Additional Info
- Schema changes - Just the spelling of the sorting choices and adding some
-- (Provider, Provider reverse, Item ID, Item ID reverse)
- Testing instructions - Well, just sort stuff and check if it works :)
- AI disclaimer - no AI used for this in any way.
