### PR TITLE
Adds OIDC post-logout redirect URI support

### DIFF
--- a/docs/authentication/oidc.md
+++ b/docs/authentication/oidc.md
@@ -28,6 +28,7 @@ appConfig:
       adminGroup: dashy-admins           # Members of this group are admins
       adminRole: dashy-admin             # Or grant admin by role instead
       enableSilentRenew: true            # Refresh the session in the background before it expires
+      # postLogoutRedirectUri: 'https://dashy.example.com' # Where to send users after logout (must be registered with the provider)
       # allowedIssuers: []               # Only for multi-tenant providers to override discovery document
       # disableServerSideCheck: false    # Leave as false / unset. Setting to true makes auth just client-side
 ```
@@ -107,3 +108,17 @@ Notes:
 - If a silent renewal fails for any reason (no refresh token issued, refresh token expired or revoked, the provider returns no fresh id_token, a provider error), Dashy falls back to the normal interactive sign-in. Renewal can save a round-trip, but the interactive flow always remains the safety net.
 - Renewal is driven by the access token's lifetime. If your provider issues an id_token with a much shorter lifetime than the access token, renewal may lag; keeping the two lifetimes equal (the common default) works best.
 - With multiple tabs open against a provider that rotates refresh tokens on use, tabs can briefly contend for the refresh token; the affected tab simply falls back to interactive sign-in. This is inherent to browser-based refresh tokens, not specific to Dashy.
+
+
+## Setting logout redirect URL
+
+When you log out, Dashy sends you to your provider's logout page, and by default that's where you stay. Set `postLogoutRedirectUri` if you'd like the provider to send you back to Dashy (or anywhere else) once it's done:
+
+```yaml
+    oidc:
+      clientId: dashy
+      endpoint: 'https://your-oidc-provider.example.com'
+      postLogoutRedirectUri: 'https://dashy.example.com'
+```
+
+The URL is sent to the provider as `post_logout_redirect_uri`, so it needs to be registered as a valid post-logout redirect URI in your client's settings - most providers have a field for this right next to the sign-in redirect URIs. If it's not registered, many providers will show an error instead of completing the logout, so give the logout button a quick test after setting it. Left unset, nothing changes and logout ends at the provider as before. See [#2261](https://github.com/lissy93/dashy/issues/2261) for info.

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -213,6 +213,7 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 **`adminGroup`** | `string` | _Optional_ | The group that will be considered as admin.
 **`scope`** | `string` | Required | The scope(s) to request from the OIDC provider
 **`enableSilentRenew`** | `boolean` | _Optional_ | If set to `true`, your session is silently renewed in the background before it expires (only works for providers which support the `offline_access` scope)
+**`postLogoutRedirectUri`** | `string` | _Optional_ | URL to send users back to after logging out at the provider (sent as `post_logout_redirect_uri`). Must be registered as a valid post-logout redirect URI with your provider. If unset, no redirect is requested
 **`allowedIssuers`** | `array` | _Optional_ | List of issuer URLs to accept tokens from. Needed for multi-tenant providers (e.g. Microsoft Entra) where the token issuer differs from the configured `endpoint`. If unset, the issuer from the discovery document is used
 **`disableServerSideCheck`** | `boolean` | _Optional_ | If `true`, the server skips token verification and endpoint protection, so OIDC is client-side only. Not recommended. Defaults to `false`
 

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -369,6 +369,7 @@
       "edit-section-title": "Edit Section",
       "add-section-title": "Add New Section",
       "edit-tooltip": "Click to Edit, or right-click for more options",
+      "edit-tooltip-basic": "Click to Edit",
       "remove-confirm": "Are you sure you want to remove this section? This action can be undone later.",
       "missing-name-err": "A section name is required",
       "duplicate-name-err": "A section named '{name}' already exists"

--- a/src/components/LinkItems/Collapsable.vue
+++ b/src/components/LinkItems/Collapsable.vue
@@ -185,7 +185,10 @@ export default {
       this.$emit('navigateToSection');
     },
     editTooltip() {
-      const content = this.$t('interactive-editor.edit-section.edit-tooltip');
+      const key = this.disableContextMenu
+        ? 'interactive-editor.edit-section.edit-tooltip-basic'
+        : 'interactive-editor.edit-section.edit-tooltip';
+      const content = this.$t(key);
       return { content, delay: { show: 100, hide: 0 } };
     },
     toggleTooltip() {

--- a/src/components/LinkItems/Item.vue
+++ b/src/components/LinkItems/Item.vue
@@ -183,7 +183,10 @@ export default {
       if (provider) parts.push(`<b>Provider</b>: ${provider}`);
       if (description) parts.push(description);
       if (hotkey) parts.push(`Press '${hotkey}' to launch`);
-      const editText = this.$t('interactive-editor.edit-section.edit-tooltip');
+      const editKey = this.appConfig.disableContextMenu
+        ? 'interactive-editor.edit-section.edit-tooltip-basic'
+        : 'interactive-editor.edit-section.edit-tooltip';
+      const editText = this.$t(editKey);
       return {
         content: (this.isEditMode ? editText : parts.join('<br>')),
         html: true,

--- a/src/utils/auth/OidcAuth.js
+++ b/src/utils/auth/OidcAuth.js
@@ -58,6 +58,7 @@ class OidcAuth {
       adminGroup,
       adminRole,
       enableSilentRenew,
+      postLogoutRedirectUri,
     } = auth.oidc;
     if (typeof clientId === 'number' && !Number.isSafeInteger(clientId)) {
       ErrorHandler(
@@ -76,6 +77,7 @@ class OidcAuth {
       authority: endpoint,
       client_id: String(clientId),
       redirect_uri: `${window.location.origin}`,
+      post_logout_redirect_uri: postLogoutRedirectUri,
       response_type: 'code',
       scope: requestedScope,
       response_mode: 'query',

--- a/src/utils/config/ConfigSchema.json
+++ b/src/utils/config/ConfigSchema.json
@@ -691,6 +691,11 @@
                   "default": false,
                   "description": "If set to true, Dashy automatically renews your session in the background before it expires. Requires your OIDC provider to issue refresh tokens"
                 },
+                "postLogoutRedirectUri": {
+                  "title": "Post-Logout Redirect URI",
+                  "type": "string",
+                  "description": "URL to send users back to after logging out at the OIDC provider. Must be registered as a valid post-logout redirect URI with your provider"
+                },
                 "allowedIssuers": {
                   "title": "Allowed Token Issuers",
                   "type": "array",


### PR DESCRIPTION
### Category
Feature

### Overview
Adds an `auth.postLogoutRedirectUri` option. Which is where users get sent to after using the logout button, providing it's already configured in their oidc client settings.

Also small fix so that when the `disableContextMenu` accessibility option is set, the tooltip will no longer include reference to "right-click for more options". Note that this will now having missing translations for most languages, until `edit-tooltip-basic` is added (under `interactive-editor.edit-section.edit-tooltip-basic`)

### Issue Number
Fixes #2261
Fixes #2279
