### PR TITLE
fix(i18n): add missing translation keys (#2291)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -23,8 +23,7 @@ import { syncPageMeta } from '@/utils/PageMeta';
 import { viewFromPath } from '@/utils/config/ConfigHelpers';
 import { applyTheme } from '@/utils/Theming';
 import Keys from '@/utils/StoreMutations';
-import { loadLocale } from '@/utils/languages';
-import i18n from '@/utils/i18n';
+import { applyUserLocale } from '@/utils/applyLocale';
 import {
   localStorageKeys,
   splashScreenTime,
@@ -214,17 +213,9 @@ export default {
       return this.autoDetectLanguage(availibleLocales);
     },
 
-    /* Fetch or detect users language, then apply it */
     async applyLanguage() {
-      const language = this.getLanguage();
-      try {
-        const msg = await loadLocale(language);
-        i18n.global.setLocaleMessage(language, msg);
-      } catch (e) {
-        ErrorHandler(`Failed to load locale '${language}'`, e);
-      }
+      const language = await applyUserLocale(this.getLanguage());
       this.$store.commit(Keys.SET_LANGUAGE, language);
-      this.$i18n.locale = language;
       document.getElementsByTagName('html')[0].setAttribute('lang', language);
     },
     /* If placeholder element still visible, hide it */

--- a/src/assets/locales/de.json
+++ b/src/assets/locales/de.json
@@ -356,6 +356,7 @@
       "cancel-changes-tooltip": "Modifikationen zurücksetzen und Bearbeitungsmodus schließen. Dies hat keinen Einfluss auf die Konfigurationsdatei",
       "leave-while-editing-confirm": "Sie haben ungespeicherte Änderungen. Möchten Sie diese Seite verlassen und die Änderungen verwerfen?",
       "edit-mode-name": "Bearbeitung",
+      "edit-mode-enabled": "Bearbeitungsmodus aktiv",
       "edit-mode-subtitle": "Sie sind im Bearbeitungsmodus",
       "edit-mode-description": "Das bedeutet, dass Änderungen an der Konfigurationsdatei vorgenommen werden können. Änderungen können vor dem Speichern betrachtet werden.",
       "save-stage-btn": "Speichern",
@@ -363,7 +364,9 @@
       "save-locally-warning": "Wenn Sie fortfahren werden die Änderungen nur in Ihrem Browser gespeichert. Um die Konfiguration auf anderen Geräten zu nutzen sollten Sie sie exportieren. Möchten Sie fortfahren?"
     },
     "edit-item": {
-      "missing-title-err": "Ein Titel ist zwingend erforderlich"
+      "missing-title-err": "Ein Titel ist zwingend erforderlich",
+      "add-new-title": "Neues Element hinzufügen",
+      "add-new-description": "Klicken, um neues Element hinzuzufügen"
     },
     "edit-section": {
       "edit-section-title": "Sektion bearbeiten",
@@ -372,7 +375,41 @@
       "edit-tooltip-basic": "Klicken zum Bearbeiten",
       "remove-confirm": "Sind Sie sicher, dass Sie diese Sektion entfernen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
       "missing-name-err": "Ein Sektionsname ist erforderlich",
-      "duplicate-name-err": "Eine Sektion namens '{name}' existiert bereits"
+      "duplicate-name-err": "Eine Sektion namens '{name}' existiert bereits",
+      "fields": {
+        "name": {
+          "title": "Sektionsname",
+          "description": "Titel/Überschrift für eine Sektion. Erforderlich und muss eindeutig sein"
+        },
+        "icon": {
+          "title": "Sektions-Icon",
+          "description": "Icon wird neben dem Titel angezeigt"
+        },
+        "displayData": {
+          "title": "Anzeigedaten",
+          "description": "Optionale Metadaten zur Anpassung einer Sektion"
+        },
+        "sortBy": {
+          "title": "Sortieren nach",
+          "description": "Wie Elemente innerhalb der Sektion sortiert werden. Standardmäßig werden Elemente in der Reihenfolge angezeigt, in der sie in der Konfiguration aufgeführt sind"
+        },
+        "rows": {
+          "title": "Anzahl Zeilen",
+          "description": "Vertikaler Platzbedarf der Sektion (gilt für das Standardlayout „auto“; bei „masonry“ wird die Höhe vom Inhalt bestimmt)"
+        },
+        "cols": {
+          "title": "Anzahl Spalten",
+          "description": "Horizontaler Platzbedarf der Sektion"
+        },
+        "collapsed": {
+          "title": "Eingeklappt?",
+          "description": "Wenn aktiv, muss die Sektion angeklickt werden, um sie zu öffnen"
+        },
+        "hideForGuests": {
+          "title": "Für Gäste ausblenden?",
+          "description": "Wenn aktiv, ist die Sektion für angemeldete Benutzer sichtbar, aber nicht für Gäste"
+        }
+      }
     },
     "edit-widget": {
       "edit-widget-title": "Widget bearbeiten",

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -356,6 +356,7 @@
       "cancel-changes-tooltip": "Reset current modifications, and exit Edit Mode. This will not affect your saved config",
       "leave-while-editing-confirm": "You have unsaved changes. Leave this page and discard them?",
       "edit-mode-name": "Edit Mode",
+      "edit-mode-enabled": "Edit Mode Enabled",
       "edit-mode-subtitle": "You are in Edit Mode",
       "edit-mode-description": "This means you can make modifications to your config, and preview the results, but until you save, none of your changes will be preserved.",
       "save-stage-btn": "Save",
@@ -363,7 +364,9 @@
       "save-locally-warning": "If you proceed, changes will be saved only in your browser. You should export a copy of your config for use on other machines. Would you like to continue?"
     },
     "edit-item": {
-      "missing-title-err": "An item title is required"
+      "missing-title-err": "An item title is required",
+      "add-new-title": "Add New Item",
+      "add-new-description": "Click to add new item"
     },
     "edit-section": {
       "edit-section-title": "Edit Section",
@@ -372,7 +375,41 @@
       "edit-tooltip-basic": "Click to Edit",
       "remove-confirm": "Are you sure you want to remove this section? This action can be undone later.",
       "missing-name-err": "A section name is required",
-      "duplicate-name-err": "A section named '{name}' already exists"
+      "duplicate-name-err": "A section named '{name}' already exists",
+      "fields": {
+        "name": {
+          "title": "Section Name",
+          "description": "Title/ heading for a section. Required and must be unique"
+        },
+        "icon": {
+          "title": "Section Icon",
+          "description": "Icon will be displayed next to title"
+        },
+        "displayData": {
+          "title": "Display Data",
+          "description": "Optional meta data for customizing a section"
+        },
+        "sortBy": {
+          "title": "Sort By",
+          "description": "How to sort items within the section. By default items are displayed in the order in which they are listed in within the config"
+        },
+        "rows": {
+          "title": "Num Rows",
+          "description": "The amount of space that the section spans vertically (applies to the default 'auto' layout; ignored by 'masonry' where heights follow content)"
+        },
+        "cols": {
+          "title": "Num Cols",
+          "description": "The amount of space that the section spans horizontally"
+        },
+        "collapsed": {
+          "title": "Is Collapsed?",
+          "description": "If true, section needs to be clicked to open"
+        },
+        "hideForGuests": {
+          "title": "Hide for Guests?",
+          "description": "If set to true, section will be visible for logged in users, but not for guests"
+        }
+      }
     },
     "edit-widget": {
       "edit-widget-title": "Edit Widget",

--- a/src/components/InteractiveEditor/EditModeTopBanner.vue
+++ b/src/components/InteractiveEditor/EditModeTopBanner.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="edit-mode-top-banner">
-    <span>Edit Mode Enabled</span>
+    <span>{{ $t('interactive-editor.menu.edit-mode-enabled') }}</span>
   </div>
 </template>
 

--- a/src/components/InteractiveEditor/EditSection.vue
+++ b/src/components/InteractiveEditor/EditSection.vue
@@ -29,30 +29,8 @@ import AccessError from '@/components/Configuration/AccessError';
 
 const SchemaForm = defineAsyncComponent(() => import('@/components/FormElements/SchemaForm.vue'));
 
-/* Curated subset of the section schema: omits `items` (edited per-item elsewhere)
- * and trims displayData to the commonly-tweaked attributes. */
 const sectionProps = DashySchema.properties.sections.items.properties;
 const displayProps = sectionProps.displayData.properties;
-const SECTION_SCHEMA = {
-  type: 'object',
-  required: DashySchema.properties.sections.items.required,
-  properties: {
-    name: sectionProps.name,
-    icon: sectionProps.icon,
-    displayData: {
-      type: 'object',
-      title: sectionProps.displayData.title,
-      description: sectionProps.displayData.description,
-      properties: {
-        sortBy: displayProps.sortBy,
-        rows: displayProps.rows,
-        cols: displayProps.cols,
-        collapsed: displayProps.collapsed,
-        hideForGuests: displayProps.hideForGuests,
-      },
-    },
-  },
-};
 
 export default {
   name: 'EditSection',
@@ -65,12 +43,62 @@ export default {
   data() {
     return {
       modalName: modalNames.EDIT_SECTION,
-      customSchema: SECTION_SCHEMA,
       sectionData: {},
     };
   },
   computed: {
     allowViewConfig() { return this.$store.getters.permissions.allowViewConfig; },
+    customSchema() {
+      const t = (key) => this.$t(`interactive-editor.edit-section.fields.${key}`);
+      return {
+        type: 'object',
+        required: DashySchema.properties.sections.items.required,
+        properties: {
+          name: {
+            ...sectionProps.name,
+            title: t('name.title'),
+            description: t('name.description'),
+          },
+          icon: {
+            ...sectionProps.icon,
+            title: t('icon.title'),
+            description: t('icon.description'),
+          },
+          displayData: {
+            type: 'object',
+            title: t('displayData.title'),
+            description: t('displayData.description'),
+            properties: {
+              sortBy: {
+                ...displayProps.sortBy,
+                title: t('sortBy.title'),
+                description: t('sortBy.description'),
+              },
+              rows: {
+                ...displayProps.rows,
+                title: t('rows.title'),
+                description: t('rows.description'),
+              },
+              cols: {
+                ...displayProps.cols,
+                title: t('cols.title'),
+                description: t('cols.description'),
+              },
+              collapsed: {
+                ...displayProps.collapsed,
+                title: t('collapsed.title'),
+                description: t('collapsed.description'),
+              },
+              hideForGuests: {
+                ...displayProps.hideForGuests,
+                title: t('hideForGuests.title'),
+                description: t('hideForGuests.description'),
+              },
+            },
+          },
+        },
+      };
+    },
   },
   mounted() {
     const live = this.isAddNew ? null : this.$store.getters.getSectionByName(this.sectionName);
@@ -82,7 +110,6 @@ export default {
       this.$store.commit(StoreKeys.SET_MODAL_OPEN, false);
       this.$emit('closeEditSection');
     },
-    /* Section names used as id, so need to be present and unique  */
     validateName(name) {
       if (!name || !name.trim()) return this.$t('interactive-editor.edit-section.missing-name-err');
       const slug = makePageName(name);
@@ -95,7 +122,6 @@ export default {
     },
     saveSection() {
       try {
-        /* Form only edits metadata, so preserve the live section's items array. */
         const payload = pruneSchemaDefaults(this.sectionData, this.customSchema);
         const nameError = this.validateName(payload.name);
         if (nameError) { this.$toast.error(nameError); return; }

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -46,12 +46,7 @@
       </template>
       <!-- When in edit mode, show additional item, for Add New item -->
       <Item v-if="isEditMode"
-        :item="{
-          icon: ':heavy_plus_sign:',
-          title: 'Add New Item',
-          description: 'Click to add new item',
-          id: 'add-new',
-        }"
+        :item="addNewItemPlaceholder"
         :isAddNew="true"
         :parentSectionTitle="title"
         key="add-new"
@@ -198,6 +193,14 @@ export default {
     },
     isEditMode() {
       return this.$store.state.editMode;
+    },
+    addNewItemPlaceholder() {
+      return {
+        icon: ':heavy_plus_sign:',
+        title: this.$t('interactive-editor.edit-item.add-new-title'),
+        description: this.$t('interactive-editor.edit-item.add-new-description'),
+        id: 'add-new',
+      };
     },
     itemSize() {
       return this.displayData.itemSize || this.$store.getters.iconSize;

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ import dragSort from '@/directives/DragSort';         // Drag-and-drop list sort
 import { initKeycloakAuth, isKeycloakEnabled } from '@/utils/auth/KeycloakAuth';
 import { initHeaderAuth, isHeaderAuthEnabled } from '@/utils/auth/HeaderAuth';
 import { initOidcAuth, isOidcEnabled } from '@/utils/auth/OidcAuth';
+import { applyUserLocale } from '@/utils/applyLocale';
 import Keys from '@/utils/StoreMutations';
 import ErrorHandler from '@/utils/logging/ErrorHandler';
 import Toast from '@/utils/Toast';
@@ -67,7 +68,8 @@ const handleAuthFailure = (provider, err) => {
   router.replace({ name: 'login' }).catch(() => {}).finally(mount);
 };
 
-router.isReady().then(() => {
+router.isReady().then(async () => {
+  await applyUserLocale();
   if (isOidcEnabled()) {
     initOidcAuth().then((reloading) => { if (!reloading) mount(); })
       .catch((e) => handleAuthFailure('OIDC', e));

--- a/src/utils/applyLocale.js
+++ b/src/utils/applyLocale.js
@@ -1,0 +1,31 @@
+import i18n from '@/utils/i18n';
+import { loadLocale } from '@/utils/languages';
+import { localStorageKeys, language as defaultLanguage } from '@/utils/config/defaults';
+import store from '@/store';
+import ErrorHandler from '@/utils/logging/ErrorHandler';
+
+const setLocale = (code) => {
+  if (i18n.global.locale && typeof i18n.global.locale === 'object' && 'value' in i18n.global.locale) {
+    i18n.global.locale.value = code;
+  } else {
+    i18n.global.locale = code;
+  }
+};
+
+export const resolvePreferredLocale = () => (
+  localStorage[localStorageKeys.LANGUAGE]
+  || store.state.config?.appConfig?.language
+  || defaultLanguage
+);
+
+export const applyUserLocale = async (preferredCode) => {
+  const code = preferredCode || resolvePreferredLocale();
+  try {
+    const msg = await loadLocale(code);
+    i18n.global.setLocaleMessage(code, msg);
+  } catch (e) {
+    ErrorHandler(`Failed to load locale '${code}'`, e);
+  }
+  setLocale(code);
+  return code;
+};


### PR DESCRIPTION
### Category
Localization

### Overview
Wires hardcoded English leftovers in edit mode / section editor through `$t(...)`, adds matching keys in `en.json` and `de.json`, and loads the preferred locale before auth toasts so `login.authenticated-redirecting` resolves with language=de after a clean cache.

**Keys / UI fixed**
- `interactive-editor.menu.edit-mode-enabled` — edit-mode top banner
- `interactive-editor.edit-item.add-new-title` / `add-new-description` — add-item tile
- `interactive-editor.edit-section.fields.*` — section form labels/descriptions (`name`, `icon`, `displayData`, `sortBy`, `rows`, `cols`, `collapsed`, `hideForGuests`)
- `login.authenticated-redirecting` — existing key; applied via early locale load before OIDC/Keycloak toast

### Issue Number
Fixes https://github.com/Lissy93/dashy/issues/2291

### Additional Info
**How to verify**
1. Set language to German (`de`) and hard-refresh / clear cache
2. Enter edit mode — banner, add-item tile, and section editor fields should be German
3. With SSO/auth enabled, confirm the auth toast shows the German `authenticated-redirecting` string