### PR TITLE
Fixes OOM crash from unclosed secureConnect listeners

### DIFF
--- a/services/utils/request.js
+++ b/services/utils/request.js
@@ -239,12 +239,9 @@ function request(config) {
         });
       });
 
-      // Expose socket events for servername access
+      // Expose socket for servername access (used by status-check.js)
       req.on('socket', (socket) => {
         req.socket = socket;
-        socket.on('secureConnect', () => {
-          req.socket = socket;
-        });
       });
 
       req.on('error', (err) => {


### PR DESCRIPTION
### Category
Bugfix

### Overview
There was a secureConnext event listener being attached to each proxy request. Which since the Node 24 upgrade is effectivley dead code. It was opening a listener, and then never closing it or cleaning it up. Overtime, there was lot's of open listeners, eating memory.

Thanks @maartendolk for reporting :)

### Issue Number
Fixes #2282