### PR TITLE
Fixes for Mario

### DIFF
--- a/docs/authentication/authelia-oidc.md
+++ b/docs/authentication/authelia-oidc.md
@@ -246,32 +246,28 @@ When you load Dashy, you'll be redirected to Authelia's login page. After signin
 
 ## 4. Groups and Visibility
 
-Once group membership is in the id_token, you can use it to hide or show pages, sections and items. The property name is `hideForKeycloakUsers` / `showForKeycloakUsers` (the name is historical; it works for any OIDC provider, including Authelia).
+Once group membership is in the id_token, you can use it to hide or show pages, sections and items, with `showForGroups` and `hideForGroups` under `displayData`.
 
 To make an Admin section visible only to members of `admins`:
 
 ```yaml
 displayData:
-  showForKeycloakUsers:
-    groups:
-      - admins
+  showForGroups:
+    - admins
 ```
 
-Both `showForKeycloakUsers` and `hideForKeycloakUsers` accept lists of `groups` and `roles`. If a user matches an entry they're allowed or excluded as defined.
+Both `showForGroups` and `hideForGroups` accept a list of group names (`showForRoles` / `hideForRoles` do the same for a `roles` claim). If a user matches an entry they're allowed or excluded as defined.
 
 ```yaml
 sections:
   - name: Internal Tools
     displayData:
-      showForKeycloakUsers:
-        groups: ['admins']
-      hideForKeycloakUsers:
-        groups: ['users']
+      showForGroups: ['admins']
+      hideForGroups: ['users']
     items:
       - title: Hidden from interns
         displayData:
-          hideForKeycloakUsers:
-            groups: ['interns']
+          hideForGroups: ['interns']
 ```
 
 ---
@@ -391,7 +387,7 @@ Boot starts in [`src/main.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/m
 
 [`src/utils/auth/getApiAuthHeader.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/auth/getApiAuthHeader.js) builds the Authorization header for every internal API call. It does a client-side `exp` check and returns `null` for missing or expired tokens, so the next request triggers a fresh login rather than a 401.
 
-[`src/utils/IsVisibleToUser.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/IsVisibleToUser.js) reads `KEYCLOAK_INFO` when evaluating `showForKeycloakUsers` and `hideForKeycloakUsers` rules.
+[`src/utils/IsVisibleToUser.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/IsVisibleToUser.js) reads `KEYCLOAK_INFO` when evaluating `show`/`hideForGroups` and `show`/`hideForRoles` rules.
 
 ### Server side
 

--- a/docs/authentication/authentik.md
+++ b/docs/authentication/authentik.md
@@ -122,7 +122,7 @@ First boot runs database migrations and takes a minute or two. Once the `server`
 
 ### Create the groups scope
 
-Authentik doesn't expose group membership in the id_token by default. Dashy needs it for the `adminGroup` check and for the `showForKeycloakUsers` / `hideForKeycloakUsers` visibility rules.
+Authentik doesn't expose group membership in the id_token by default. Dashy needs it for the `adminGroup` check and for the `showForGroups` / `hideForGroups` visibility rules.
 
 1. Go to **Customization > Property Mappings**
 2. Click **Create > Scope Mapping**
@@ -256,32 +256,28 @@ When you load Dashy, you'll be redirected to Authentik's login page. After signi
 
 ## 4. Groups and Visibility
 
-Once group membership is in the id_token, you can use it to hide or show pages, sections and items in Dashy. The property name is `hideForKeycloakUsers` / `showForKeycloakUsers` (the name is historical; it works for any OIDC provider, including Authentik).
+Once group membership is in the id_token, you can use it to hide or show pages, sections and items in Dashy, with `showForGroups` and `hideForGroups` under `displayData`.
 
 To make an Admin section visible only to members of `dashy-admins`:
 
 ```yaml
 displayData:
-  showForKeycloakUsers:
-    groups:
-      - dashy-admins
+  showForGroups:
+    - dashy-admins
 ```
 
-Both `showForKeycloakUsers` and `hideForKeycloakUsers` accept lists of `groups` and `roles`. If a user matches an entry they're allowed or excluded as defined.
+Both `showForGroups` and `hideForGroups` accept a list of group names (`showForRoles` / `hideForRoles` do the same for a `roles` claim). If a user matches an entry they're allowed or excluded as defined.
 
 ```yaml
 sections:
   - name: Internal Tools
     displayData:
-      showForKeycloakUsers:
-        groups: ['dashy-admins']
-      hideForKeycloakUsers:
-        groups: ['guests']
+      showForGroups: ['dashy-admins']
+      hideForGroups: ['guests']
     items:
       - title: Hidden from interns
         displayData:
-          hideForKeycloakUsers:
-            groups: ['interns']
+          hideForGroups: ['interns']
 ```
 
 

