### PR TITLE
Upgrade Docker to node 24, drop armv7

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@
 # - On weekly cron, rebuilds :latest from master for upstream patches
 #
 # The workflow will:
-# - Builds multi-arch (amd64, arm64, armv7) in parallel on native runners
+# - Builds multi-arch (amd64, arm64) in parallel on native runners
 # - Trivy scans + reports security issues, and fails cron on CRITICAL CVEs
 # - Publishes to GHCR, and to Docker Hub if creds are configured
 # - Attests both the build provenance and SBOM and publishes to GHCR
@@ -58,9 +58,6 @@ jobs:
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
             arch: arm64
-          - platform: linux/arm/v7
-            runner: ubuntu-latest
-            arch: armv7
     runs-on: ${{ matrix.runner }}
     steps:
       - name: 🛎️ Checkout
@@ -85,12 +82,6 @@ jobs:
           fi
           echo "value=$v" >> "$GITHUB_OUTPUT"
           echo "revision=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: 🔧 Set up QEMU
-        if: matrix.arch == 'armv7'
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: linux/arm/v7
 
       - name: 🔧 Set up Buildx
         uses: docker/setup-buildx-action@v4
@@ -333,7 +324,7 @@ jobs:
             echo
             echo "| Arch | Size | Layers | Digest |"
             echo "|---|---|---|---|"
-            for arch in amd64 arm64 armv7; do
+            for arch in amd64 arm64; do
               f="$DIGESTS_DIR/$arch"
               [ -f "$f" ] || continue
               digest=$(cat "$f")

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS build
+FROM node:24-alpine AS build
 
 WORKDIR /app
 
@@ -8,7 +8,7 @@ RUN yarn install --frozen-lockfile --network-timeout 600000
 COPY . .
 RUN yarn build
 
-FROM node:22-alpine AS deps
+FROM node:24-alpine AS deps
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ COPY package.json yarn.lock ./
 RUN yarn install --production --frozen-lockfile --network-timeout 600000 \
   && yarn cache clean
 
