### PR TITLE
Improved schema support

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -49,6 +49,7 @@ The following file provides a reference of all supported configuration options.
 - [**Notes**](#notes)
   - [Editing Config through the UI](#editing-config-through-the-ui)
   - [About YAML](#about-yaml)
+  - [Schema Validation in your Editor](#schema-validation-in-your-editor)
   - [Config Saving Methods](#config-saving-methods)
   - [Preventing Changes](#preventing-changes)
   - [Example](#example)
@@ -402,6 +403,28 @@ Config can be modified directly through the UI, and then written to disk, or app
 ### About YAML
 
 If you're new to YAML, it's pretty straight-forward. The format is exactly the same as that of JSON, but instead of using curly braces, structure is denoted using whitespace. This [quick guide](https://linuxhandbook.com/yaml-basics/) should get you up to speed in a few minutes, for more advanced topics take a look at this [Wikipedia article](https://en.wikipedia.org/wiki/YAML).
+
+### Schema Validation in your Editor
+
+Dashy's config is described by a [JSON schema](https://github.com/Lissy93/dashy/blob/master/src/utils/config/ConfigSchema.json) (and served up at `[your-dashy-instance.local]/schema.json`).
+
+Most editors can use this to give you validation, auto-complete and inline docs as you type, so long as you have the `$schema` key pointing to the schema URL.
+
+If you have the [YAML Language Server](https://github.com/redhat-developer/yaml-language-server) in your editor (which comes with the YAML extension), then you can also add the schema directly. E.g. for VS Code, put the following in your `settings.json`.
+
+```json
+{
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/Lissy93/dashy/master/src/utils/config/ConfigSchema.json": ["conf.yml", "user-data/*.yml"]
+  }
+}
+```
+
+The built-in YAML editor (under Config --> Edit Config) also has live validation and auto-complete from the schema.
+
+<p align="center">
+<img width="700" src="https://pixelflare.cc/alicia/dashy/yaml-editor" alt="YAML editor screenshot" />
+</p>
 
 ### Config Saving Methods
 

--- a/services/app.js
+++ b/services/app.js
@@ -11,12 +11,15 @@ const crypto = require('crypto');
 /* Project root — one level up from services/ */
 const rootDir = path.join(__dirname, '..');
 
-/* Import NPM dependencies */
-const yaml = require('./utils/yaml');
-
 /* Import Express + middleware functions */
 const express = require('express');
 const basicAuth = require('express-basic-auth');
+
+/* Config schema, served at /schema.json for use by external editors */
+const configSchema = require('../src/utils/config/ConfigSchema.json');
+
+/* Import NPM dependencies */
+const yaml = require('./utils/yaml');
 
 /* Kick of some basic checks */
 require('./utils/update-checker'); // Checks if there are any updates available, prints message
@@ -45,6 +48,7 @@ const ENDPOINTS = {
   systemInfo: '/system-info',
   corsProxy: '/cors-proxy',
   getUser: '/get-user',
+  configSchema: '/schema.json',
   api: '/api',
 };
 
@@ -323,6 +327,8 @@ const app = express()
     onConfigSaved: (filename, newConf) => { if (filename === 'conf.yml') config = newConf; },
   }))
   .use(ENDPOINTS.api, apiErrorHandler)
+  // Serves the config schema, for use by external editors and validators
+  .get(ENDPOINTS.configSchema, (req, res) => res.json(configSchema))
   // Middleware to serve any .yml/.yaml files in USER_DATA_DIR with optional protection
   // Note: returns stripped version if auth configured but not yet authenticated
   .get(/\.ya?ml$/i, bootstrapAuth, (req, res) => {

--- a/services/endpoints/save-config.js
+++ b/services/endpoints/save-config.js
@@ -9,6 +9,30 @@ const path = require('path');
 
 const MAX_CONFIG_BYTES = 256 * 1024;
 
+/* Schema modeline, added to conf.yml so editors can validate it (see docs/configuring.md) */
+const SCHEMA_MODELINE = '# yaml-language-server: $schema='
+  + 'https://raw.githubusercontent.com/Lissy93/dashy/master/src/utils/config/ConfigSchema.json';
+
+// Same shape the YAML language server looks for: '# ' then the directive
+const MODELINE = /^#[ \t]+(?:yaml-language-server[ \t]*:|\$schema:).*/m;
+
+/* The document header (comments, blanks, directives) - a modeline is only read from here */
+const headerOf = (text) => {
+  const lines = String(text).split(/\r?\n/);
+  const firstContent = lines.findIndex((line) => !/^\s*(?:#|%|---\s*$|$)/.test(line));
+  return (firstContent === -1 ? lines : lines.slice(0, firstContent)).join('\n');
+};
+
+/* Saving re-serializes the config, which drops all comments. So carry over the
+ * user's modeline (keeping any custom URL), or add the default one to conf.yml */
+const withModeline = (newConfig, oldConfig, isRootConfig) => {
+  // Nothing to do if it's already there, or if a byte-order-mark must stay first
+  if (newConfig.startsWith('\uFEFF') || MODELINE.test(headerOf(newConfig))) return newConfig;
+  const [existing] = headerOf(oldConfig).match(MODELINE) || [];
+  const modeline = existing || (isRootConfig ? SCHEMA_MODELINE : null);
+  return modeline ? `${modeline}\n${newConfig}` : newConfig;
+};
+
 // Disallow paths having path separators, control chars (NUL/CR/LF), or ..
 const SAFE_FILENAME = /^(?!\.+$)[^\\/\0\r\n]+\.ya?ml$/i;
 
@@ -63,7 +87,9 @@ module.exports = async (newConfig, render) => {
 
   // Write the new config
   try {
-    await fsPromises.writeFile(targetFilePath, newConfig.config, { encoding: 'utf8' });
+    const previous = await fsPromises.readFile(targetFilePath, 'utf8').catch(() => '');
+    const toWrite = withModeline(newConfig.config, previous, targetFile === 'conf.yml');
+    await fsPromises.writeFile(targetFilePath, toWrite, { encoding: 'utf8' });
   } catch (error) {
     respond(false, `Unable to write to ${targetFile}: ${error}`);
     return;

--- a/services/endpoints/save-config.js
+++ b/services/endpoints/save-config.js
@@ -9,25 +9,22 @@ const path = require('path');
 
 const MAX_CONFIG_BYTES = 256 * 1024;
 
-/* Schema modeline, added to conf.yml so editors can validate it (see docs/configuring.md) */
+/* Schema modeline to get added to conf.yml */
 const SCHEMA_MODELINE = '# yaml-language-server: $schema='
   + 'https://raw.githubusercontent.com/Lissy93/dashy/master/src/utils/config/ConfigSchema.json';
 
-// Same shape the YAML language server looks for: '# ' then the directive
-const MODELINE = /^#[ \t]+(?:yaml-language-server[ \t]*:|\$schema:).*/m;
-
-/* The document header (comments, blanks, directives) - a modeline is only read from here */
-const headerOf = (text) => {
-  const lines = String(text).split(/\r?\n/);
-  const firstContent = lines.findIndex((line) => !/^\s*(?:#|%|---\s*$|$)/.test(line));
-  return (firstContent === -1 ? lines : lines.slice(0, firstContent)).join('\n');
-};
-
-/* Saving re-serializes the config, which drops all comments. So carry over the
- * user's modeline (keeping any custom URL), or add the default one to conf.yml */
+/* Adds the $schema part in, if not already present */
 const withModeline = (newConfig, oldConfig, isRootConfig) => {
-  // Nothing to do if it's already there, or if a byte-order-mark must stay first
-  if (newConfig.startsWith('\uFEFF') || MODELINE.test(headerOf(newConfig))) return newConfig;
+  // ReGex for checking if a schema reference already present
+  const MODELINE = /^#[ \t]+(?:yaml-language-server[ \t]*:|\$schema:).*/m;
+  const SCHEMA_KEY = /^["']?\$schema["']?[ \t]*:/m;
+
+  // Gets everything before the first line of content
+  const headerOf = (text) => text.split(/^(?![ \t]*(?:#|%|---|$))/m)[0];
+
+  // Skip if a schema is already referenced or if has byte-order-mark
+  if (newConfig.startsWith('\uFEFF') || SCHEMA_KEY.test(newConfig)
+    || MODELINE.test(headerOf(newConfig))) return newConfig;
   const [existing] = headerOf(oldConfig).match(MODELINE) || [];
   const modeline = existing || (isRootConfig ? SCHEMA_MODELINE : null);
   return modeline ? `${modeline}\n${newConfig}` : newConfig;

--- a/src/components/Configuration/JsonEditor.vue
+++ b/src/components/Configuration/JsonEditor.vue
@@ -119,19 +119,24 @@
 <script>
 import { shallowRef, markRaw } from 'vue';
 import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter } from '@codemirror/view';
-import { EditorState, Compartment } from '@codemirror/state';
+import { EditorState, Compartment, Prec } from '@codemirror/state';
 import { yaml } from '@codemirror/lang-yaml';
 import { linter, lintGutter, forEachDiagnostic } from '@codemirror/lint';
-import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands';
+import {
+  defaultKeymap, history, historyKeymap, indentWithTab, insertNewlineAndIndent,
+} from '@codemirror/commands';
 import {
   bracketMatching, foldGutter, foldKeymap, indentOnInput, syntaxHighlighting, HighlightStyle,
 } from '@codemirror/language';
-import { closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
+import {
+  acceptCompletion, autocompletion, closeBrackets, closeBracketsKeymap, closeCompletion, startCompletion,
+} from '@codemirror/autocomplete';
 import { highlightSelectionMatches, searchKeymap } from '@codemirror/search';
 import { tags as t } from '@lezer/highlight';
 import { load as yamlLoad, dump as yamlDump } from '@/utils/yaml';
 import { schemaLinter } from '@/utils/config/schemaLinter';
 import { schemaHover } from '@/utils/config/schemaHover';
+import { schemaComplete } from '@/utils/config/schemaComplete';
 import ConfigSavingMixin from '@/mixins/ConfigSaving';
 import ErrorHandler, { InfoHandler, InfoKeys } from '@/utils/logging/ErrorHandler';
 import StoreKeys from '@/utils/StoreMutations';
@@ -260,7 +265,22 @@ export default {
             indentOnInput(),
             syntaxHighlighting(dashyHighlight, { fallback: true }),
             highlightSelectionMatches(),
+            // Esc closes an open suggestion list, without reaching the modal (which
+            // would close the whole editor). Falls through when nothing is open
+            Prec.highest(keymap.of([
+              { key: 'Escape', run: closeCompletion, stopPropagation: true },
+            ])),
             keymap.of([
+              // Tab accepts an open suggestion; Enter starts a new line, then offers them
+              { key: 'Tab', run: acceptCompletion },
+              {
+                key: 'Enter',
+                run: (view) => {
+                  if (!insertNewlineAndIndent(view)) return false;
+                  startCompletion(view);
+                  return true;
+                },
+              },
               ...closeBracketsKeymap,
               ...defaultKeymap,
               ...searchKeymap,
@@ -272,6 +292,7 @@ export default {
             lintGutter(),
             linter(schemaLinter, { delay: 300 }),
             schemaHover,
+            autocompletion({ override: [schemaComplete], icons: false }),
             this.wrapCompartment.of(this.wordWrap ? EditorView.lineWrapping : []),
             EditorView.darkTheme.of(true),
             updateListener,
@@ -726,6 +747,25 @@ p.no-permission-note {
   &-error {
     border-left-color: var(--danger);
   }
+}
+
+/* Autocomplete popup. Extra classes needed to out-weigh CodeMirror's own theme */
+.cm-editor .cm-tooltip.cm-tooltip-autocomplete {
+  ul li[aria-selected] {
+    background: var(--config-settings-background);
+    color: var(--config-settings-color);
+  }
+  .cm-completionDetail {
+    color: var(--medium-grey);
+    font-style: normal;
+    float: right;
+    margin-left: 1rem;
+  }
+}
+
+.cm-editor .cm-tooltip.cm-completionInfo {
+  max-width: 22rem;
+  padding: 0.5rem 0.75rem;
 }
 
 .cm-schema-hover {

--- a/src/utils/config/ConfigSchema.json
+++ b/src/utils/config/ConfigSchema.json
@@ -1,10 +1,22 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/lissy93/dashy/master/src/utils/config/ConfigSchema.json",
+  "title": "Dashy Config",
+  "description": "Validates a Dashy config file against all supported options",
   "type": "object",
   "required": [
     "sections"
   ],
   "additionalProperties": false,
+  "patternProperties": {
+    "^x-": {}
+  },
   "properties": {
+    "$schema": {
+      "title": "Schema",
+      "type": "string",
+      "description": "Optional reference to this schema, used by external editors for validation and autocompletion. Ignored by Dashy"
+    },
     "pages": {
       "title": "Page List",
       "type": "array",

--- a/src/utils/config/schemaComplete.js
+++ b/src/utils/config/schemaComplete.js
@@ -1,0 +1,75 @@
+/**
+ * A completion source for CodeMirror 6,
+ * suggests property names and enum/boolean values from
+ * ConfigSchema.json, based on the cursor's path in the YAML doc
+ */
+import { parseDocument } from 'yaml';
+import schema from './ConfigSchema.json';
+import { yamlPathAtOffset, yamlNodeAt, schemaAt } from './schemaPath';
+
+// Spliced in at the cursor before parsing, so blank lines still resolve to a path
+const PROBE = 'xProbex';
+
+const describeType = (s) => (Array.isArray(s.type) ? s.type.join(' | ') : s.type);
+
+// Whether the offset falls within a node's source range
+const insideNode = (node, offset) => {
+  const r = node?.range;
+  return !!r && offset >= r[0] && offset <= (r[2] ?? r[1] ?? r[0]);
+};
+
+// Property names for an object schema, minus keys already used in the map
+const keyOptions = (target, mapNode, currentKey, colonAfter) => {
+  const existing = new Set((mapNode?.items || [])
+    .map((p) => String(p.key && 'value' in p.key ? p.key.value : p.key))
+    // A half-typed key can parse merged with the next line, as "pa sections"
+    .flatMap((k) => k.split(/\s+/)));
+  return Object.entries(target?.properties || {})
+    .filter(([name]) => !existing.has(name) || name === currentKey)
+    .map(([name, s]) => ({
+      label: name,
+      type: 'property',
+      detail: describeType(s),
+      info: s.description,
+      apply: colonAfter ? name : `${name}: `,
+    }));
+};
+
+// Value completions: the schema's allowed enum entries, or true/false for booleans
+const valueOptions = (target) => {
+  if (Array.isArray(target?.enum)) {
+    return target.enum.map((v) => ({ label: String(v), type: 'constant' }));
+  }
+  if ([].concat(target?.type || []).includes('boolean')) {
+    return [{ label: 'true', type: 'constant' }, { label: 'false', type: 'constant' }];
+  }
+  return [];
+};
+
+export const schemaComplete = (context) => {
+  const { state, pos } = context;
+  const word = context.matchBefore(/[\w$-]*/);
+  if (!word) return null;
+
+  const line = state.doc.lineAt(pos);
+  const beforeCursor = line.text.slice(0, pos - line.from);
+  const afterCursor = line.text.slice(pos - line.from);
+  const typingKey = /^[\s-]*[\w$-]*$/.test(beforeCursor); // `  ti` or `  - `
+  const typingValue = /:\s+[\w$-]*$/.test(beforeCursor); // `  layout: au` or `  layout: `
+  if (!typingKey && !typingValue) return null;
+
+  const doc = parseDocument(state.sliceDoc(0, pos) + PROBE + state.sliceDoc(pos));
+  const path = yamlPathAtOffset(doc, pos);
+  const [wordAfter] = /^[\w$-]*/.exec(afterCursor);
+  const result = (options) => (options.length
+    ? { from: word.from, to: pos + wordAfter.length, options, validFor: /^[\w$-]*$/ }
+    : null);
+
+  if (typingValue) return result(valueOptions(schemaAt(schema, path)));
+
+  // When the cursor is on a key (not inside a value), complete against its parent
+  const onKey = path.length && !insideNode(yamlNodeAt(doc.contents, path), pos);
+  const currentKey = onKey ? String(path.pop()).replace(PROBE, '') : null;
+  const colonAfter = /^\s*:/.test(afterCursor.slice(wordAfter.length));
+  return result(keyOptions(schemaAt(schema, path), yamlNodeAt(doc.contents, path), currentKey, colonAfter));
+};

--- a/tests/unit/schema-complete.test.js
+++ b/tests/unit/schema-complete.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { EditorState } from '@codemirror/state';
+import { CompletionContext } from '@codemirror/autocomplete';
+import { schemaComplete } from '../../src/utils/config/schemaComplete';
+
+const at = (text, explicit = false) => {
+  const pos = text.indexOf('|');
+  const state = EditorState.create({ doc: text.replace('|', '') });
+  return schemaComplete(new CompletionContext(state, pos, explicit));
+};
+const labels = (r) => (r ? r.options.map((o) => o.label) : null);
+
+describe('schemaComplete', () => {
+  it('completes nested keys', () => {
+    const r = at('pageInfo:\n  ti|\n');
+    expect(labels(r)).toContain('title');
+    expect(r.options.find((o) => o.label === 'title').apply).toBe('title: ');
+  });
+  it('excludes keys already present', () => {
+    const l = labels(at('pageInfo:\n  title: x\n  na|\n'));
+    expect(l).toContain('navLinks');
+    expect(l).not.toContain('title');
+  });
+  it('completes root keys, excluding present ones', () => {
+    const l = labels(at('pa|\nsections: []\n'));
+    expect(l).toEqual(expect.arrayContaining(['pages', 'pageInfo', '$schema']));
+    expect(l).not.toContain('sections');
+  });
+  it('word that prefixes the PARENT key stays scoped to parent', () => {
+    const l = labels(at('pageInfo:\n  pa|\n'));
+    expect(l).toContain('title');       // pageInfo's props...
+    expect(l).not.toContain('pages');   // ...not root's
+  });
+  it('completes enum values', () => {
+    expect(labels(at('appConfig:\n  layout: |\n'))).toContain('horizontal');
+  });
+  it('completes enum values with a typed prefix', () => {
+    expect(labels(at('appConfig:\n  layout: ho|\n'))).toContain('horizontal');
+  });
+  it('completes booleans', () => {
+    expect(labels(at('appConfig:\n  statusCheck: |\n'))).toEqual(['true', 'false']);
+  });
+  it('completes keys inside a section item', () => {
+    const l = labels(at('sections:\n  - name: A\n    items:\n      - ti|\n'));
+    expect(l).toEqual(expect.arrayContaining(['title']));
+  });
+  it('silent for free-text values', () => {
+    expect(at('pageInfo:\n  title: My|\n')).toBeNull();
+    expect(at('pageInfo:\n  title: My Da|\n')).toBeNull();
+  });
+  it('resolves blank nested lines to the parent', () => {
+    expect(labels(at('pageInfo:\n  |\n', true))).toContain('title');
+    const l = labels(at('pageInfo:\n  title: x\n  |\n', true));
+    expect(l).toContain('navLinks');
+    expect(l).not.toContain('title');
+  });
+  it('offers item keys on a bare new list entry', () => {
+    expect(labels(at('sections:\n  - name: A\n  - |\n', true))).toContain('name');
+  });
+  it('explicit trigger on empty root doc offers root keys', () => {
+    expect(labels(at('|', true))).toContain('sections');
+  });
+  it('mid-key edit applies name without a colon', () => {
+    const r = at('pageInfo:\n  tit|le: x\n');
+    expect(r.options.find((o) => o.label === 'title').apply).toBe('title');
+  });
+  it('info and detail carry schema docs', () => {
+    const o = at('pageInfo:\n  ti|\n').options.find((x) => x.label === 'title');
+    expect(o.detail).toBe('string');
+    expect(o.info).toBeTruthy();
+  });
+});

--- a/user-data/conf.yml
+++ b/user-data/conf.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Lissy93/dashy/master/src/utils/config/ConfigSchema.json
 ---
 # Page meta info, like heading, footer text and nav links
 pageInfo:

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -74,7 +74,7 @@ export default defineConfig({
         skipWaiting: false,
         navigateFallback: '/index.html',
         navigateFallbackDenylist: [
-          /^\/(status-check|ping-check|system-info|cors-proxy|get-user|config-manager)\b/,
+          /^\/(status-check|ping-check|system-info|cors-proxy|get-user|config-manager|schema)\b/,
         ],
         maximumFileSizeToCacheInBytes: 10 * 1024 * 1024,
         globIgnores: [


### PR DESCRIPTION
### Category
Feature

### Overview
- Linking the schema definition doesn't make schema error
- The schema ref now included by default in config
- The schema gets served up at `<dasy.local>/schema.json` so no github request needed
- Adds interactive auto-compelte in the yaml editor from schema
- Adds some docs about using schema in IDE and other places


Here's a picture of auto-complete on the built-in yaml editor:

<p align="center">
<img width="500" src="https://pixelflare.cc/alicia/dashy/yaml-editor" />
</p>

### Issue Number
Fixes #2303