--- a/docs/authentication/keycloak.md
+++ b/docs/authentication/keycloak.md
@@ -272,30 +272,26 @@ For example, to make any given section only visible to admins, simply add the fo
 
 ```yaml
 displayData:
-  showForKeycloakUsers:
-    roles:
-      - dashy-admin # ID of the admin role you created earlier
+  showForRoles:
+    - dashy-admin # ID of the admin role you created earlier
 ```
 
 Keycloak server administration and configuration is a deep topic; please refer to the [server admin guide](https://www.keycloak.org/docs/latest/server_admin/index.html#assigning-permissions-and-access-using-roles-and-groups) to see details about creating and assigning roles and groups.
 
-Once you have groups or roles assigned to users you can configure access under each section or item `displayData.showForKeycloakUsers` and `displayData.hideForKeycloakUsers`.
+Once you have groups or roles assigned to users you can configure access under each section or item, using `showForGroups`, `hideForGroups`, `showForRoles` and `hideForRoles` within `displayData`.
 
-Both show and hide configurations accept a list of `groups` and `roles` that limit access. If a users data matches one or more items in these lists they will be allowed or excluded as defined.
+Each accepts a list of group or role names that limit access. If a users data matches one or more items in these lists they will be allowed or excluded as defined.
 
 ```yaml
 sections:
   - name: DeveloperResources
     displayData:
-      showForKeycloakUsers:
-        roles: ['canViewDevResources']
-      hideForKeycloakUsers:
-        groups: ['ProductTeam']
+      showForRoles: ['canViewDevResources']
+      hideForGroups: ['ProductTeam']
     items:
       - title: Not Visible for developers
         displayData:
-          hideForKeycloakUsers:
-            groups: ['DevelopmentTeam']
+          hideForGroups: ['DevelopmentTeam']
 ```
 
 ---
@@ -382,7 +378,7 @@ Boot starts in [`src/main.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/m
 
 [`src/utils/auth/getApiAuthHeader.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/auth/getApiAuthHeader.js) builds the Authorization header for every internal API call. It does a client-side `exp` check and returns `null` for missing or expired tokens, so the next request triggers a fresh login rather than a 401.
 
-The localStorage keys (`ID_TOKEN`, `KEYCLOAK_INFO`, `USERNAME`, `ISADMIN`) live in [`src/utils/config/defaults.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/config/defaults.js). [`src/utils/IsVisibleToUser.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/IsVisibleToUser.js) reads `KEYCLOAK_INFO` when evaluating `showForKeycloakUsers` and `hideForKeycloakUsers` rules.
+The localStorage keys (`ID_TOKEN`, `KEYCLOAK_INFO`, `USERNAME`, `ISADMIN`) live in [`src/utils/config/defaults.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/config/defaults.js). [`src/utils/IsVisibleToUser.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/IsVisibleToUser.js) reads `KEYCLOAK_INFO` when evaluating `show`/`hideForGroups` and `show`/`hideForRoles` rules.
 
 ### Server side
 

--- a/docs/authentication/pocketid.md
+++ b/docs/authentication/pocketid.md
@@ -180,32 +180,28 @@ When you load Dashy, you'll be redirected to Pocket ID's sign-in page. Authentic
 
 ## 4. Groups and Visibility
 
-Once the `groups` claim is in the id_token, you can use it to hide or show pages, sections and items. The property name is `hideForKeycloakUsers` / `showForKeycloakUsers` (the name is historical; it works for any OIDC provider, including Pocket ID).
+Once the `groups` claim is in the id_token, you can use it to hide or show pages, sections and items, with `showForGroups` and `hideForGroups` under `displayData`.
 
 To make an Admin section visible only to members of `admins`:
 
 ```yaml
 displayData:
-  showForKeycloakUsers:
-    groups:
-      - admins
+  showForGroups:
+    - admins
 ```
 
-Both `showForKeycloakUsers` and `hideForKeycloakUsers` accept lists of `groups` and `roles`. If a user matches an entry they're allowed or excluded as defined.
+Both `showForGroups` and `hideForGroups` accept a list of group names (`showForRoles` / `hideForRoles` do the same for a `roles` claim). If a user matches an entry they're allowed or excluded as defined.
 
 ```yaml
 sections:
   - name: Internal Tools
     displayData:
-      showForKeycloakUsers:
-        groups: ['admins']
-      hideForKeycloakUsers:
-        groups: ['guests']
+      showForGroups: ['admins']
+      hideForGroups: ['guests']
     items:
       - title: Hidden from interns
         displayData:
-          hideForKeycloakUsers:
-            groups: ['interns']
+          hideForGroups: ['interns']
 ```
 
 ---
@@ -292,7 +288,7 @@ Boot starts in [`src/main.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/m
 
 [`src/utils/auth/getApiAuthHeader.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/auth/getApiAuthHeader.js) builds the Authorization header for every internal API call. It does a client-side `exp` check and returns `null` for missing or expired tokens, so the next request triggers a fresh login rather than a 401.
 
-[`src/utils/IsVisibleToUser.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/IsVisibleToUser.js) reads `KEYCLOAK_INFO` when evaluating `showForKeycloakUsers` and `hideForKeycloakUsers` rules.
+[`src/utils/IsVisibleToUser.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/IsVisibleToUser.js) reads `KEYCLOAK_INFO` when evaluating `show`/`hideForGroups` and `show`/`hideForRoles` rules.
 
 ### Server side
 

--- a/docs/authentication/zitadel.md
+++ b/docs/authentication/zitadel.md
@@ -250,32 +250,28 @@ When you load Dashy, you'll be redirected to Zitadel's login page. After signing
 
 ## 4. Groups and Visibility
 
-Once the Action puts roles in the id_token's `groups` claim, you can use them to hide or show pages, sections and items. The property name is `hideForKeycloakUsers` / `showForKeycloakUsers` (the name is historical; it works for any OIDC provider, including Zitadel).
+Once the Action puts roles in the id_token's `groups` claim, you can use them to hide or show pages, sections and items, with `showForGroups` and `hideForGroups` under `displayData`.
 
 To make an Admin section visible only to members of `admins`:
 
 ```yaml
 displayData:
-  showForKeycloakUsers:
-    groups:
-      - admins
+  showForGroups:
+    - admins
 ```
 
-Both `showForKeycloakUsers` and `hideForKeycloakUsers` accept lists of `groups` and `roles`. If a user matches an entry they're allowed or excluded as defined.
+Both `showForGroups` and `hideForGroups` accept a list of group names (`showForRoles` / `hideForRoles` do the same for a `roles` claim). If a user matches an entry they're allowed or excluded as defined.
 
 ```yaml
 sections:
   - name: Internal Tools
     displayData:
-      showForKeycloakUsers:
-        groups: ['admins']
-      hideForKeycloakUsers:
-        groups: ['guests']
+      showForGroups: ['admins']
+      hideForGroups: ['guests']
     items:
       - title: Hidden from interns
         displayData:
-          hideForKeycloakUsers:
-            groups: ['interns']
+          hideForGroups: ['interns']
 ```
 
 ---
@@ -369,7 +365,7 @@ Boot starts in [`src/main.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/m
 
 [`src/utils/auth/getApiAuthHeader.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/auth/getApiAuthHeader.js) builds the Authorization header for every internal API call. It does a client-side `exp` check and returns `null` for missing or expired tokens, so the next request triggers a fresh login rather than a 401.
 
-[`src/utils/IsVisibleToUser.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/IsVisibleToUser.js) reads `KEYCLOAK_INFO` when evaluating `showForKeycloakUsers` and `hideForKeycloakUsers` rules.
+[`src/utils/IsVisibleToUser.js`](https://github.com/lissy93/dashy/blob/4.1.5/src/utils/IsVisibleToUser.js) reads `KEYCLOAK_INFO` when evaluating `show`/`hideForGroups` and `show`/`hideForRoles` rules.
 
 ### Server side
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -39,12 +39,12 @@ The following file provides a reference of all supported configuration options.
     - [`headerAuth`](#appconfigauthheaderauth-optional) - Auth config for HeaderAuth
 - [**`sections`**](#section) - List of sections
   - [`displayData`](#sectiondisplaydata-optional) - Section display settings
-    - [`show/hideForKeycloakUsers`](#sectiondisplaydatahideforkeycloakusers-sectiondisplaydatashowforkeycloakusers-itemdisplaydatahideforkeycloakusers-and-itemdisplaydatashowforkeycloakusers) - Set user controls
+    - [`show/hideForGroups` and `show/hideForRoles`](#showforgroups-hideforgroups-showforroles-and-hideforroles) - Set group/role controls
   - [`icon`](#sectionicon-and-sectionitemicon) - Icon for a section
   - [`items`](#sectionitem) - List of items
     - [`icon`](#sectionicon-and-sectionitemicon) - Icon for an item
     - [`displayData`](#itemdisplaydata-optional) - Item display settings
-      - [`show/hideForKeycloakUsers`](#sectiondisplaydatahideforkeycloakusers-sectiondisplaydatashowforkeycloakusers-itemdisplaydatahideforkeycloakusers-and-itemdisplaydatashowforkeycloakusers) - Set user controls
+      - [`show/hideForGroups` and `show/hideForRoles`](#showforgroups-hideforgroups-showforroles-and-hideforroles) - Set group/role controls
   - [`widgets`](#sectionwidget-optional) - List of widgets
 - [**Notes**](#notes)
   - [Editing Config through the UI](#editing-config-through-the-ui)
@@ -295,8 +295,10 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 **`hideForUsers`** | `string[]` | _Optional_ | Current item will be visible to all users, except for those specified in this list
 **`showForUsers`** | `string[]` | _Optional_ | Current item will be hidden from all users, except for those specified in this list
 **`hideForGuests`** | `boolean` | _Optional_ | Current item will be visible for logged in users, but not for guests (see `appConfig.enableGuestAccess`). Defaults to `false`
-**`hideForKeycloakUsers`** | `object`  | _Optional_ | Current item will be visible to all keycloak users, except for those configured via these groups and roles. See `hideForKeycloakUsers`
-**`showForKeycloakUsers`** | `object`  | _Optional_ | Current item will be hidden from all keycloak users, except for those configured via these groups and roles. See `showForKeycloakUsers`
+**`hideForGroups`** | `string[]` | _Optional_ | Current item will be visible to all users, except for those in any of these SSO groups. See [Group and Role Controls](#showforgroups-hideforgroups-showforroles-and-hideforroles)
+**`showForGroups`** | `string[]` | _Optional_ | Current item will be hidden from all users, except for those in one or more of these SSO groups
+**`hideForRoles`** | `string[]` | _Optional_ | Current item will be visible to all users, except for those with any of these SSO roles
+**`showForRoles`** | `string[]` | _Optional_ | Current item will be hidden from all users, except for those with one or more of these SSO roles
 **`hideFromWorkspace`** | `boolean` | _Optional_ | Current item will be visible in the default view but not in the Workspace view sidebar. Defaults to `false`
 **`hideFromHomepage`** | `boolean` | _Optional_ | If `true`, item is hidden from the home and minimal views until matched by a search. Still visible in workspace, edit mode and single-section view. Defaults to `false`
 
@@ -334,8 +336,10 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 **`hideForUsers`** | `string[]` | _Optional_ | Current section will be visible to all users, except for those specified in this list
 **`showForUsers`** | `string[]` | _Optional_ | Current section will be hidden from all users, except for those specified in this list
 **`hideForGuests`** | `boolean` | _Optional_ | Current section will be visible for logged in users, but not for guests (see `appConfig.enableGuestAccess`). Defaults to `false`
-**`hideForKeycloakUsers`** | `object`  | _Optional_ | Current section will be visible to all keycloak users, except for those configured via these groups and roles. See `hideForKeycloakUsers`
-**`showForKeycloakUsers`** | `object`  | _Optional_ | Current section will be hidden from all keycloak users, except for those configured via these groups and roles. See `showForKeycloakUsers`
+**`hideForGroups`** | `string[]` | _Optional_ | Current section will be visible to all users, except for those in any of these SSO groups. See [Group and Role Controls](#showforgroups-hideforgroups-showforroles-and-hideforroles)
+**`showForGroups`** | `string[]` | _Optional_ | Current section will be hidden from all users, except for those in one or more of these SSO groups
+**`hideForRoles`** | `string[]` | _Optional_ | Current section will be visible to all users, except for those with any of these SSO roles
+**`showForRoles`** | `string[]` | _Optional_ | Current section will be hidden from all users, except for those with one or more of these SSO roles
 **`hideFromWorkspace`** | `boolean` | _Optional_ | Current section will be visible in the default view but not in the Workspace view sidebar. Defaults to `false`
 
 **[⬆️ Back to Top](#configuring)**
@@ -348,12 +352,29 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 
 **[⬆️ Back to Top](#configuring)**
 
-## `section.displayData.hideForKeycloakUsers`, `section.displayData.showForKeycloakUsers`, `item.displayData.hideForKeycloakUsers` and `item.displayData.showForKeycloakUsers`
+## `showForGroups`, `hideForGroups`, `showForRoles` and `hideForRoles`
+
+When using an SSO provider (Keycloak, or any OIDC provider that includes `groups` / `roles` claims in the id_token), pages, sections and items can be shown or hidden based on the user's groups and roles. Set any of these under the `displayData` of a page, section or item:
 
 **Field** | **Type**   | **Required**| **Description**
 --- |------------| --- | ---
-**`groups`** | `string[]` | _Optional_ | Current Section or Item will be hidden or shown based on the user having any of the groups in this list
-**`roles`** | `string[]` | _Optional_ | Current Section or Item will be hidden or shown based on the user having any of the roles in this list
+**`showForGroups`** | `string[]` | _Optional_ | Hidden from all users, except those in one or more of these groups
+**`hideForGroups`** | `string[]` | _Optional_ | Hidden from users in any of these groups
+**`showForRoles`** | `string[]` | _Optional_ | Hidden from all users, except those with one or more of these roles
+**`hideForRoles`** | `string[]` | _Optional_ | Hidden from users with any of these roles
+
+For example:
+
+```yaml
+sections:
+  - name: Admin Tools
+    displayData:
+      showForGroups: [admins]
+    items:
+      - title: Hidden from interns
+        displayData:
+          hideForGroups: [interns]
+```
 
 **[⬆️ Back to Top](#configuring)**
 

--- a/src/components/LinkItems/Collapsable.vue
+++ b/src/components/LinkItems/Collapsable.vue
@@ -14,8 +14,8 @@
       tabIndex="-1"
     >
     <div class="section-header"
-      @mouseup.right="openContextMenu" @contextmenu.prevent
-      @long-press="openContextMenu" v-longPress="500">
+      @mouseup.right="openRightClickMenu" @contextmenu="preventNativeContextMenu"
+      @long-press="openRightClickMenu" v-longPress="500">
       <label :for="sectionKey" class="collapse-toggle"
         v-tooltip="toggleTooltip()" :aria-label="$t('context-menus.section.expand-collapse')">
         <span class="arrow" aria-hidden="true"></span>
@@ -27,7 +27,7 @@
         v-tooltip="openTooltip()" class="header-action" />
       <EditModeIcon v-if="isEditMode" @click="openEditModal"
         v-tooltip="editTooltip()" class="header-action" />
-      <EllipseIcon @click.prevent.stop="openContextMenu" @contextmenu.prevent
+      <EllipseIcon @click.prevent.stop="openContextMenu" @contextmenu="preventNativeContextMenu"
         v-tooltip="optionsTooltip()" class="header-action" />
     </div>
     <div class="collapsible-content">
@@ -74,6 +74,9 @@ export default {
   computed: {
     isEditMode() {
       return this.$store.state.editMode;
+    },
+    disableContextMenu() {
+      return this.$store.getters.appConfig.disableContextMenu;
     },
     sectionKey() {
       return `collapsible-${this.uniqueKey}`;
@@ -168,6 +171,15 @@ export default {
     },
     openContextMenu(e) {
       this.$emit('openContextMenu', e);
+    },
+    /* Right-click / long-press is skipped when disabled by user */
+    openRightClickMenu(e) {
+      if (this.disableContextMenu) return;
+      this.openContextMenu(e);
+    },
+    /* Prevent the native right-click menu, unless user disabled custom context menus */
+    preventNativeContextMenu(e) {
+      if (!this.disableContextMenu) e.preventDefault();
     },
     navigateToSection() {
       this.$emit('navigateToSection');

--- a/src/components/LinkItems/Item.vue
+++ b/src/components/LinkItems/Item.vue
@@ -2,7 +2,7 @@
   <div :class="`item-wrapper wrap-size-${size} span-${makeColumnCount}`" >
     <a @click="itemClicked"
       @long-press="openContextMenu"
-      @contextmenu.prevent
+      @contextmenu="preventNativeContextMenu"
       @mouseup.right="openContextMenu"
       v-longPress="true"
       :href="effectiveUrl"

--- a/src/components/LinkItems/Item.vue
+++ b/src/components/LinkItems/Item.vue
@@ -4,6 +4,10 @@
       @long-press="openContextMenu"
       @contextmenu="preventNativeContextMenu"
       @mouseup.right="openContextMenu"
+      @mouseenter="startTitleScroll"
+      @mouseleave="endTitleScroll"
+      @focus="startTitleScroll"
+      @blur="endTitleScroll"
       v-longPress="true"
       :href="effectiveUrl"
       :target="anchorTarget"
@@ -15,7 +19,7 @@
       :style="customStyle"
     >
       <!-- Item Text -->
-      <div :class="`tile-title  ${!itemIcon? 'bounce no-icon': ''}`" :id="`tile-${item.id}`" >
+      <div :id="`tile-${item.id}`" :class="`tile-title ${!itemIcon? 'bounce no-icon': ''}`">
         <span ref="titleText" class="text">{{ item.title }}</span>
         <p class="description">{{ item.description }}</p>
       </div>
@@ -143,6 +147,12 @@ export default {
       titleTruncated: false,
     };
   },
+  watch: {
+    /* Watch for when item gets rename, to re-measure it's length check for truncation */
+    'item.title': function titleChanged() {
+      this.$nextTick(this.checkTitleTruncation);
+    },
+  },
   methods: {
     shortUrl(value) {
       if (!value || typeof value !== 'string') {
@@ -182,10 +192,53 @@ export default {
         popperClass: `item-description-tooltip tooltip-is-${this.size}`,
       };
     },
-    /* Show the full title in the tooltip, if it's truncated in the tile */
+    /* Measure whether the title is truncated in its tile */
     checkTitleTruncation() {
       const title = this.$refs.titleText;
       this.titleTruncated = !!title && title.scrollWidth > title.clientWidth;
+    },
+    /* Slowly scroll truncated titles into view, while hovered or focused */
+    startTitleScroll() {
+      const TITLE_SCROLL_SPEED = 90; // Pixels per second for item scroll
+      clearTimeout(this.titleScrollTimer);
+      cancelAnimationFrame(this.titleScrollRaf);
+      if (!this.titleTruncated || !window.matchMedia('(hover: hover)').matches) return;
+      this.titleScrollTimer = setTimeout(() => {
+        const title = this.$refs.titleText;
+        if (!title) return;
+        const target = title.scrollWidth - title.clientWidth;
+        if (target <= title.scrollLeft) return;
+        if (this.reducedMotion()) {
+          title.scrollLeft = target;
+          return;
+        }
+        let start; let from; let duration;
+        const step = (now) => {
+          if (!start) {
+            start = now;
+            from = title.scrollLeft;
+            duration = ((target - from) / TITLE_SCROLL_SPEED) * 1000;
+          }
+          const progress = Math.min((now - start) / duration, 1);
+          title.scrollLeft = from + (target - from) * progress;
+          if (progress < 1) this.titleScrollRaf = requestAnimationFrame(step);
+        };
+        this.titleScrollRaf = requestAnimationFrame(step);
+      }, 300);
+    },
+    /* Scroll the title back, unless the item is still hovered or focused */
+    endTitleScroll(event) {
+      const link = event?.currentTarget;
+      if (link && (link.matches(':hover') || link === document.activeElement)) return;
+      clearTimeout(this.titleScrollTimer);
+      cancelAnimationFrame(this.titleScrollRaf);
+      const title = this.$refs.titleText;
+      if (title && title.scrollLeft > 0) {
+        title.scrollTo({ left: 0, behavior: this.reducedMotion() ? 'auto' : 'smooth' });
+      }
+    },
+    reducedMotion() {
+      return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     },
     openItemSettings() {
       this.editMenuOpen = true;
@@ -239,6 +292,8 @@ export default {
     if (this.pingIntervalId) clearInterval(this.pingIntervalId);
     if (this.intervalId) clearInterval(this.intervalId);
     if (this.titleObserver) this.titleObserver.disconnect();
+    clearTimeout(this.titleScrollTimer);
+    cancelAnimationFrame(this.titleScrollRaf);
   },
 };
 </script>
@@ -346,14 +401,9 @@ export default {
     display: block;
   }
 
-  /* Trigger text-marquee for text that doesn't fit */
-  .tile-title.is-overflowing{
-    .overflow-dots {
-      opacity: 0;
-    }
-    span.text {
-      transform: translateX(calc(100px - 100%));
-    }
+  /* Hide the ellipsis while a truncated title is scrolled into view */
+  .tile-title span.text {
+    text-overflow: clip;
   }
 
   /* Apply transformation of icons on hover */

--- a/src/components/LinkItems/Item.vue
+++ b/src/components/LinkItems/Item.vue
@@ -16,7 +16,7 @@
     >
       <!-- Item Text -->
       <div :class="`tile-title  ${!itemIcon? 'bounce no-icon': ''}`" :id="`tile-${item.id}`" >
-        <span class="text">{{ item.title }}</span>
+        <span ref="titleText" class="text">{{ item.title }}</span>
         <p class="description">{{ item.description }}</p>
       </div>
       <!-- Item Icon -->
@@ -140,6 +140,7 @@ export default {
   data() {
     return {
       editMenuOpen: false,
+      titleTruncated: false,
     };
   },
   methods: {
@@ -163,20 +164,28 @@ export default {
     },
     /* Returns configuration object for the tooltip */
     getTooltipOptions() {
-      if (!this.item.description && !this.item.provider) return {}; // If no description, then skip
-      const description = this.item.description || '';
-      const providerText = this.item.provider ? `<b>Provider</b>: ${this.item.provider}` : '';
-      const lb1 = description && providerText ? '<br>' : '';
-      const hotkeyText = this.item.hotkey ? `<br>Press '${this.item.hotkey}' to launch` : '';
-      const tooltipText = providerText + lb1 + description + hotkeyText;
+      const {
+        title, description, provider, hotkey,
+      } = this.item;
+      if (!description && !provider && !this.titleTruncated) return {}; // Nothing to show
+      const parts = [];
+      if (this.titleTruncated) parts.push(`<b>${title}</b>`);
+      if (provider) parts.push(`<b>Provider</b>: ${provider}`);
+      if (description) parts.push(description);
+      if (hotkey) parts.push(`Press '${hotkey}' to launch`);
       const editText = this.$t('interactive-editor.edit-section.edit-tooltip');
       return {
-        content: (this.isEditMode ? editText : tooltipText),
+        content: (this.isEditMode ? editText : parts.join('<br>')),
         html: true,
         placement: this.statusResponse || this.pingResponse ? 'left' : 'auto',
         delay: { show: 600, hide: 200 },
         popperClass: `item-description-tooltip tooltip-is-${this.size}`,
       };
+    },
+    /* Show the full title in the tooltip, if it's truncated in the tile */
+    checkTitleTruncation() {
+      const title = this.$refs.titleText;
+      this.titleTruncated = !!title && title.scrollWidth > title.clientWidth;
     },
     openItemSettings() {
       this.editMenuOpen = true;
@@ -202,6 +211,12 @@ export default {
     },
   },
   mounted() {
+    // Watch for size changes, to know when title no longer fits
+    if (typeof ResizeObserver !== 'undefined') {
+      this.titleObserver = new ResizeObserver(this.checkTitleTruncation);
+      this.titleObserver.observe(this.$refs.titleText);
+    }
+    if (document.fonts) document.fonts.ready.then(this.checkTitleTruncation);
     // If ping checking is enabled, then check ping status
     if (this.isPingCheckEnabled) {
       this.checkPingStatus();
@@ -223,6 +238,7 @@ export default {
     // Stop periodic ping-check and status-check when item is destroyed (e.g. navigating in multi-page setup)
     if (this.pingIntervalId) clearInterval(this.pingIntervalId);
     if (this.intervalId) clearInterval(this.intervalId);
+    if (this.titleObserver) this.titleObserver.disconnect();
   },
 };
 </script>

--- a/src/components/LinkItems/ItemContextMenu.vue
+++ b/src/components/LinkItems/ItemContextMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <transition name="slide">
-    <div class="context-menu" v-if="show && !isMenuDisabled"
+    <div class="context-menu" v-if="show"
       :style="posX && posY ? `top:${posY}px;left:${posX}px;` : ''">
       <!-- Open Options -->
       <ul class="menu-section">
@@ -87,9 +87,6 @@ export default {
   },
   emits: ['launchItem', 'openItemSettings', 'openMoveItemMenu', 'openDeleteItem'],
   computed: {
-    isMenuDisabled() {
-      return !!this.$store.getters.appConfig.disableContextMenu;
-    },
     isEditMode() {
       return this.$store.state.editMode;
     },

--- a/src/components/LinkItems/SectionContextMenu.vue
+++ b/src/components/LinkItems/SectionContextMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <transition name="slide">
-    <div class="context-menu" v-if="show && !isMenuDisabled"
+    <div class="context-menu" v-if="show"
       :style="posX && posY ? calcPosition() : ''">
       <!-- Open Options -->
       <ul class="menu-section">
@@ -50,9 +50,6 @@ export default {
   },
   emits: ['navigateToSection', 'openEditSection', 'expandCollapseSection', 'removeSection'],
   computed: {
-    isMenuDisabled() {
-      return !!this.$store.getters.appConfig.disableContextMenu;
-    },
     isEditMode() {
       return this.$store.state.editMode;
     },

--- a/src/components/LinkItems/SubItem.vue
+++ b/src/components/LinkItems/SubItem.vue
@@ -1,7 +1,7 @@
 <template ref="container">
   <div class="sub-item-wrapper">
     <a @click="itemClicked"
-      @contextmenu.prevent
+      @contextmenu="preventNativeContextMenu"
       @long-press="openContextMenu"
       @mouseup.right="openContextMenu"
       v-longPress="true"

--- a/src/mixins/ItemMixin.js
+++ b/src/mixins/ItemMixin.js
@@ -350,6 +350,7 @@ export default {
     },
     /* Open custom context menu, and set position */
     openContextMenu(e) {
+      if (this.appConfig.disableContextMenu) return; // Right-click menu disabled in config
       this.contextMenuOpen = !this.contextMenuOpen;
       if (e && window) {
         // Calculate placement based on cursor and scroll position
@@ -362,6 +363,10 @@ export default {
     /* Closes the context menu, called when user clicks literally anywhere */
     closeContextMenu() {
       this.contextMenuOpen = false;
+    },
+    /* Suppress the native right-click menu, unless the custom menu is disabled */
+    preventNativeContextMenu(e) {
+      if (!this.appConfig.disableContextMenu) e.preventDefault();
     },
     /* Copies a string to the users clipboard / shows error if not possible  */
     copyToClipboard(content) {

--- a/src/styles/themes/_material.scss
+++ b/src/styles/themes/_material.scss
@@ -206,9 +206,6 @@ html[data-theme='material'], html[data-theme='material-dark'] {
     div {
       transition: all 0.2s linear 0s;
     }
-    .overflow-dots {
-      display: none;
-    }
     &:before {
       content: "\f054";
       font-family: FontAwesome;

--- a/src/utils/IsVisibleToUser.js
+++ b/src/utils/IsVisibleToUser.js
@@ -1,6 +1,7 @@
 /**
  * A helper function that filters all the sections or an item based on current users permissions
  * Checks each sections displayData for hideForUsers, showForUsers and hideForGuests
+ * as well as the SSO group/role rules: show/hideForGroups and show/hideForRoles
  * Returns an array of sections that the current logged in user has permissions for
  */
 
@@ -44,27 +45,31 @@ export const isVisibleToUser = (displayData, currentUser, isGuest) => {
     if (showForUsers.length < 1) return true;
     return determineVisibility(showForUsers, cUsername);
   };
-  const getKeycloakInfo = () => {
+  const getUserInfo = () => {
     try { return JSON.parse(localStorage.getItem(localStorageKeys.KEYCLOAK_INFO) || '{}'); }
     catch { return {}; }
   };
-  const checkKeycloakVisibility = () => {
-    if (!displayData.hideForKeycloakUsers) return true;
+  /* show/hideForKeycloakUsers are the legacy names for these rules, still silently supported */
+  const pickRule = (newList, legacyList) => (
+    (newList && newList.length > 0) ? newList : (legacyList || [])
+  );
+  const checkGroupRoleVisibility = () => {
+    const legacy = displayData.hideForKeycloakUsers || {};
+    const hideForGroups = pickRule(displayData.hideForGroups, legacy.groups);
+    const hideForRoles = pickRule(displayData.hideForRoles, legacy.roles);
+    if (hideForGroups.length < 1 && hideForRoles.length < 1) return true;
 
-    const { groups, roles } = getKeycloakInfo();
-    const hideForGroups = displayData.hideForKeycloakUsers.groups || [];
-    const hideForRoles = displayData.hideForKeycloakUsers.roles || [];
-
+    const { groups, roles } = getUserInfo();
     return !(determineIntersection(hideForRoles, roles)
       || determineIntersection(hideForGroups, groups));
   };
-  const checkKeycloakHiddenability = () => {
-    if (!displayData.showForKeycloakUsers) return true;
+  const checkGroupRoleHiddenability = () => {
+    const legacy = displayData.showForKeycloakUsers;
+    const showForGroups = pickRule(displayData.showForGroups, legacy && legacy.groups);
+    const showForRoles = pickRule(displayData.showForRoles, legacy && legacy.roles);
+    if (!legacy && showForGroups.length < 1 && showForRoles.length < 1) return true;
 
-    const { groups, roles } = getKeycloakInfo();
-    const showForGroups = displayData.showForKeycloakUsers.groups || [];
-    const showForRoles = displayData.showForKeycloakUsers.roles || [];
-
+    const { groups, roles } = getUserInfo();
     return determineIntersection(showForRoles, roles)
       || determineIntersection(showForGroups, groups);
   };
@@ -76,8 +81,8 @@ export const isVisibleToUser = (displayData, currentUser, isGuest) => {
   return checkVisibility()
     && checkHiddenability()
     && checkIfHideForGuest()
-    && checkKeycloakVisibility()
-    && checkKeycloakHiddenability();
+    && checkGroupRoleVisibility()
+    && checkGroupRoleHiddenability();
 };
 
 export default isVisibleToUser;

--- a/src/utils/config/ConfigSchema.json
+++ b/src/utils/config/ConfigSchema.json
@@ -55,54 +55,78 @@
                 "default": false,
                 "description": "If set to true, page will be visible for logged in users, but not for guests"
               },
+              "showForGroups": {
+                "title": "Show for Groups",
+                "type": "array",
+                "description": "Page will be hidden from all users except those with one or more of these SSO groups",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the group that will be able to view this page"
+                }
+              },
+              "hideForGroups": {
+                "title": "Hide for Groups",
+                "type": "array",
+                "description": "Page will be hidden from users with any of these SSO groups",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the group that will not be able to view this page"
+                }
+              },
+              "showForRoles": {
+                "title": "Show for Roles",
+                "type": "array",
+                "description": "Page will be hidden from all users except those with one or more of these SSO roles",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the role that will be able to view this page"
+                }
+              },
+              "hideForRoles": {
+                "title": "Hide for Roles",
+                "type": "array",
+                "description": "Page will be hidden from users with any of these SSO roles",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the role that will not be able to view this page"
+                }
+              },
               "showForKeycloakUsers": {
-                "title": "Show for select Keycloak groups or roles",
+                "title": "Show for Groups/Roles (legacy)",
                 "type": "object",
-                "description": "Configure the Keycloak groups or roles that will have access to this page",
+                "description": "Legacy form of showForGroups and showForRoles",
                 "additionalProperties": false,
                 "properties": {
                   "groups": {
-                    "title": "Show for Groups",
                     "type": "array",
-                    "description": "Page will be hidden from all users except those with one or more of these groups",
                     "items": {
-                      "type": "string",
-                      "description": "Name of the group that will be able to view this page"
+                      "type": "string"
                     }
                   },
                   "roles": {
-                    "title": "Show for Roles",
                     "type": "array",
-                    "description": "Page will be hidden from all users except those with one or more of these roles",
                     "items": {
-                      "type": "string",
-                      "description": "Name of the role that will be able to view this page"
+                      "type": "string"
                     }
                   }
                 }
               },
               "hideForKeycloakUsers": {
-                "title": "Hide for select Keycloak groups or roles",
+                "title": "Hide for Groups/Roles (legacy)",
                 "type": "object",
-                "description": "Configure the Keycloak groups or roles that will not have access to this page",
+                "description": "Legacy form of hideForGroups and hideForRoles",
                 "additionalProperties": false,
                 "properties": {
                   "groups": {
-                    "title": "Hide for Groups",
                     "type": "array",
-                    "description": "Page will be hidden from users with any of these groups",
                     "items": {
-                      "type": "string",
-                      "description": "name of the group that will not be able to view this page"
+                      "type": "string"
                     }
                   },
                   "roles": {
-                    "title": "Hide for Roles",
                     "type": "array",
-                    "description": "Page will be hidden from users with any of roles",
                     "items": {
-                      "type": "string",
-                      "description": "name of the role that will not be able to view this page"
+                      "type": "string"
                     }
                   }
                 }
@@ -985,54 +1009,78 @@
                 "default": false,
                 "description": "If set to true, section will be visible for logged in users, but not for guests"
               },
+              "showForGroups": {
+                "title": "Show for Groups",
+                "type": "array",
+                "description": "Section will be hidden from all users except those with one or more of these SSO groups",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the group that will be able to view this section"
+                }
+              },
+              "hideForGroups": {
+                "title": "Hide for Groups",
+                "type": "array",
+                "description": "Section will be hidden from users with any of these SSO groups",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the group that will not be able to view this section"
+                }
+              },
+              "showForRoles": {
+                "title": "Show for Roles",
+                "type": "array",
+                "description": "Section will be hidden from all users except those with one or more of these SSO roles",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the role that will be able to view this section"
+                }
+              },
+              "hideForRoles": {
+                "title": "Hide for Roles",
+                "type": "array",
+                "description": "Section will be hidden from users with any of these SSO roles",
+                "items": {
+                  "type": "string",
+                  "description": "Name of the role that will not be able to view this section"
+                }
+              },
               "showForKeycloakUsers": {
-                "title": "Show for select Keycloak groups or roles",
+                "title": "Show for Groups/Roles (legacy)",
                 "type": "object",
-                "description": "Configure the Keycloak groups or roles that will have access to this section",
+                "description": "Legacy form of showForGroups and showForRoles",
                 "additionalProperties": false,
                 "properties": {
                   "groups": {
-                    "title": "Show for Groups",
                     "type": "array",
-                    "description": "Section will be hidden from all users except those with one or more of these groups",
                     "items": {
-                      "type": "string",
-                      "description": "Name of the group that will be able to view this section"
+                      "type": "string"
                     }
                   },
                   "roles": {
-                    "title": "Show for Roles",
                     "type": "array",
-                    "description": "Section will be hidden from all users except those with one or more of these roles",
                     "items": {
-                      "type": "string",
-                      "description": "Name of the role that will be able to view this section"
+                      "type": "string"
                     }
                   }
                 }
               },
               "hideForKeycloakUsers": {
-                "title": "Hide for select Keycloak groups or roles",
+                "title": "Hide for Groups/Roles (legacy)",
                 "type": "object",
-                "description": "Configure the Keycloak groups or roles that will not have access to this section",
+                "description": "Legacy form of hideForGroups and hideForRoles",
                 "additionalProperties": false,
                 "properties": {
                   "groups": {
-                    "title": "Hide for Groups",
                     "type": "array",
-                    "description": "Section will be hidden from users with any of these groups",
                     "items": {
-                      "type": "string",
-                      "description": "name of the group that will not be able to view this section"
+                      "type": "string"
                     }
                   },
                   "roles": {
-                    "title": "Hide for Roles",
                     "type": "array",
-                    "description": "Section will be hidden from users with any of roles",
                     "items": {
-                      "type": "string",
-                      "description": "name of the role that will not be able to view this section"
+                      "type": "string"
                     }
                   }
                 }
@@ -1125,54 +1173,78 @@
                       "default": false,
                       "description": "If set to true, item will be visible for logged in users, but not for guests"
                     },
+                    "showForGroups": {
+                      "title": "Show for Groups",
+                      "type": "array",
+                      "description": "Item will be hidden from all users except those with one or more of these SSO groups",
+                      "items": {
+                        "type": "string",
+                        "description": "Name of the group that will be able to view this item"
+                      }
+                    },
+                    "hideForGroups": {
+                      "title": "Hide for Groups",
+                      "type": "array",
+                      "description": "Item will be hidden from users with any of these SSO groups",
+                      "items": {
+                        "type": "string",
+                        "description": "Name of the group that will not be able to view this item"
+                      }
+                    },
+                    "showForRoles": {
+                      "title": "Show for Roles",
+                      "type": "array",
+                      "description": "Item will be hidden from all users except those with one or more of these SSO roles",
+                      "items": {
+                        "type": "string",
+                        "description": "Name of the role that will be able to view this item"
+                      }
+                    },
+                    "hideForRoles": {
+                      "title": "Hide for Roles",
+                      "type": "array",
+                      "description": "Item will be hidden from users with any of these SSO roles",
+                      "items": {
+                        "type": "string",
+                        "description": "Name of the role that will not be able to view this item"
+                      }
+                    },
                     "showForKeycloakUsers": {
-                      "title": "Show for select Keycloak groups or roles",
+                      "title": "Show for Groups/Roles (legacy)",
                       "type": "object",
-                      "description": "Configure the Keycloak groups or roles that will have access to this item",
+                      "description": "Legacy form of showForGroups and showForRoles",
                       "additionalProperties": false,
                       "properties": {
                         "groups": {
-                          "title": "Show for Groups",
                           "type": "array",
-                          "description": "Item will be hidden from all users except those with one or more of these groups",
                           "items": {
-                            "type": "string",
-                            "description": "Name of the group that will be able to view this item"
+                            "type": "string"
                           }
                         },
                         "roles": {
-                          "title": "Show for Roles",
                           "type": "array",
-                          "description": "Item will be hidden from all users except those with one or more of these roles",
                           "items": {
-                            "type": "string",
-                            "description": "Name of the role that will be able to view this item"
+                            "type": "string"
                           }
                         }
                       }
                     },
                     "hideForKeycloakUsers": {
-                      "title": "Hide for select Keycloak groups or roles",
+                      "title": "Hide for Groups/Roles (legacy)",
                       "type": "object",
-                      "description": "Configure the Keycloak groups or roles that will not have access to this item",
+                      "description": "Legacy form of hideForGroups and hideForRoles",
                       "additionalProperties": false,
                       "properties": {
                         "groups": {
-                          "title": "Hide for Groups",
                           "type": "array",
-                          "description": "Item will be hidden from users with any of these groups",
                           "items": {
-                            "type": "string",
-                            "description": "name of the group that will not be able to view this item"
+                            "type": "string"
                           }
                         },
                         "roles": {
-                          "title": "Hide for Roles",
                           "type": "array",
-                          "description": "Item will be hidden from users with any of roles",
                           "items": {
-                            "type": "string",
-                            "description": "name of the role that will not be able to view this item"
+                            "type": "string"
                           }
                         }
                       }


### PR DESCRIPTION
### Category
Bugfix

### Overview

- When `appConfig.disableContextMenu` is set, this should only disable the right-click context menu, not left-click
  - Fixes #2255
- If an item has long title, title is included in tooltip by default
  - Fixes #2256
- Does
  - Fixes #2257

### Issue Number
#2255, #2256, #2257

### Additional Info

For the schema change, the old keys will continue to work just fine.
But are now undocumented, and the new keys are much cleaner.

The following schema rename happened:

| Legacy key | New key |
|---|---|
| `showForKeycloakUsers.groups` | `showForGroups` |
| `showForKeycloakUsers.roles`  | `showForRoles`  |
| `hideForKeycloakUsers.groups` | `hideForGroups` |
| `hideForKeycloakUsers.roles`  | `hideForRoles`  |


So, this will then look like this:

#### Old version

```yaml
displayData:
  showForKeycloakUsers:
    groups: [admins]
    roles: [canViewDevResources]
```

#### New version
```yaml
displayData:
  showForGroups: [admins]
  showForRoles: [canViewDevResources]
```
