### PR TITLE
Docker tag from package.json version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,7 +78,8 @@ jobs:
           elif [ "$EVENT_NAME" = "push" ]; then
             v="$REF_NAME"
           else
-            v="latest"
+            v="$(jq -r '.version // empty' package.json 2>/dev/null || true)"
+            v="${v:-latest}"
           fi
           echo "value=$v" >> "$GITHUB_OUTPUT"
           echo "revision=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Category
CI

### Overview
The Dashy version attached as the OCI label to the docker image published comes from git tag.
This PR adds a fallback, so if for any reason no git tag, we read the version from package.json (which has the same version), and use that instead.

This won't have any user-facing changes, it's just redundancy for OCI labelling. 

### Issue Number
Fixes #2324