### PR TITLE
Adds missing DE translations for edit item

### DIFF
--- a/src/assets/locales/de.json
+++ b/src/assets/locales/de.json
@@ -363,7 +363,9 @@
       "save-locally-warning": "Wenn Sie fortfahren werden die Änderungen nur in Ihrem Browser gespeichert. Um die Konfiguration auf anderen Geräten zu nutzen sollten Sie sie exportieren. Möchten Sie fortfahren?"
     },
     "edit-item": {
-      "missing-title-err": "Ein Titel ist zwingend erforderlich"
+      "missing-title-err": "Ein Titel ist zwingend erforderlich",
+      "add-item-title": "Neues Element hinzufügen",
+      "add-item-description": "Klicken, um ein neues Element hinzuzufügen"
     },
     "edit-section": {
       "edit-section-title": "Sektion bearbeiten",


### PR DESCRIPTION
### Category
Localization

### Overview
Adds the missing Deutsch translations for edit item
‼️I used AI to translate. It's possible that this PR is slop 

@vmario89 or @CrazyWolf13 would either of you be able to do quick review? 
I'll wait before merging, to check this is ok for real 🇩🇪 Tell me if I should change anything

Here's what the english version looked like:

```json
    "edit-item": {
      "missing-title-err": "An item title is required",
      "add-item-title": "Add New Item",
      "add-item-description": "Click to add new item"
    },
```

### Issue Number
#2291

