### PR TITLE
Better Uptime Kuma widget

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -2837,23 +2837,21 @@ Linkding is a self-hosted bookmarking service, which has a clean interface and i
 | ------------------ | -------- | ------------ | --------------------------------------------------------------------------------- |
 | **`host`**         | `string` | Required     | The URL of the Uptime Kuma instance                                               |
 | **`slug`**         | `string` | Required     | The slug of the status page                                                       |
-| **`monitorNames`** | `strins` | _Optional_   | Names of monitored services (in the same order as on the kuma uptime status page) |
+| **`monitorNames`** | `string[]` | _Optional_   | Optional labels to override the monitor names from Uptime Kuma, in the same order as they appear on the status page |
 
 #### Example
 
 ```yaml
 - type: uptime-kuma-status-page
+  useProxy: true
   options:
     host: http://localhost:3001
     slug: another-beautiful-status-page
-    monitorNames:
-      - "Name1"
-      - "Name2"
 ```
 
 #### Info
 
-- **CORS**: 🟢 Enabled
+- **CORS**: 🔴 Proxied (Uptime Kuma only sends CORS headers when running in development mode, so `useProxy: true` is required)
 - **Auth**: 🟢 Not Needed
 - **Price**: 🟢 Free
 - **Host**: Self-Hosted (see [Uptime Kuma](https://github.com/louislam/uptime-kuma) )

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -73,8 +73,8 @@ Dashy has support for displaying dynamic content in the form of widgets. There a
   - [Drone CI Build](#drone-ci-builds)
   - [Filebrowser](#filebrowser)
   - [Linkding](#linkding)
-  - [Uptime Kuma](#uptime-kuma)
   - [Uptime Kuma Status Page](#uptime-kuma-status-page)
+  - [Uptime Kuma](#uptime-kuma)
   - [Tactical RMM](#tactical-rmm)
 - **[System Resource Monitoring](#system-resource-monitoring)**
   - [CPU Usage Current](#current-cpu-usage)
@@ -2796,6 +2796,42 @@ Linkding is a self-hosted bookmarking service, which has a clean interface and i
 
 ---
 
+### Uptime Kuma Status Page
+
+[Uptime Kuma](https://github.com/louislam/uptime-kuma) is an easy-to-use self-hosted monitoring tool.
+This widget displays the status of your Uptime Kuma monitors from a given status page, including their current history, uptime history, response times and recent failures.
+
+#### Options
+
+| **Field**          | **Type** | **Required** | **Description**                                                                   |
+| ------------------ | -------- | ------------ | --------------------------------------------------------------------------------- |
+| **`host`**         | `string` | Required     | The URL of the Uptime Kuma instance                                               |
+| **`slug`**         | `string` | Required     | The slug of the status page                                                       |
+| **`monitorNames`** | `string[]` | _Optional_   | Optional labels to override the monitor names from Uptime Kuma, in the same order as they appear on the status page |
+| **`hideHistory`**  | `boolean` | _Optional_   | Optionally hide the strip of recent heartbeats |
+| **`hideUptime`**   | `boolean` | _Optional_   | Optionally hide the 24-hour uptime percentage |
+| **`hideStatus`**   | `boolean` | _Optional_   | Optionally hide the up/ down status pill |
+
+#### Example
+
+```yaml
+- type: uptime-kuma-status-page
+  useProxy: true
+  options:
+    host: https://uptime.as93.net
+    slug: domain-locker
+```
+
+#### Info
+
+- **CORS**: 🔴 Proxied (Uptime Kuma only sends CORS headers when running in development mode, so `useProxy: true` is required)
+- **Auth**: 🟢 Not Needed
+- **Price**: 🟢 Free
+- **Host**: Self-Hosted (see [Uptime Kuma](https://github.com/louislam/uptime-kuma) )
+- **Privacy**: _See [Uptime Kuma](https://github.com/louislam/uptime-kuma)_
+
+---
+
 ### Uptime Kuma
 
 [Uptime Kuma](https://github.com/louislam/uptime-kuma) is an easy-to-use self-hosted monitoring tool.
@@ -2806,6 +2842,11 @@ Linkding is a self-hosted bookmarking service, which has a clean interface and i
 | ------------ | -------- | ------------ | ------------------------------------------------------------------------ |
 | **`url`**    | `string` | Required     | The URL of the Uptime Kuma instance                                      |
 | **`apiKey`** | `string` | Required     | The API key (see https://github.com/louislam/uptime-kuma/wiki/API-Keys). |
+| **`hideStatus`** | `boolean` | _Optional_ | Optionally hide the up/ down status pill |
+| **`hideResponseTime`** | `boolean` | _Optional_ | Optionally hide the response time |
+| **`hideUptime`** | `boolean` | _Optional_ | Optionally hide the 24-hour uptime percentage |
+
+Each monitor shows its status, response time and 24-hour uptime. Hover a monitor for its 30-day and 1-year uptime, and average response times. Hide any of the columns with the options above.
 
 #### Example
 
@@ -2821,38 +2862,6 @@ Linkding is a self-hosted bookmarking service, which has a clean interface and i
 
 - **CORS**: 🔴 Proxied
 - **Auth**: 🟢 Required
-- **Price**: 🟢 Free
-- **Host**: Self-Hosted (see [Uptime Kuma](https://github.com/louislam/uptime-kuma) )
-- **Privacy**: _See [Uptime Kuma](https://github.com/louislam/uptime-kuma)_
-
----
-
-### Uptime Kuma Status Page
-
-[Uptime Kuma](https://github.com/louislam/uptime-kuma) is an easy-to-use self-hosted monitoring tool.
-
-#### Options
-
-| **Field**          | **Type** | **Required** | **Description**                                                                   |
-| ------------------ | -------- | ------------ | --------------------------------------------------------------------------------- |
-| **`host`**         | `string` | Required     | The URL of the Uptime Kuma instance                                               |
-| **`slug`**         | `string` | Required     | The slug of the status page                                                       |
-| **`monitorNames`** | `string[]` | _Optional_   | Optional labels to override the monitor names from Uptime Kuma, in the same order as they appear on the status page |
-
-#### Example
-
-```yaml
-- type: uptime-kuma-status-page
-  useProxy: true
-  options:
-    host: http://localhost:3001
-    slug: another-beautiful-status-page
-```
-
-#### Info
-
-- **CORS**: 🔴 Proxied (Uptime Kuma only sends CORS headers when running in development mode, so `useProxy: true` is required)
-- **Auth**: 🟢 Not Needed
 - **Price**: 🟢 Free
 - **Host**: Self-Hosted (see [Uptime Kuma](https://github.com/louislam/uptime-kuma) )
 - **Privacy**: _See [Uptime Kuma](https://github.com/louislam/uptime-kuma)_

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -2819,7 +2819,7 @@ Linkding is a self-hosted bookmarking service, which has a clean interface and i
 
 #### Info
 
-- **CORS**: 🟢 Enabled
+- **CORS**: 🔴 Proxied
 - **Auth**: 🟢 Required
 - **Price**: 🟢 Free
 - **Host**: Self-Hosted (see [Uptime Kuma](https://github.com/louislam/uptime-kuma) )

--- a/src/components/Widgets/UptimeKuma.vue
+++ b/src/components/Widgets/UptimeKuma.vue
@@ -1,15 +1,17 @@
 <template>
   <div>
     <template v-if="monitors">
-      <div v-for="(monitor, index) in monitors" :key="index" class="item-wrapper">
+      <div v-for="monitor in monitors" :key="monitor.name" class="item-wrapper">
         <div class="item monitor-row">
           <div class="title-title"><span class="text">{{ monitor.name }}</span></div>
           <div class="monitors-container">
             <div class="status-container">
-              <span class="status-pill" :class="[monitor.statusClass]">{{ monitor.status }}</span>
+              <span class="status-pill" :class="getStatusClass(monitor.status)">
+                {{ getStatusText(monitor.status) }}
+              </span>
             </div>
             <div class="status-container">
-              <span class="response-time">{{ monitor.responseTime }}ms</span>
+              <span class="response-time">{{ formatResponseTime(monitor.responseTime) }}</span>
             </div>
           </div>
         </div>
@@ -26,15 +28,21 @@
 
 <script>
 /**
- * A simple example which you can use as a template for creating your own widget.
- * Takes two optional parameters (`text` and `count`), and fetches a list of images
- * from dummyapis.com, then renders the results to the UI.
+ * Renders the status and response time of each monitor on an Uptime Kuma
+ * instance, read from its Prometheus-format `/metrics` endpoint
  */
 import WidgetMixin from '@/mixins/WidgetMixin';
 
+const STATUSES = {
+  0: { text: 'Down', class: 'down' },
+  1: { text: 'Up', class: 'up' },
+  2: { text: 'Pending', class: 'pending' },
+  3: { text: 'Maintenance', class: 'maintenance' },
+};
+const UNKNOWN = { text: 'Unknown', class: 'unknown' };
+
 export default {
   mixins: [WidgetMixin],
-  components: {},
   data() {
     return {
       monitors: null,
@@ -46,9 +54,6 @@ export default {
     };
   },
 
-  mounted() {
-    this.fetchData();
-  },
   computed: {
     /* Get API key for access to instance */
     apiKey() {
@@ -68,23 +73,34 @@ export default {
     },
   },
   methods: {
-    /* The update() method extends mixin, used to update the data.
-     * It's called by parent component, when the user presses update
-     */
+    getStatusText(status) {
+      return (STATUSES[status] || UNKNOWN).text;
+    },
+    getStatusClass(status) {
+      return (STATUSES[status] || UNKNOWN).class;
+    },
     update() {
       this.startLoading();
       this.fetchData();
     },
     /* Make the data request to the computed API endpoint */
     fetchData() {
-      const { authHeaders, url } = this;
+      const { authHeaders, url, apiKey } = this;
 
-      if (!this.optionsValid({ authHeaders, url })) {
+      if (!this.optionsValid({ url, apiKey })) {
         return;
       }
 
       this.makeRequest(url, authHeaders)
-        .then(this.processData);
+        .then(this.processData)
+        .catch((error) => {
+          this.errorMessage = error.message || 'Failed to fetch data';
+        });
+    },
+    /* Add ms unit to response time if it valid (-1 means no ping) */
+    formatResponseTime(responseTime) {
+      const ms = Number(responseTime);
+      return Number.isFinite(ms) && ms >= 0 ? `${ms}ms` : '-';
     },
     /* Convert API response data into a format to be consumed by the UI */
     processData(response) {
@@ -97,14 +113,18 @@ export default {
         this.processRow(row, monitors);
       }
 
+      this.errorMessage = null;
       this.monitors = Array.from(monitors.values());
     },
     getMonitorRows(response) {
+      if (typeof response !== 'string') return [];
       return response.split('\n').filter(row => row.startsWith('monitor_'));
     },
     processRow(row, monitors) {
       const dataType = this.getRowDataType(row);
       const monitorName = this.getRowMonitorName(row);
+
+      if (!monitorName) return;
 
       if (!monitors.has(monitorName)) {
         monitors.set(monitorName, { name: monitorName });
@@ -133,8 +153,7 @@ export default {
           break;
         }
         case 'monitor_status': {
-          copy.status = value === '1' ? 'Up' : 'Down';
-          copy.statusClass = copy.status.toLowerCase();
+          copy.status = Number(value);
           break;
         }
         default:
@@ -144,7 +163,7 @@ export default {
       return copy;
     },
     getRowValue(row) {
-      return this.getValueWithRegex(row, /\b(\d+)(\.\d+)*\b$/);
+      return this.getValueWithRegex(row, /\s(\S+)\s*$/);
     },
     getRowMonitorName(row) {
       return this.getValueWithRegex(row, /monitor_name="([^"]+)"/);
@@ -163,13 +182,13 @@ export default {
 
       return result.length > 1 ? result[1] : result[0];
     },
-    optionsValid({ url, authHeaders }) {
+    optionsValid({ url, apiKey }) {
       const errors = [];
-      if (url === undefined) {
+      if (!url) {
         errors.push(this.errorMessageConstants.missingUrl);
       }
 
-      if (authHeaders === undefined) {
+      if (!apiKey) {
         errors.push(this.errorMessageConstants.missingApiKey);
       }
 
@@ -192,7 +211,7 @@ export default {
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  padding: .35em .65em;
+  padding: 0.35em 0.65em;
   margin: 0.1em 0.5em;
   min-width: 64px;
 
@@ -200,9 +219,20 @@ export default {
     background-color: var(--success);
     color: var(--black);
   }
-
   &.down {
     background-color: var(--danger);
+    color: var(--white);
+  }
+  &.pending {
+    background-color: var(--warning);
+    color: var(--black);
+  }
+  &.maintenance {
+    background-color: var(--info);
+    color: var(--black);
+  }
+  &.unknown {
+    background-color: var(--neutral);
     color: var(--white);
   }
 }

--- a/src/components/Widgets/UptimeKuma.vue
+++ b/src/components/Widgets/UptimeKuma.vue
@@ -197,13 +197,13 @@ export default {
   min-width: 64px;
 
   &.up {
-    background-color: rgb(92, 221, 139);
-    color: black;
+    background-color: var(--success);
+    color: var(--black);
   }
 
   &.down {
-    background-color: rgb(220, 53, 69);
-    color: white;
+    background-color: var(--danger);
+    color: var(--white);
   }
 }
 

--- a/src/components/Widgets/UptimeKuma.vue
+++ b/src/components/Widgets/UptimeKuma.vue
@@ -2,16 +2,19 @@
   <div>
     <template v-if="monitors">
       <div v-for="monitor in monitors" :key="monitor.name" class="item-wrapper">
-        <div class="item monitor-row">
+        <div class="item monitor-row" v-tooltip="monitorTooltip(monitor)">
           <div class="title-title"><span class="text">{{ monitor.name }}</span></div>
           <div class="monitors-container">
-            <div class="status-container">
+            <div v-if="!hideStatus" class="status-container">
               <span class="status-pill" :class="getStatusClass(monitor.status)">
                 {{ getStatusText(monitor.status) }}
               </span>
             </div>
-            <div class="status-container">
+            <div v-if="!hideResponseTime" class="status-container">
               <span class="response-time">{{ formatResponseTime(monitor.responseTime) }}</span>
+            </div>
+            <div v-if="!hideUptime && monitor.uptime" class="status-container">
+              <span class="uptime">{{ monitor.uptime }}</span>
             </div>
           </div>
         </div>
@@ -40,6 +43,8 @@ const STATUSES = {
   3: { text: 'Maintenance', class: 'maintenance' },
 };
 const UNKNOWN = { text: 'Unknown', class: 'unknown' };
+const WINDOWS = [['1d', '24h'], ['30d', '30d'], ['365d', '1y']];
+const formatPercent = (ratio) => `${(ratio * 100).toFixed(2)}%`;
 
 export default {
   mixins: [WidgetMixin],
@@ -62,6 +67,15 @@ export default {
     /* Get instance URL */
     url() {
       return this.parseAsEnvVar(this.options.url);
+    },
+    hideStatus() {
+      return this.options.hideStatus || false;
+    },
+    hideResponseTime() {
+      return this.options.hideResponseTime || false;
+    },
+    hideUptime() {
+      return this.options.hideUptime || false;
     },
     /* Create authorisation header for the instance from the apiKey */
     authHeaders() {
@@ -98,6 +112,18 @@ export default {
         });
     },
     /* Add ms unit to response time if it valid (-1 means no ping) */
+    summariseWindows(label, values, format) {
+      const parts = WINDOWS
+        .filter(([key]) => Number.isFinite(values?.[key]))
+        .map(([key, name]) => `${format(values[key])} (${name})`);
+      return parts.length ? `${label}: ${parts.join(', ')}` : null;
+    },
+    monitorTooltip(monitor) {
+      return this.tooltip([
+        this.summariseWindows('Uptime', monitor.uptimes, formatPercent),
+        this.summariseWindows('Avg response', monitor.avgResponse, (v) => `${Math.round(v * 1000)}ms`),
+      ].filter(Boolean).join('<br>'), true);
+    },
     formatResponseTime(responseTime) {
       const ms = Number(responseTime);
       return Number.isFinite(ms) && ms >= 0 ? `${ms}ms` : '-';
@@ -133,13 +159,22 @@ export default {
       const monitor = monitors.get(monitorName);
       const value = this.getRowValue(row);
 
-      const updated = this.setMonitorValue(dataType, monitor, value);
+      const updated = this.setMonitorValue(dataType, monitor, value, this.getRowWindow(row));
 
       monitors.set(monitorName, updated);
     },
-    setMonitorValue(key, monitor, value) {
+    setMonitorValue(key, monitor, value, timeWindow) {
       const copy = { ...monitor };
       switch (key) {
+        case 'monitor_uptime_ratio': {
+          copy.uptimes = { ...copy.uptimes, [timeWindow]: Number(value) };
+          if (timeWindow === '1d') copy.uptime = formatPercent(Number(value));
+          break;
+        }
+        case 'monitor_response_time_seconds': {
+          copy.avgResponse = { ...copy.avgResponse, [timeWindow]: Number(value) };
+          break;
+        }
         case 'monitor_cert_days_remaining': {
           copy.certDaysRemaining = value;
           break;
@@ -167,6 +202,9 @@ export default {
     },
     getRowMonitorName(row) {
       return this.getValueWithRegex(row, /monitor_name="([^"]+)"/);
+    },
+    getRowWindow(row) {
+      return this.getValueWithRegex(row, /window="([^"]+)"/);
     },
     getRowDataType(row) {
       return this.getValueWithRegex(row, /^(.*?)\{/);

--- a/src/components/Widgets/UptimeKumaStatusPage.vue
+++ b/src/components/Widgets/UptimeKumaStatusPage.vue
@@ -13,13 +13,7 @@
       >
         <div class="item monitor-row">
           <div class="title-title">
-            <span class="text">
-              {{
-                monitorNames && monitorNames[index]
-                  ? monitorNames[index]
-                  : `Monitor ${index + 1}`
-              }}
-            </span>
+            <span class="text">{{ heartbeat.name }}</span>
           </div>
           <div class="monitors-container">
             <div class="status-container">
@@ -60,10 +54,14 @@ export default {
       return this.parseAsEnvVar(this.options.slug);
     },
     monitorNames() {
-      return this.options.monitorNames || [];
+      return Array.isArray(this.options.monitorNames) ? this.options.monitorNames : [];
     },
     endpoint() {
       return `${this.host}/api/status-page/heartbeat/${this.slug}`;
+    },
+    /* Monitor names aren't in the heartbeat response, they're only here */
+    configEndpoint() {
+      return `${this.host}/api/status-page/${this.slug}`;
     },
     statusPageUrl() {
       return `${this.host}/status/${this.slug}`;
@@ -82,24 +80,33 @@ export default {
       if (!this.optionsValid({ host, slug })) {
         return;
       }
-      this.makeRequest(this.endpoint)
-        .then(this.processData)
+      Promise.all([
+        this.makeRequest(this.endpoint), // Get uptime data
+        this.makeRequest(this.configEndpoint).catch(() => null), // attempt get monitor names
+      ])
+        .then(([heartbeats, statusPage]) => this.processData(heartbeats, statusPage))
         .catch((error) => {
           this.errorMessage = error.message || 'Failed to fetch data';
         });
     },
-    processData(response) {
+    processData(response, statusPage) {
       const { heartbeatList } = response;
-      const lastHeartbeats = [];
-      // Use Object.keys to safely iterate over heartbeatList
-      Object.keys(heartbeatList).forEach((monitorId) => {
-        const heartbeats = heartbeatList[monitorId];
-        if (heartbeats.length > 0) {
-          const lastHeartbeat = heartbeats[heartbeats.length - 1];
-          lastHeartbeats.push(lastHeartbeat);
-        }
-      });
-      this.lastHeartbeats = lastHeartbeats;
+      this.lastHeartbeats = this.getOrderedMonitors(statusPage, heartbeatList)
+        .map((monitor, index) => {
+          const heartbeats = heartbeatList[monitor.id];
+          return {
+            ...heartbeats[heartbeats.length - 1],
+            name: this.monitorNames[index] || monitor.name || `Monitor ${index + 1}`,
+          };
+        });
+    },
+    /* Monitors which have heartbeats, in the same order as the status page */
+    getOrderedMonitors(statusPage, heartbeatList) {
+      const groups = statusPage?.publicGroupList;
+      const monitors = groups
+        ? groups.flatMap((group) => group.monitorList)
+        : Object.keys(heartbeatList).map((id) => ({ id }));
+      return monitors.filter((monitor) => heartbeatList[monitor.id]?.length > 0);
     },
     optionsValid({ host, slug }) {
       const errors = [];
@@ -163,24 +170,24 @@ export default {
   margin: 0.1em 0.5em;
   min-width: 64px;
   &.up {
-    background-color: #5cdd8b;
-    color: black;
+    background-color: var(--success);
+    color: var(--black);
   }
   &.down {
-    background-color: #dc3545;
-    color: white;
+    background-color: var(--danger);
+    color: var(--white);
   }
   &.pending {
-    background-color: #f8a306;
-    color: black;
+    background-color: var(--warning);
+    color: var(--black);
   }
   &.maintenance {
-    background-color: #1747f5;
-    color: white;
+    background-color: var(--info);
+    color: var(--black);
   }
   &.unknown {
-    background-color: gray;
-    color: white;
+    background-color: var(--neutral);
+    color: var(--white);
   }
 }
 .monitor-row {
@@ -193,7 +200,7 @@ export default {
   font-weight: bold;
 }
 .error-message {
-  color: red;
+  color: var(--danger);
   font-weight: bold;
 }
 </style>

--- a/src/components/Widgets/UptimeKumaStatusPage.vue
+++ b/src/components/Widgets/UptimeKumaStatusPage.vue
@@ -11,19 +11,23 @@
         :key="heartbeat.id"
         class="item-wrapper"
       >
-        <div class="item monitor-row">
+        <div class="item monitor-row" v-tooltip="monitorTooltip(heartbeat)">
           <div class="title-title">
             <span class="text">{{ heartbeat.name }}</span>
           </div>
           <div class="monitors-container">
-            <div class="status-container">
+            <div v-if="!hideHistory" class="heartbeat-strip">
               <span
-                class="status-pill"
-                :class="getStatusClass(heartbeat.status)"
-              >
-                {{ getStatusText(heartbeat.status) }}
-              </span>
+                v-for="(beat, index) in heartbeat.history"
+                :key="index"
+                class="beat"
+                :class="getStatusClass(beat.status)"
+              ></span>
             </div>
+            <span v-if="!hideUptime && heartbeat.uptime" class="uptime">{{ heartbeat.uptime }}</span>
+            <span v-if="!hideStatus" class="status-pill" :class="getStatusClass(heartbeat.status)">
+              {{ getStatusText(heartbeat.status) }}
+            </span>
           </div>
         </div>
       </div>
@@ -33,6 +37,7 @@
 
 <script>
 import WidgetMixin from '@/mixins/WidgetMixin';
+import { getTimeAgo } from '@/utils/MiscHelpers';
 
 const STATUSES = {
   0: { text: 'Down', class: 'down' },
@@ -41,6 +46,7 @@ const STATUSES = {
   3: { text: 'Maintenance', class: 'maintenance' },
 };
 const UNKNOWN = { text: 'Unknown', class: 'unknown' };
+const HISTORY_BEATS = 30;
 
 export default {
   mixins: [WidgetMixin],
@@ -63,6 +69,15 @@ export default {
     },
     monitorNames() {
       return Array.isArray(this.options.monitorNames) ? this.options.monitorNames : [];
+    },
+    hideHistory() {
+      return this.options.hideHistory || false;
+    },
+    hideUptime() {
+      return this.options.hideUptime || false;
+    },
+    hideStatus() {
+      return this.options.hideStatus || false;
     },
     endpoint() {
       return `${this.host}/api/status-page/heartbeat/${this.slug}`;
@@ -100,17 +115,30 @@ export default {
         });
     },
     processData(response, statusPage) {
-      const { heartbeatList } = response;
+      const { heartbeatList, uptimeList } = response;
       this.errorMessage = null;
       this.lastHeartbeats = this.getOrderedMonitors(statusPage, heartbeatList)
         .map((monitor, index) => {
           const heartbeats = heartbeatList[monitor.id];
+          const uptime = uptimeList?.[`${monitor.id}_24`];
           return {
             ...heartbeats[heartbeats.length - 1],
             id: monitor.id,
             name: this.monitorNames[index] || monitor.name || `Monitor ${index + 1}`,
+            uptime: typeof uptime === 'number' ? `${(uptime * 100).toFixed(2)}%` : null,
+            history: heartbeats.slice(-HISTORY_BEATS),
           };
         });
+    },
+    monitorTooltip(heartbeat) {
+      const failed = heartbeat.history.filter((beat) => beat.status === 0).length;
+      return this.tooltip([
+        Number.isFinite(heartbeat.ping) ? `Response: ${heartbeat.ping}ms` : null,
+        /* Kuma sends UTC, without a zone marker */
+        heartbeat.time ? `Last check: ${getTimeAgo(`${heartbeat.time.replace(' ', 'T')}Z`)}` : null,
+        failed ? `${failed} of ${heartbeat.history.length} recent checks failed` : null,
+        heartbeat.msg,
+      ].filter(Boolean).join('<br>'), true);
     },
     getOrderedMonitors(statusPage, heartbeatList) {
       const groups = statusPage?.publicGroupList;
@@ -174,6 +202,36 @@ export default {
 
 .clickable-widget {
   cursor: pointer;
+  container-type: inline-size;
+}
+.monitors-container {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+.uptime {
+  font-size: 0.8em;
+  opacity: 0.8;
+}
+.heartbeat-strip {
+  display: none;
+  gap: 1px;
+
+  .beat {
+    width: 3px;
+    height: 1.1em;
+    border-radius: 1px;
+    background-color: var(--neutral);
+
+    &.up { background-color: var(--success); }
+    &.down { background-color: var(--danger); }
+    &.pending { background-color: var(--warning); }
+    &.maintenance { background-color: var(--info); }
+  }
+}
+/* Only room for the strip once the widget's own column is wide enough */
+@container (min-width: 320px) {
+  .heartbeat-strip { display: flex; }
 }
 .monitor-row {
   display: flex;

--- a/src/components/Widgets/UptimeKumaStatusPage.vue
+++ b/src/components/Widgets/UptimeKumaStatusPage.vue
@@ -7,8 +7,8 @@
     </template>
     <template v-else-if="lastHeartbeats">
       <div
-        v-for="(heartbeat, index) in lastHeartbeats"
-        :key="index"
+        v-for="heartbeat in lastHeartbeats"
+        :key="heartbeat.id"
         class="item-wrapper"
       >
         <div class="item monitor-row">
@@ -33,6 +33,14 @@
 
 <script>
 import WidgetMixin from '@/mixins/WidgetMixin';
+
+const STATUSES = {
+  0: { text: 'Down', class: 'down' },
+  1: { text: 'Up', class: 'up' },
+  2: { text: 'Pending', class: 'pending' },
+  3: { text: 'Maintenance', class: 'maintenance' },
+};
+const UNKNOWN = { text: 'Unknown', class: 'unknown' };
 
 export default {
   mixins: [WidgetMixin],
@@ -59,7 +67,6 @@ export default {
     endpoint() {
       return `${this.host}/api/status-page/heartbeat/${this.slug}`;
     },
-    /* Monitor names aren't in the heartbeat response, they're only here */
     configEndpoint() {
       return `${this.host}/api/status-page/${this.slug}`;
     },
@@ -67,10 +74,13 @@ export default {
       return `${this.host}/status/${this.slug}`;
     },
   },
-  mounted() {
-    this.fetchData();
-  },
   methods: {
+    getStatusText(status) {
+      return (STATUSES[status] || UNKNOWN).text;
+    },
+    getStatusClass(status) {
+      return (STATUSES[status] || UNKNOWN).class;
+    },
     update() {
       this.startLoading();
       this.fetchData();
@@ -91,16 +101,17 @@ export default {
     },
     processData(response, statusPage) {
       const { heartbeatList } = response;
+      this.errorMessage = null;
       this.lastHeartbeats = this.getOrderedMonitors(statusPage, heartbeatList)
         .map((monitor, index) => {
           const heartbeats = heartbeatList[monitor.id];
           return {
             ...heartbeats[heartbeats.length - 1],
+            id: monitor.id,
             name: this.monitorNames[index] || monitor.name || `Monitor ${index + 1}`,
           };
         });
     },
-    /* Monitors which have heartbeats, in the same order as the status page */
     getOrderedMonitors(statusPage, heartbeatList) {
       const groups = statusPage?.publicGroupList;
       const monitors = groups
@@ -121,42 +132,11 @@ export default {
     openStatusPage() {
       window.open(this.statusPageUrl, '_blank');
     },
-    getStatusText(status) {
-      switch (status) {
-        case 1:
-          return 'Up';
-        case 0:
-          return 'Down';
-        case 2:
-          return 'Pending';
-        case 3:
-          return 'Maintenance';
-        default:
-          return 'Unknown';
-      }
-    },
-    getStatusClass(status) {
-      switch (status) {
-        case 1:
-          return 'up';
-        case 0:
-          return 'down';
-        case 2:
-          return 'pending';
-        case 3:
-          return 'maintenance';
-        default:
-          return 'unknown';
-      }
-    },
   },
 };
 </script>
 
 <style scoped lang="scss">
-.clickable-widget {
-  cursor: pointer;
-}
 .status-pill {
   border-radius: 50em;
   box-sizing: border-box;
@@ -169,6 +149,7 @@ export default {
   padding: 0.35em 0.65em;
   margin: 0.1em 0.5em;
   min-width: 64px;
+
   &.up {
     background-color: var(--success);
     color: var(--black);
@@ -189,6 +170,10 @@ export default {
     background-color: var(--neutral);
     color: var(--white);
   }
+}
+
+.clickable-widget {
+  cursor: pointer;
 }
 .monitor-row {
   display: flex;

--- a/tests/components/widgets/uptimekuma.test.js
+++ b/tests/components/widgets/uptimekuma.test.js
@@ -1,0 +1,80 @@
+import {
+  describe, it, expect, beforeEach, vi,
+} from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import request from '@/utils/request';
+import UptimeKuma from '@/components/Widgets/UptimeKuma.vue';
+
+vi.mock('@/utils/request', () => ({ default: vi.fn() }));
+vi.mock('@/utils/logging/ErrorHandler', () => ({ default: vi.fn() }));
+
+/* Prometheus rows, as Uptime Kuma writes them on /metrics */
+const row = (metric, name, value) => `${metric}{monitor_id="1",monitor_name="${name}",`
+  + `monitor_type="http",monitor_url="https://example.com"} ${value}`;
+
+const metrics = [
+  '# HELP monitor_status Monitor Status (1 = UP, 0= DOWN, 2= PENDING, 3= MAINTENANCE)',
+  row('monitor_status', 'App', 1),
+  row('monitor_status', 'Docs', 2),
+  row('monitor_status', 'API', 3),
+  row('monitor_response_time', 'App', 83),
+  row('monitor_response_time', 'Docs', -1),
+  row('monitor_response_time', 'API', 112),
+].join('\n');
+
+async function mount(options = {}) {
+  const wrapper = shallowMount(UptimeKuma, {
+    props: {
+      options: {
+        useProxy: false,
+        url: 'https://uptime.example.com/metrics',
+        apiKey: 'uk1_test',
+        ...options,
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+const textOf = (wrapper, selector) => wrapper.findAll(selector).map((n) => n.text());
+
+describe('UptimeKuma widget', () => {
+  beforeEach(() => {
+    request.mockReset();
+    request.mockResolvedValue({ data: metrics });
+  });
+
+  it('names each monitor, from its metric labels', async () => {
+    expect(textOf(await mount(), '.title-title')).toEqual(['App', 'Docs', 'API']);
+  });
+
+  it('distinguishes pending and maintenance from down', async () => {
+    const pills = (await mount()).findAll('.status-pill');
+    expect(pills.map((p) => p.text())).toEqual(['Up', 'Pending', 'Maintenance']);
+    expect(pills[1].classes()).toContain('pending');
+  });
+
+  it('shows a placeholder for a monitor with no ping, which Kuma reports as -1', async () => {
+    expect(textOf(await mount(), '.response-time')).toEqual(['83ms', '-', '112ms']);
+  });
+
+  it.each([
+    ['apiKey', 'No API key set'],
+    ['url', 'No URL set'],
+  ])('asks for a %s when one is missing', async (option, message) => {
+    const wrapper = await mount({ [option]: undefined });
+    expect(wrapper.find('.error-message').text()).toBe(message);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('shows a message when the request fails', async () => {
+    request.mockRejectedValue(new Error('Request failed with status code 401'));
+    expect((await mount()).find('.error-message').text()).toContain('401');
+  });
+
+  it('renders nothing when the response is not metrics text', async () => {
+    request.mockResolvedValue({ data: { unexpected: 'json' } });
+    expect((await mount()).findAll('.monitor-row')).toHaveLength(0);
+  });
+});

--- a/tests/components/widgets/uptimekuma.test.js
+++ b/tests/components/widgets/uptimekuma.test.js
@@ -9,8 +9,9 @@ vi.mock('@/utils/request', () => ({ default: vi.fn() }));
 vi.mock('@/utils/logging/ErrorHandler', () => ({ default: vi.fn() }));
 
 /* Prometheus rows, as Uptime Kuma writes them on /metrics */
-const row = (metric, name, value) => `${metric}{monitor_id="1",monitor_name="${name}",`
-  + `monitor_type="http",monitor_url="https://example.com"} ${value}`;
+const row = (metric, name, value) => `${metric}{monitor_id="1",monitor_name="${name}"} ${value}`;
+const windowed = (metric, name, win, value) => `${metric}{monitor_name="${name}",`
+  + `window="${win}"} ${value}`;
 
 const metrics = [
   '# HELP monitor_status Monitor Status (1 = UP, 0= DOWN, 2= PENDING, 3= MAINTENANCE)',
@@ -20,7 +21,13 @@ const metrics = [
   row('monitor_response_time', 'App', 83),
   row('monitor_response_time', 'Docs', -1),
   row('monitor_response_time', 'API', 112),
+  windowed('monitor_uptime_ratio', 'App', '1d', 0.9998),
+  windowed('monitor_uptime_ratio', 'App', '30d', 0.5),
+  windowed('monitor_response_time_seconds', 'App', '1d', 0.083),
 ].join('\n');
+
+const tooltips = [];
+const tooltip = { mounted: (el, binding) => tooltips.push(binding.value.content) };
 
 async function mount(options = {}) {
   const wrapper = shallowMount(UptimeKuma, {
@@ -32,6 +39,7 @@ async function mount(options = {}) {
         ...options,
       },
     },
+    global: { directives: { tooltip } },
   });
   await flushPromises();
   return wrapper;
@@ -41,6 +49,7 @@ const textOf = (wrapper, selector) => wrapper.findAll(selector).map((n) => n.tex
 
 describe('UptimeKuma widget', () => {
   beforeEach(() => {
+    tooltips.length = 0;
     request.mockReset();
     request.mockResolvedValue({ data: metrics });
   });
@@ -59,6 +68,22 @@ describe('UptimeKuma widget', () => {
     expect(textOf(await mount(), '.response-time')).toEqual(['83ms', '-', '112ms']);
   });
 
+  it('shows 24 hour uptime in the row, and the other windows in a tooltip', async () => {
+    const wrapper = await mount();
+    expect(textOf(wrapper, '.uptime')).toEqual(['99.98%']);
+    expect(tooltips[0]).toBe('Uptime: 99.98% (24h), 50.00% (30d)<br>Avg response: 83ms (24h)');
+  });
+
+  it.each([
+    ['hideStatus', '.status-pill'],
+    ['hideResponseTime', '.response-time'],
+    ['hideUptime', '.uptime'],
+  ])('%s hides it, leaving the rest', async (option, selector) => {
+    const wrapper = await mount({ [option]: true });
+    expect(wrapper.findAll(selector)).toHaveLength(0);
+    expect(textOf(wrapper, '.title-title')).toEqual(['App', 'Docs', 'API']);
+  });
+
   it.each([
     ['apiKey', 'No API key set'],
     ['url', 'No URL set'],
@@ -71,10 +96,5 @@ describe('UptimeKuma widget', () => {
   it('shows a message when the request fails', async () => {
     request.mockRejectedValue(new Error('Request failed with status code 401'));
     expect((await mount()).find('.error-message').text()).toContain('401');
-  });
-
-  it('renders nothing when the response is not metrics text', async () => {
-    request.mockResolvedValue({ data: { unexpected: 'json' } });
-    expect((await mount()).findAll('.monitor-row')).toHaveLength(0);
   });
 });

--- a/tests/components/widgets/uptimekumastatuspage.test.js
+++ b/tests/components/widgets/uptimekumastatuspage.test.js
@@ -1,0 +1,91 @@
+import {
+  describe, it, expect, beforeEach, vi,
+} from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import request from '@/utils/request';
+import UptimeKumaStatusPage from '@/components/Widgets/UptimeKumaStatusPage.vue';
+
+vi.mock('@/utils/request', () => ({ default: vi.fn() }));
+vi.mock('@/utils/logging/ErrorHandler', () => ({ default: vi.fn() }));
+
+/* Note the display order (App, API, Docs) differs from monitor id order (5, 6, 7) */
+const statusPage = {
+  publicGroupList: [
+    {
+      name: 'Web',
+      monitorList: [{ id: 5, name: 'App' }, { id: 7, name: 'API' }, { id: 6, name: 'Docs' }],
+    },
+    { name: 'Auth', monitorList: [] },
+  ],
+};
+
+const beats = (status) => [{ status: 1, ping: 91 }, { status, ping: 83 }];
+const heartbeats = { heartbeatList: { 5: beats(1), 7: beats(0), 6: beats(1) } };
+
+/* Heartbeats and monitor names come from two separate endpoints */
+function mockApi({ beatData = heartbeats, pageData = statusPage } = {}) {
+  request.mockImplementation(({ url }) => {
+    if (url.includes('/heartbeat/')) return Promise.resolve({ data: beatData });
+    if (!pageData) return Promise.reject(new Error('Status Page Not Found'));
+    return Promise.resolve({ data: pageData });
+  });
+}
+
+async function mount(options = {}) {
+  const wrapper = shallowMount(UptimeKumaStatusPage, {
+    props: {
+      options: {
+        useProxy: false, host: 'https://uptime.example.com', slug: 'domain-locker', ...options,
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+const names = (wrapper) => wrapper.findAll('.title-title').map((n) => n.text());
+
+describe('UptimeKumaStatusPage widget', () => {
+  beforeEach(() => {
+    request.mockReset();
+    mockApi();
+  });
+
+  it('names each monitor, in the order the status page lists them', async () => {
+    expect(names(await mount())).toEqual(['App', 'API', 'Docs']);
+  });
+
+  it('shows each monitor status, from its latest heartbeat', async () => {
+    const pills = (await mount()).findAll('.status-pill');
+    expect(pills.map((p) => p.text())).toEqual(['Up', 'Down', 'Up']);
+    expect(pills[1].classes()).toContain('down');
+  });
+
+  it('lets monitorNames override the names from Uptime Kuma', async () => {
+    expect(names(await mount({ monitorNames: ['One', 'Two', 'Three'] }))).toEqual(['One', 'Two', 'Three']);
+  });
+
+  it('keeps the real name where monitorNames runs out', async () => {
+    expect(names(await mount({ monitorNames: ['One'] }))).toEqual(['One', 'API', 'Docs']);
+  });
+
+  it('ignores a monitorNames given as a string rather than a list', async () => {
+    expect(names(await mount({ monitorNames: '["One","Two"]' }))).toEqual(['App', 'API', 'Docs']);
+  });
+
+  it('numbers the monitors when the status page cannot be reached', async () => {
+    mockApi({ pageData: null });
+    expect(names(await mount())).toEqual(['Monitor 1', 'Monitor 2', 'Monitor 3']);
+  });
+
+  it('skips monitors with no heartbeats yet', async () => {
+    mockApi({ beatData: { heartbeatList: { 5: beats(1), 7: [], 6: beats(1) } } });
+    expect(names(await mount())).toEqual(['App', 'Docs']);
+  });
+
+  it('asks for a slug when one is missing', async () => {
+    const wrapper = await mount({ slug: undefined });
+    expect(wrapper.find('.error-message').text()).toBe('No slug set');
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/widgets/uptimekumastatuspage.test.js
+++ b/tests/components/widgets/uptimekumastatuspage.test.js
@@ -1,5 +1,5 @@
 import {
-  describe, it, expect, beforeEach, vi,
+  describe, it, expect, beforeEach, afterEach, vi,
 } from 'vitest';
 import { shallowMount, flushPromises } from '@vue/test-utils';
 import request from '@/utils/request';
@@ -8,7 +8,7 @@ import UptimeKumaStatusPage from '@/components/Widgets/UptimeKumaStatusPage.vue'
 vi.mock('@/utils/request', () => ({ default: vi.fn() }));
 vi.mock('@/utils/logging/ErrorHandler', () => ({ default: vi.fn() }));
 
-/* Note the display order (App, API, Docs) differs from monitor id order (5, 6, 7) */
+/* Display order (App, API, Docs) differs from monitor id order (5, 6, 7) */
 const statusPage = {
   publicGroupList: [
     {
@@ -19,8 +19,20 @@ const statusPage = {
   ],
 };
 
-const beats = (status) => [{ status: 1, ping: 91 }, { status, ping: 83 }];
-const heartbeats = { heartbeatList: { 5: beats(1), 7: beats(0), 6: beats(1) } };
+const beats = (status, msg = '') => [
+  { status: 1, ping: 91, time: '2026-08-27 17:15:46' },
+  {
+    status, ping: 83, time: '2026-08-27 17:16:46', msg,
+  },
+];
+
+const heartbeats = {
+  heartbeatList: { 5: beats(1), 7: beats(0, 'timeout'), 6: beats(1) },
+  uptimeList: { '5_24': 1, '7_24': 0.9876, '6_24': 0.5 },
+};
+
+const tooltips = [];
+const tooltip = { mounted: (el, binding) => tooltips.push(binding.value.content) };
 
 /* Heartbeats and monitor names come from two separate endpoints */
 function mockApi({ beatData = heartbeats, pageData = statusPage } = {}) {
@@ -38,49 +50,65 @@ async function mount(options = {}) {
         useProxy: false, host: 'https://uptime.example.com', slug: 'domain-locker', ...options,
       },
     },
+    global: { directives: { tooltip } },
   });
   await flushPromises();
   return wrapper;
 }
 
-const names = (wrapper) => wrapper.findAll('.title-title').map((n) => n.text());
+const textOf = (wrapper, selector) => wrapper.findAll(selector).map((n) => n.text());
+const names = (wrapper) => textOf(wrapper, '.title-title');
 
 describe('UptimeKumaStatusPage widget', () => {
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] }); // Date only, so promises still flush
+    vi.setSystemTime(new Date('2026-08-27T17:20:46Z'));
+    tooltips.length = 0;
     request.mockReset();
     mockApi();
   });
+
+  afterEach(() => vi.useRealTimers());
 
   it('names each monitor, in the order the status page lists them', async () => {
     expect(names(await mount())).toEqual(['App', 'API', 'Docs']);
   });
 
-  it('shows each monitor status, from its latest heartbeat', async () => {
-    const pills = (await mount()).findAll('.status-pill');
-    expect(pills.map((p) => p.text())).toEqual(['Up', 'Down', 'Up']);
-    expect(pills[1].classes()).toContain('down');
+  it('shows the status and 24 hour uptime of each monitor', async () => {
+    const wrapper = await mount();
+    expect(textOf(wrapper, '.status-pill')).toEqual(['Up', 'Down', 'Up']);
+    expect(textOf(wrapper, '.uptime')).toEqual(['100.00%', '98.76%', '50.00%']);
   });
 
-  it('lets monitorNames override the names from Uptime Kuma', async () => {
-    expect(names(await mount({ monitorNames: ['One', 'Two', 'Three'] }))).toEqual(['One', 'Two', 'Three']);
+  it('draws a bar per heartbeat, coloured by its status', async () => {
+    const bars = (await mount()).findAll('.heartbeat-strip')[1].findAll('.beat');
+    expect(bars).toHaveLength(2);
+    expect(bars[1].classes()).toContain('down');
   });
 
-  it('keeps the real name where monitorNames runs out', async () => {
-    expect(names(await mount({ monitorNames: ['One'] }))).toEqual(['One', 'API', 'Docs']);
+  it('summarises each monitor in a tooltip', async () => {
+    await mount();
+    expect(tooltips[0]).toBe('Response: 83ms<br>Last check: 4 minutes ago');
+    expect(tooltips[1]).toContain('1 of 2 recent checks failed<br>timeout');
   });
 
-  it('ignores a monitorNames given as a string rather than a list', async () => {
-    expect(names(await mount({ monitorNames: '["One","Two"]' }))).toEqual(['App', 'API', 'Docs']);
+  it.each([
+    ['hideHistory', '.beat'],
+    ['hideUptime', '.uptime'],
+    ['hideStatus', '.status-pill'],
+  ])('%s hides it, leaving the rest', async (option, selector) => {
+    const wrapper = await mount({ [option]: true });
+    expect(wrapper.findAll(selector)).toHaveLength(0);
+    expect(names(wrapper)).toEqual(['App', 'API', 'Docs']);
+  });
+
+  it('lets monitorNames override the names, falling back once it runs out', async () => {
+    expect(names(await mount({ monitorNames: ['One', 'Two'] }))).toEqual(['One', 'Two', 'Docs']);
   });
 
   it('numbers the monitors when the status page cannot be reached', async () => {
     mockApi({ pageData: null });
     expect(names(await mount())).toEqual(['Monitor 1', 'Monitor 2', 'Monitor 3']);
-  });
-
-  it('skips monitors with no heartbeats yet', async () => {
-    mockApi({ beatData: { heartbeatList: { 5: beats(1), 7: [], 6: beats(1) } } });
-    expect(names(await mount())).toEqual(['App', 'Docs']);
   });
 
   it('asks for a slug when one is missing', async () => {


### PR DESCRIPTION
### Category
Feature

### Overview
Previously users had to name each monitor. But since the Uptime Kuma config endpoint does return monitors, we can now do this automatically - much easier!! :)

I've also added historical uptime lil chart. This can be disabled with  `hideHistory` if you don't like it (you can also use `hideUptime`, `hideStatus` to hide the other 2 parts, like if you just wanted to show history only). Docs updated to explain all this.


### Issue Number
Fixes #2312 

### Additional Info

Here's a screenshot:

<img width="609" height="330" alt="2026-08-28_11-33-32" src="https://github.com/user-attachments/assets/e7c9f36c-8151-47d5-99fb-a4328faa87c7" />

the above screenshot was from this config:

```yaml
- name: Domain Locker Uptime
  icon: https://domain-locker.com/icons/favicon-16x16.png
  widgets:
    - type: uptime-kuma-status-page
      useProxy: true
      options:
        host: https://uptime.as93.net
        slug: domain-locker
```