### PR TITLE
Adds support for status txt overrides in uptime widgets

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -2811,6 +2811,7 @@ This widget displays the status of your Uptime Kuma monitors from a given status
 | **`hideHistory`**  | `boolean` | _Optional_   | Optionally hide the strip of recent heartbeats |
 | **`hideUptime`**   | `boolean` | _Optional_   | Optionally hide the 24-hour uptime percentage |
 | **`hideStatus`**   | `boolean` | _Optional_   | Optionally hide the up/ down status pill |
+| **`statusLabels`** | `object` | _Optional_   | Optional text overrides for the status pill, keyed by status: `up`, `down`, `pending`, `maintenance`, `unknown` |
 
 #### Example
 
@@ -2845,6 +2846,7 @@ This widget displays the status of your Uptime Kuma monitors from a given status
 | **`hideStatus`** | `boolean` | _Optional_ | Optionally hide the up/ down status pill |
 | **`hideResponseTime`** | `boolean` | _Optional_ | Optionally hide the response time |
 | **`hideUptime`** | `boolean` | _Optional_ | Optionally hide the 24-hour uptime percentage |
+| **`statusLabels`** | `object` | _Optional_ | Optional text overrides for the status pill, keyed by status: `up`, `down`, `pending`, `maintenance`, `unknown` |
 
 Each monitor shows its status, response time and 24-hour uptime. Hover a monitor for its 30-day and 1-year uptime, and average response times. Hide any of the columns with the options above.
 

--- a/src/components/Widgets/UptimeKuma.vue
+++ b/src/components/Widgets/UptimeKuma.vue
@@ -77,6 +77,10 @@ export default {
     hideUptime() {
       return this.options.hideUptime || false;
     },
+    /* Optional status pill text overrides, keyed by status (e.g. `down: Error`) */
+    statusLabels() {
+      return this.options.statusLabels || {};
+    },
     /* Create authorisation header for the instance from the apiKey */
     authHeaders() {
       if (!this.apiKey) {
@@ -88,7 +92,8 @@ export default {
   },
   methods: {
     getStatusText(status) {
-      return (STATUSES[status] || UNKNOWN).text;
+      const { text, class: key } = STATUSES[status] || UNKNOWN;
+      return this.statusLabels[key] || text;
     },
     getStatusClass(status) {
       return (STATUSES[status] || UNKNOWN).class;

--- a/src/components/Widgets/UptimeKumaStatusPage.vue
+++ b/src/components/Widgets/UptimeKumaStatusPage.vue
@@ -79,6 +79,10 @@ export default {
     hideStatus() {
       return this.options.hideStatus || false;
     },
+    /* Status pill text overrides */
+    statusLabels() {
+      return this.options.statusLabels || {};
+    },
     endpoint() {
       return `${this.host}/api/status-page/heartbeat/${this.slug}`;
     },
@@ -91,7 +95,8 @@ export default {
   },
   methods: {
     getStatusText(status) {
-      return (STATUSES[status] || UNKNOWN).text;
+      const { text, class: key } = STATUSES[status] || UNKNOWN;
+      return this.statusLabels[key] || text;
     },
     getStatusClass(status) {
       return (STATUSES[status] || UNKNOWN).class;


### PR DESCRIPTION
### Category
Feature

### Overview
Adds support for overriding the status labels (for up, down, pending, maintenance, unknown) in the uptime kuma widgets, with a new `statusLabels` option. This changes the text shown in the status pill.

### Issue Number
Fixes #2321


