### PR TITLE
Extracts some hard-coded strings

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -363,7 +363,9 @@
       "save-locally-warning": "If you proceed, changes will be saved only in your browser. You should export a copy of your config for use on other machines. Would you like to continue?"
     },
     "edit-item": {
-      "missing-title-err": "An item title is required"
+      "missing-title-err": "An item title is required",
+      "add-item-title": "Add New Item",
+      "add-item-description": "Click to add new item"
     },
     "edit-section": {
       "edit-section-title": "Edit Section",

--- a/src/components/InteractiveEditor/EditModeTopBanner.vue
+++ b/src/components/InteractiveEditor/EditModeTopBanner.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="edit-mode-top-banner">
-    <span>Edit Mode Enabled</span>
+    <span>{{ $t('interactive-editor.menu.edit-mode-subtitle') }}</span>
   </div>
 </template>
 

--- a/src/components/LinkItems/Section.vue
+++ b/src/components/LinkItems/Section.vue
@@ -48,8 +48,8 @@
       <Item v-if="isEditMode"
         :item="{
           icon: ':heavy_plus_sign:',
-          title: 'Add New Item',
-          description: 'Click to add new item',
+          title: $t('interactive-editor.edit-item.add-item-title'),
+          description: $t('interactive-editor.edit-item.add-item-description'),
           id: 'add-new',
         }"
         :isAddNew="true"


### PR DESCRIPTION
### Category
Localization

### Overview
There were some strings still hard-coded, I've extracted these into `en.json` so they can now be translated into other languages if needed. 

The new strings are:
- `interactive-editor.edit-item.add-item-title` - "Add New Item"
- `interactive-editor.edit-item.add-item-description` - "Click to add new item"
- `login.authenticated-redirecting` - "Authenticated, redirecting..."

Also, the following keys were pre-existing but are missing for some locales (reported in the issue)
- `interactive-editor.edit-section.edit-tooltip-basic` - "Click to Edit"
- `interactive-editor.edit-section.missing-name-err` - A section name is required
- `interactive-editor.edit-section.duplicate-name-err` - A section named '{name}' already exists

### Issue Number
Fixes #2291 
