### PR TITLE
Fixes search not updating on mobile

### DIFF
--- a/src/components/Settings/SearchBar.vue
+++ b/src/components/Settings/SearchBar.vue
@@ -4,7 +4,7 @@
     <div class="search-wrap">
       <input
         id="filter-tiles"
-        v-model="input"
+        :value="input"
         ref="filter"
         role="searchbox"
         :aria-label="$t('search.search-label')"
@@ -107,7 +107,8 @@ export default {
       }
     },
     /* Emmits users's search term up to parent */
-    userIsTypingSomething() {
+    userIsTypingSomething(event) {
+      if (event) this.input = event.target.value;
       if (this.emitFrame != null) return;
       this.emitFrame = requestAnimationFrame(() => {
         this.emitFrame = null;


### PR DESCRIPTION
### Category
Bugfix

### Overview
**Issue**: Reactivity issue causing dashboard items to not update when searching using soft keyboard / mobile

**Cause**: A qwirk of `v-model` ignoring inputs while an IME composition is active, and some Android keyboards keep composition open per whole word, meaning `this.input` would be stale until blur/click outsite.

**Fix**: Just reading the input even directly from `:value` instad of the v-model atribute.


### Issue Number
Fixes #2295
