### PR TITLE
🐛 Fix status & ping checks losing query params (path-relative req.url)

### DIFF
--- a/services/ping-check.js
+++ b/services/ping-check.js
@@ -19,8 +19,11 @@ module.exports = (paramStr, render) => {
   if (!paramStr || !paramStr.includes('=')) {
     immediateError(render);
   } else {
-    // Prepare the parameters, which are got from the URL
-    const params = new URLSearchParams(paramStr);
+    // Prepare the parameters, which are got from the URL. paramStr is either a bare
+    // query string or Express's mount-relative req.url ('/?host=...') - drop
+    // anything before the '?' or the first key is mis-parsed
+    const queryStr = paramStr.includes('?') ? paramStr.slice(paramStr.indexOf('?') + 1) : paramStr;
+    const params = new URLSearchParams(queryStr);
     const host = decodeURIComponent(params.get('host'));
     const count = Number(decodeURIComponent(params.get('count'))) || 2;
     const timeout = Number(decodeURIComponent(params.get('timeout'))) || 2000;

--- a/services/status-check.js
+++ b/services/status-check.js
@@ -102,8 +102,11 @@ module.exports = (paramStr, render) => {
   if (!paramStr || !paramStr.includes('=')) {
     immediateError(render);
   } else {
-    // Prepare the parameters, which are got from the URL
-    const params = new URLSearchParams(paramStr);
+    // Prepare the parameters, which are got from the URL. paramStr is either a bare
+    // query string (e.g. Netlify's rawQuery) or Express's mount-relative req.url
+    // ('/?url=...') - drop anything before the '?' or the first key is mis-parsed
+    const queryStr = paramStr.includes('?') ? paramStr.slice(paramStr.indexOf('?') + 1) : paramStr;
+    const params = new URLSearchParams(queryStr);
     const url = decodeURIComponent(params.get('url'));
     const acceptCodes = decodeURIComponent(params.get('acceptCodes'));
     const maxRedirects = decodeURIComponent(params.get('maxRedirects')) || 0;

--- a/tests/server/status-check.test.js
+++ b/tests/server/status-check.test.js
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import fs from 'fs';
+import http from 'http';
 import os from 'os';
 import path from 'path';
 import { describe, it, expect } from 'vitest';
@@ -27,6 +28,19 @@ describe('Status check', () => {
     const res = await request(app).post('/status-check/?&url=x');
     expect(res.status).toBeLessThan(500);
   });
+
+  it('resolves the url param when invoked via the mounted route', async () => {
+    // The route handler passes Express's mount-relative req.url ('/?url=...'),
+    // so the url param must still be found despite the leading path segment
+    const target = http.createServer((req, res) => { res.end('ok'); });
+    await new Promise((resolve) => { target.listen(0, '127.0.0.1', resolve); });
+    const targetUrl = encodeURIComponent(`http://127.0.0.1:${target.address().port}/`);
+    const res = await request(app).get(`/status-check/?url=${targetUrl}`);
+    await new Promise((resolve) => { target.close(resolve); });
+    const body = JSON.parse(res.text);
+    expect(body.successStatus).toBe(true);
+    expect(body.statusCode).toBe(200);
+  });
 });
 
 describe('Ping check', () => {
@@ -45,5 +59,12 @@ describe('Ping check', () => {
   it('ignores POST requests', async () => {
     const res = await request(app).post('/ping-check/?&host=localhost');
     expect(res.status).toBeLessThan(500);
+  });
+
+  it('resolves the host param when invoked via the mounted route', async () => {
+    // Same mount-relative req.url shape as the status check above
+    const res = await request(app).get('/ping-check/?host=127.0.0.1&count=1');
+    const body = JSON.parse(res.text);
+    expect(body.successStatus).toBe(true);
   });
 });


### PR DESCRIPTION
### Category
Bugfix

### Overview
Every status check (and ping check) fails on stock 4.4.x with `❌ Service Unavailable: Server resulted in a fatal error`, even when the target service is up. The container still reports `healthy` and the UI serves fine, so the breakage is invisible until you notice every status dot is red.

**Root cause:** the Express handlers in `services/app.js` pass the *mount-relative* `req.url` (e.g. `/?url=https%3A%2F%2Fexample.com`) into `statusCheck()` / `pingCheck()`. `URLSearchParams` only understands bare query strings, so it keys the first pair as `/?url` instead of `url`, `params.get('url')` returns `null`, and the check errors out. (`decodeURIComponent(null)` then yields the string `"null"`, which also slips past the `!url` guard.)

**Fix:** in both modules, slice everything before the first `?` before handing the string to `URLSearchParams`. Bare-query input — `event.rawQuery` from the Netlify wrapper (`services/serverless-functions/cloud-status-check.js`) and the existing unit tests — is unaffected.

Repro on current master:
```
curl 'http://localhost:8080/status-check/?url=https%3A%2F%2Fexample.com'
# → {"successStatus":false,"message":"❌ Service Unavailable: Server resulted in a fatal error "}
```

### Issue Number
N/A — I couldn't find an existing issue for this.

### Additional Info
- **Tests:** added mounted-route regression tests for both endpoints, using supertest against the real app so the request goes through the actual Express mount (the existing tests pass bare/error-path inputs, which is why this slipped through CI). The status-check test spins up a local `http` listener, so no external network is needed. Both fail on master and pass with this change.
- **Schema / UI changes:** none.
- **Breaking changes:** none — parsing of bare query strings is unchanged.
- **Field-tested:** this exact fix has been running in production on my self-hosted instance since 4.4.5 (as a bind-mounted override of `status-check.js`) — it's what restored all our status checks.
- **AI disclaimer:** this PR was prepared by Claude (an AI assistant) operating on the account owner's machine at their direction; the change mirrors the patch we already run in production, and the account owner reviews and takes responsibility for the contribution.