### PR TITLE
Adds option to skip auto-guest-login for OIDC

### DIFF
--- a/docs/authentication/oidc.md
+++ b/docs/authentication/oidc.md
@@ -28,6 +28,7 @@ appConfig:
       adminGroup: dashy-admins           # Members of this group are admins
       adminRole: dashy-admin             # Or grant admin by role instead
       enableSilentRenew: true            # Refresh the session in the background before it expires
+      # showLoginPage: false             # If true, login redirects to Dashy's own login page
       # postLogoutRedirectUri: 'https://dashy.example.com' # Where to send users after logout (must be registered with the provider)
       # allowedIssuers: []               # Only for multi-tenant providers to override discovery document
       # disableServerSideCheck: false    # Leave as false / unset. Setting to true makes auth just client-side
@@ -66,6 +67,19 @@ When set, tokens are accepted only if their `iss` matches one of these (signatur
 ## Guest access
 
 Set `enableGuestAccess: true` to let people view the dashboard read-only without signing in. They get the full config but can't save anything, and sections or items marked `hideForGuests` stay hidden. With it off (the default), anyone who isn't signed in is sent to the login flow.
+
+## Showing Dashy's login page
+
+By default, anyone who isn't signed in is sent straight to your provider's login page (or, with `enableGuestAccess: true`, straight into the dashboard as a guest). Set `showLoginPage: true` under `auth.oidc` to show Dashy's own login page first instead:
+
+```yaml
+    oidc:
+      clientId: dashy
+      endpoint: 'https://your-oidc-provider.example.com'
+      showLoginPage: true
+```
+
+The page has a button to sign in with your provider, plus a *Proceed as Guest* button if guest access is enabled, so the user picks which they want. This is useful when Dashy is the landing page after another redirect (e.g. a captive portal), where an immediate second redirect off to the IdP is disorienting. It's shown on each page load until you sign in; the choice isn't remembered. See [#2302](https://github.com/lissy93/dashy/issues/2302) for info.
 
 ## Using with a PWA
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -213,6 +213,7 @@ For more info, see the **[Authentication Docs](/docs/authentication.md)**
 **`adminRole`** | `string` | _Optional_ | The role that will be considered as admin.
 **`adminGroup`** | `string` | _Optional_ | The group that will be considered as admin.
 **`scope`** | `string` | Required | The scope(s) to request from the OIDC provider
+**`showLoginPage`** | `boolean` | _Optional_ | Set to `true` to redirect to Dashy's login page, instead of your OIDC auth page
 **`enableSilentRenew`** | `boolean` | _Optional_ | If set to `true`, your session is silently renewed in the background before it expires (only works for providers which support the `offline_access` scope)
 **`postLogoutRedirectUri`** | `string` | _Optional_ | URL to send users back to after logging out at the provider (sent as `post_logout_redirect_uri`). Must be registered as a valid post-logout redirect URI with your provider. If unset, no redirect is requested
 **`allowedIssuers`** | `array` | _Optional_ | List of issuer URLs to accept tokens from. Needed for multi-tenant providers (e.g. Microsoft Entra) where the token issuer differs from the configured `endpoint`. If unset, the issuer from the discovery document is used

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -26,6 +26,8 @@
   "login": {
     "title": "Dashy",
     "guest-label": "Guest Access",
+    "oidc-label": "Single Sign-On",
+    "oidc-login-button": "Sign In with SSO",
     "username-label": "Username",
     "password-label": "Password",
     "login-button": "Login",

--- a/src/components/Settings/AuthButtons.vue
+++ b/src/components/Settings/AuthButtons.vue
@@ -26,7 +26,7 @@ import router from '@/router';
 import Keys from '@/utils/StoreMutations';
 import { logout as registerLogout, getLogoutRedirectUrl } from '@/utils/auth/Auth';
 import { getKeycloakAuth, isKeycloakEnabled } from '@/utils/auth/KeycloakAuth';
-import { getOidcAuth, isOidcEnabled } from '@/utils/auth/OidcAuth';
+import { getOidcAuth, isOidcEnabled, oidcSignIn } from '@/utils/auth/OidcAuth';
 import { localStorageKeys, userStateEnum } from '@/utils/config/defaults';
 import IconLogout from '@/assets/interface-icons/user-logout.svg';
 
@@ -90,7 +90,7 @@ export default {
     },
     goToLogin() {
       if (isOidcEnabled()) {
-        getOidcAuth().userManager.signinRedirect();
+        oidcSignIn();
       } else if (isKeycloakEnabled()) {
         const kc = getKeycloakAuth();
         kc.keycloakClient.login(kc.loginOptions);

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,8 @@ import tooltip from '@/directives/Tooltip';           // Custom tooltip directiv
 import dragSort from '@/directives/DragSort';         // Drag-and-drop list sorting directive
 import { initKeycloakAuth, isKeycloakEnabled } from '@/utils/auth/KeycloakAuth';
 import { initHeaderAuth, isHeaderAuthEnabled } from '@/utils/auth/HeaderAuth';
-import { initOidcAuth, isOidcEnabled } from '@/utils/auth/OidcAuth';
+import { initOidcAuth, isOidcEnabled, isOidcLoginPageEnabled } from '@/utils/auth/OidcAuth';
+import { isLoggedIn } from '@/utils/auth/Auth';
 import Keys from '@/utils/StoreMutations';
 import ErrorHandler from '@/utils/logging/ErrorHandler';
 import Toast from '@/utils/Toast';
@@ -67,10 +68,17 @@ const handleAuthFailure = (provider, err) => {
   router.replace({ name: 'login' }).catch(() => {}).finally(mount);
 };
 
+/* With OIDC set to show the login page, signed-out users are sent there before mounting */
+const needsOidcLoginPage = () => isOidcLoginPageEnabled() && !isLoggedIn()
+  && router.currentRoute.value.name !== 'login';
+
 router.isReady().then(() => {
   if (isOidcEnabled()) {
-    initOidcAuth().then((reloading) => { if (!reloading) mount(); })
-      .catch((e) => handleAuthFailure('OIDC', e));
+    initOidcAuth().then((reloading) => {
+      if (reloading) return;
+      if (needsOidcLoginPage()) router.replace({ name: 'login' }).catch(() => {}).finally(mount);
+      else mount();
+    }).catch((e) => handleAuthFailure('OIDC', e));
   } else if (isKeycloakEnabled()) {
     initKeycloakAuth().then(mount).catch((e) => handleAuthFailure('Keycloak', e));
   } else if (isHeaderAuthEnabled()) {

--- a/src/utils/auth/OidcAuth.js
+++ b/src/utils/auth/OidcAuth.js
@@ -1,5 +1,5 @@
 import ConfigAccumulator from '@/utils/config/ConfigAccumalator';
-import { localStorageKeys } from '@/utils/config/defaults';
+import { localStorageKeys, routePaths } from '@/utils/config/defaults';
 import ErrorHandler from '@/utils/logging/ErrorHandler';
 import { statusMsg, statusErrorMsg } from '@/utils/logging/CoolConsole';
 import getApiAuthHeader, { getApiAuthState } from '@/utils/auth/getApiAuthHeader';
@@ -24,12 +24,14 @@ const markSilentRenewAttempt = () => {
   try { sessionStorage.setItem(SILENT_RENEW_GUARD_KEY, String(Date.now())); } catch { /* ignore */ }
 };
 
-/* Return a same-origin path to navigate back to after IdP, or just `/` */
+
+/* Returns path to navigate back to after IdP (same-origin, not /login page) */
 const safeReturnTo = (raw) => {
   if (typeof raw !== 'string') return '/';
   try {
     const u = new URL(raw, window.location.origin);
-    return u.origin === window.location.origin ? u.pathname + u.search + u.hash : '/';
+    if (u.origin !== window.location.origin || u.pathname === routePaths.login) return '/';
+    return u.pathname + u.search + u.hash;
   } catch {
     return '/';
   }
@@ -43,6 +45,12 @@ const getAppConfig = () => {
 const isOidcGuestAccessEnabled = () => {
   const { auth } = getAppConfig();
   return auth && auth.enableGuestAccess;
+};
+
+/* True when Dashy's own login page should be shown, instead of jumping to the IdP */
+export const isOidcLoginPageEnabled = () => {
+  const { auth } = getAppConfig();
+  return Boolean(auth?.oidc?.showLoginPage);
 };
 
 class OidcAuth {
@@ -136,7 +144,7 @@ class OidcAuth {
 
     const user = await this.userManager.getUser();
     if (user === null) {
-      if (isOidcGuestAccessEnabled()) return false;
+      if (isOidcGuestAccessEnabled() || isOidcLoginPageEnabled()) return false;
       await this.redirectToIdp();
       return true;
     }
@@ -221,11 +229,11 @@ class OidcAuth {
     if (this.silentRenewEnabled && user?.refresh_token) this.userManager.startSilentRenew();
   }
 
-  /* Redirect to the IdP for interactive sign-in
-   * If we just tried this, bail with error to prevent loops */
-  async redirectToIdp() {
+
+  /* Redirects to IdP for signin. Bail on failed retry to prevent infinite redirect loop */
+  async redirectToIdp(userInitiated = false) {
     const lastAttempt = Number(sessionStorage.getItem(SIGNIN_GUARD_KEY)) || 0;
-    if (Date.now() - lastAttempt < SIGNIN_GUARD_THRESHOLD_MS) {
+    if (!userInitiated && Date.now() - lastAttempt < SIGNIN_GUARD_THRESHOLD_MS) {
       sessionStorage.removeItem(SIGNIN_GUARD_KEY);
       throw new Error(
         'OIDC sign-in redirect loop detected. Check provider redirect URIs '
@@ -301,3 +309,6 @@ export const getOidcAuth = () => {
   }
   return oidc;
 };
+
+/* Sends the user off to the IdP, for an interactive sign-in */
+export const oidcSignIn = () => getOidcAuth().redirectToIdp(true);

--- a/src/utils/config/ConfigSchema.json
+++ b/src/utils/config/ConfigSchema.json
@@ -697,6 +697,12 @@
                     "type": "string",
                     "description": "The scope(s) to request from the OIDC provider"
                   },
+                "showLoginPage": {
+                  "title": "Show Dashy's Login Page",
+                  "type": "boolean",
+                  "default": false,
+                  "description": "If set to true, signed-out users are shown Dashy's login page (with sign-in and guest buttons), instead of being redirected straight to the OIDC provider"
+                },
                 "enableSilentRenew": {
                   "title": "Enable Silent Token Renewal",
                   "type": "boolean",

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -48,9 +48,17 @@
         <p :class="`login-error-message ${status}`" v-show="message">{{ message }}</p>
       </transition>
     </form>
+    <!-- OIDC sign-in -->
+    <form class="login-form" v-if="isOidcEnabled && !isUserAlreadyLoggedIn">
+      <h2 class="login-title">{{ $t('login.oidc-label') }}</h2>
+      <Button class="login-button" :click="oidcLogin">
+        {{ $t('login.oidc-login-button') }}
+      </Button>
+    </form>
     <!-- Guest login form -->
     <form class="guest-form"
-      v-if="isGuestAccessEnabled && !isUserAlreadyLoggedIn && isAuthenticationEnabled">
+      v-if="isGuestAccessEnabled && !isUserAlreadyLoggedIn
+        && (isAuthenticationEnabled || isOidcEnabled)">
       <h2 class="login-title">{{ $t('login.guest-label') }}</h2>
       <Button class="login-button" :click="guestLogin">
         {{ $t('login.proceed-guest-button') }}
@@ -61,7 +69,7 @@
       </p>
     </form>
     <!-- Edge case - guest mode enabled, but no users configured -->
-    <div class="not-configured" v-if="!isAuthenticationEnabled">
+    <div class="not-configured" v-if="!isAuthenticationEnabled && !isOidcEnabled">
       <h2>{{ $t('login.error') }}</h2>
       <p>{{ $t('login.error-no-user-configured') }}</p>
       <Button class="login-button" :click="guestLogin">
@@ -86,6 +94,7 @@ import {
   isGuestAccessEnabled,
   getLogoutRedirectUrl,
 } from '@/utils/auth/Auth';
+import { isOidcEnabled, oidcSignIn } from '@/utils/auth/OidcAuth';
 
 export default {
   name: 'login',
@@ -134,11 +143,16 @@ export default {
       return Array.isArray(auth) ? auth : auth.users || [];
     },
     isUserAlreadyLoggedIn() {
+      // For OIDC there are no configured users, so the session itself is the check
+      if (this.isOidcEnabled) return Boolean(isLoggedIn() && this.existingUsername);
       const loggedIn = (!this.users || this.users.length === 0 || isLoggedIn());
       return (loggedIn && this.existingUsername);
     },
     isGuestAccessEnabled() {
       return isGuestAccessEnabled();
+    },
+    isOidcEnabled() {
+      return isOidcEnabled();
     },
     isAuthenticationEnabled() {
       return (this.appConfig && this.appConfig.auth && this.users.length > 0);
@@ -166,6 +180,10 @@ export default {
       } else {
         WarningInfoHandler('Unable to Sign In', InfoKeys.AUTH, this.message);
       }
+    },
+    /* Sends the user to their OIDC provider, to sign in */
+    oidcLogin() {
+      oidcSignIn();
     },
     /* Calls function to double-check guest access enabled, then log in as guest */
     guestLogin() {


### PR DESCRIPTION
### Category
Feature

### Overview
Some users who have OIDC enabled plus guest access wish to land strait on Dashy's login page, instead of being directly sent to their guest-authenticated dashboard. This saves them a click.

Now if the new `showLoginPage` is set, instead of landing on their dashboard, they will land on Dashy's `/login` page, where they can either click: "Proceed with OIDC" (and login), or "Proceed as guest" (and go strait to guest access homepage).

### Issue Number
Fixes #2302

### Additional Info

Usage is done by adding `appConfig.auth.oidc.showLoginPage` to `true`. Like this:

```yaml
    oidc:
      clientId: dashy
      endpoint: 'https://your-oidc-provider.example.com'
      showLoginPage: true # <---- this :)
```