-FROM node:22-alpine
+FROM node:24-alpine
 
 ARG VERSION=dev
 ARG REVISION

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ It can also hold sub-config files, item icons, fonts, custom CSS, or anything el
 Dashy is distributed both on [DockerHub](https://hub.docker.com/r/lissy93/dashy) (`lissy93/dashy`) and [GHCR](https://github.com/lissy93/dashy/pkgs/container/dashy) (`ghcr.io/lissy93/dashy`).
 
 You can either use `:latest` or pin to specific versions (like `4.0.0`).
-All images are multi-arch (works on amd64, arm64, and arm/v7).
+All images are multi-arch (works on amd64 and arm64).
 
 > Once you've got Dashy running, see [the docs](https://dashy.to/docs/) for configuration references and usage guides.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -66,7 +66,7 @@ Once you've got Dashy up and running, you'll want to configure it with your own 
 ## Requirements
 
 ### Architecture
-The pre-built Docker image runs on `amd64`, `arm64` and `armv7` (`armv6` is not supported).
+The pre-built Docker image runs on `amd64` and `arm64` (32-bit `armv7` and `armv6` are not supported). If you need armv7, pin an older release such as `lissy93/dashy:4.4.10`.
 
 ### System Resources
 - CPU: any single core, x86-64 or ARM

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,13 +1,13 @@
 # Docker
 
 Docker is the recommended way of running Dashy.
-We have light-weight multi-arch (amd64, arm64 and arm/v7) images published to DockerHub ([`lissy93/dashy`](https://hub.docker.com/r/lissy93/dashy)) and GHCR ([`ghcr.io/lissy93/dashy`](https://github.com/lissy93/dashy/pkgs/container/dashy)) with full semver tags.
+We have light-weight multi-arch (amd64 and arm64) images published to DockerHub ([`lissy93/dashy`](https://hub.docker.com/r/lissy93/dashy)) and GHCR ([`ghcr.io/lissy93/dashy`](https://github.com/lissy93/dashy/pkgs/container/dashy)) with full semver tags.
 
 The container runs on port 8080 (can be overridden with PORT). Your config (`conf.yml`) and any other assets (icons, styles, themes, fonts, scripts, etc) will live in `/app/user-data` in the container.
 
 **Container Info**: [
-![Docker Supported Architecture](https://img.shields.io/badge/Architectures-amd64%20|%20arm32v7%20|%20arm64v8-6ba6e5)
-![Docker Base Image](https://img.shields.io/badge/Base_Image-node%3A22--alpine-6ba6e5)
+![Docker Supported Architecture](https://img.shields.io/badge/Architectures-amd64%20|%20arm64v8-6ba6e5)
+![Docker Base Image](https://img.shields.io/badge/Base_Image-node%3A24--alpine-6ba6e5)
 ![Docker Hosted on](https://img.shields.io/badge/Hosted_on-DockerHub%20%26%20GHCR-6ba6e5)
 ](https://hub.docker.com/r/lissy93/dashy)<br>
 **Status**:
@@ -45,7 +45,7 @@ Explanation of the above options:
 
 Notes:
 - Dashy is also available through GHCR: `docker pull ghcr.io/lissy93/dashy:latest`
-- The image is multi-arch, so the same tag works on amd64, arm64, and arm/v7 (Raspberry Pi 2+). Docker selects the right variant for your host automatically.
+- The image is multi-arch, so the same tag works on amd64 and arm64. Docker selects the right variant for your host automatically.
 - Published tags: `latest`, exact versions (e.g. `4.3.9`), and rolling minor/major tags (`4.3`, `4.x`). See [available tags](https://hub.docker.com/r/lissy93/dashy/tags)
 - The container runs as the `node` user (uid 1000). If your mounted `user-data` is owned by a different uid, you may hit permission errors. Fix this with `chown`, or run with `--user "$(id -u):$(id -g)"`
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -30,7 +30,7 @@ Your dashboard should now be up and running at `http://localhost:8080` (or your 
 
 Dashy is also available via GHCR (`ghcr.io/lissy93/dashy`).<br>
 You can either use `:latest` or pin to specific versions (like `4.0.0`).<br>
-All images are multi-arch (works on amd64, arm64, and arm/v7).<br>
+All images are multi-arch (works on amd64 and arm64).<br>
 To use with compose, see our sample [`docker-compose.yml`](https://github.com/lissy93/dashy/blob/master/docker-compose.yml).<br>
 Once up and running, check the [configuring reference](https://dashy.to/docs/configuring) and [other docs](https://dashy.to/docs).<br>
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -93,7 +93,7 @@ This runs a series of checks against the PR. A path-filter step first works out 
 
 > The Docker workflow builds and publishes the Docker image.
 
-Uses our [`Dockerfile`](https://github.com/lissy93/dashy/blob/master/Dockerfile). This is a multi-arch (amd64, arm64, armv7) with each run as a matrix. The image is published to both GHCR ([`ghcr.io/lissy93/dashy`](https://github.com/lissy93/dashy/pkgs/container/dashy)) and DockerHub ([`lissy93/dashy`](https://hub.docker.com/r/lissy93/dashy/)). It also runs a trivy security scan, and if critical issues are present the scheduled job will fail, and results published under the Security tab. The job also attests both the build provenance and SBOM, which are published alongside the image. The Docker tags are computed from the values in the Dockerfile.
+Uses our [`Dockerfile`](https://github.com/lissy93/dashy/blob/master/Dockerfile). This is a multi-arch (amd64, arm64) build, with each run as a matrix. The image is published to both GHCR ([`ghcr.io/lissy93/dashy`](https://github.com/lissy93/dashy/pkgs/container/dashy)) and DockerHub ([`lissy93/dashy`](https://hub.docker.com/r/lissy93/dashy/)). It also runs a trivy security scan, and if critical issues are present the scheduled job will fail, and results published under the Security tab. The job also attests both the build provenance and SBOM, which are published alongside the image. The Docker tags are computed from the values in the Dockerfile.
 
 | | |
 |---|---|

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -62,6 +62,7 @@
   - [Mount Type Mismatch](#mount-type-mismatch)
   - [DockerHub toomanyrequests](#dockerhub-toomanyrequests)
   - [Old image tags fail to pull](#old-image-tags-fail-to-pull)
+  - [no matching manifest for linux/arm/v7 (32-bit ARM)](#no-matching-manifest-for-linuxarmv7)
   - [Healthcheck Failing in Docker](#healthcheck-failing-in-docker)
   - [Docker Login Fails on Ubuntu](#docker-login-fails-on-ubuntu)
 - [Styles and Assets not Updating](#styles-and-assets-not-updating)
@@ -635,7 +636,21 @@ image: lissy93/dashy:latest
 
 Docker fetches the right architecture for your host automatically. To pin a version, use a semver tag, e.g. `lissy93/dashy:3.2.14`.
 
-32-bit `armv7` (Raspberry Pi 2, or a Pi running a 32-bit OS) is no longer supported. If you need it, pin the last armv7 image with `image: lissy93/dashy:4.4.10`.
+### `no matching manifest for linux/arm/v7`
+
+Dashy's Docker image is built for `amd64` and `arm64` only (`4.4.10` was the last release to include a 32-bit `armv7` build). On a 32-bit ARM host (Raspberry Pi 2, or a Pi 3/4 running a 32-bit OS), `docker pull`, `docker run` or `docker compose up` fails with:
+
+```
+no matching manifest for linux/arm/v7 in the manifest list entries
+```
+
+(Pi 1 and Pi Zero report `linux/arm/v6`.) 32-bit ARM was dropped because the build toolchain (Rolldown) no longer ships a 32-bit ARM binary, and Node 24 dropped 32-bit ARM too. To fix it:
+
+- **Recommended:** reinstall your host OS as 64-bit (`arm64`). The Raspberry Pi 3 and newer all support it, and Dashy's `arm64` image is then selected automatically.
+- **Stay on 32-bit:** pin the last image that shipped `armv7`:
+  ```yaml
+  image: lissy93/dashy:4.4.10
+  ```
 
 ### Healthcheck Failing in Docker
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,6 +105,8 @@ There should be an error message, explaining the reason the config save failed. 
 
 The container can't write to your `conf.yml` or its directory. Almost always an ownership mismatch: the host directory belongs to a different uid than the one Dashy runs as inside the container. Less commonly a read-only mount or an over-strict file mode.
 
+The `COPY --chown=node:node` in the Dockerfile only sets ownership *inside the image*. When you bind-mount `user-data`, your host directory takes over that path entirely, so its ownership is what counts - not the image's.
+
 Dashy runs as UID=1000 (default non-root node user). You can see this by running `docker exec -it dashy id`. Then, check who owns the user-data directory, with: `docker exec -it dashy ls -la /app/user-data` - if it's not `1000` then that's the issue. And the solution is just to run `sudo chown -R 1000:1000 /path/to/your/user-data` to set the right owner.
 
 Fixes:
@@ -625,13 +627,15 @@ You can [check your rate limit status](https://www.docker.com/blog/checking-your
 
 If `docker pull` returns `manifest unknown` or `manifest for lissy93/dashy:arm32v7 not found`, the cause is a stale architecture-specific tag in your compose file or run command. Tags like `:arm32v7`, `:arm64v8`, and `:multi-arch` are no longer published.
 
-The `:latest` tag is now multi-arch and works on amd64, arm64, and arm/v7 (Raspberry Pi 2 and up) without you having to pick a variant. Just use:
+The `:latest` tag is multi-arch and works on amd64 and arm64 without you having to pick a variant. Just use:
 
 ```yaml
 image: lissy93/dashy:latest
 ```
 
 Docker fetches the right architecture for your host automatically. To pin a version, use a semver tag, e.g. `lissy93/dashy:3.2.14`.
+
+32-bit `armv7` (Raspberry Pi 2, or a Pi running a 32-bit OS) is no longer supported. If you need it, pin the last armv7 image with `image: lissy93/dashy:4.4.10`.
 
 ### Healthcheck Failing in Docker
 


### PR DESCRIPTION
### Category
Dependencies

### Overview
Moves Docker image to Node 24
Drops the official 32-bit ARM/v7 arch.
Updates docs accordingly

### Issue Number
N/A
