### PR TITLE
Adds calendar widget

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -199,6 +199,7 @@ Dashy supports [Widgets](/docs/widgets.md) for displaying dynamic content. Below
 |---|---|---|
 | [Weather](/docs/widgets.md#weather) / [Weather Forecast](/docs/widgets.md#weather-forecast) | `https://api.openweathermap.org` | [OWM Privacy Policy](https://openweather.co.uk/privacy-policy) |
 | [RSS Feed](/docs/widgets.md#rss-feed) | `https://api.rss2json.com/v1/api.json` | [Rss2Json Privacy Policy](https://rss2json.com/privacy-policy) |
+| [Calendar](/docs/widgets.md#calendar) | Your own ICS feed URL | _No third-party service; the feed you configure is fetched directly_ |
 | [IP Address](/docs/widgets.md#public-ip) | `https://free.freeipapi.com/api/json` | [FreeIPAPI](https://freeipapi.com/) |
 | | `https://ipinfo.io/json` | [IPInfo Privacy Policy](https://ipinfo.io/privacy-policy) |
 | | `https://api.ipquery.io/` | [IPQuery](https://ipquery.io/) |

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -271,6 +271,7 @@ Shows upcoming events from any calendar that publishes an iCalendar (`.ics`) fee
 Note that this needs to be proxied through Dashy, since calendar providers don't send CORS headers.
 `webcal://` links are accepted, same as `https://`.
 Recurring events, exceptions and moved occurrences are all expanded, and times are converted to your browser's timezone.
+Events already underway stay listed until they end, and calendars with no `name` set use the name their feed publishes.
 
 #### Options
 
@@ -280,6 +281,8 @@ Recurring events, exceptions and moved occurrences are all expanded, and times a
 **`days`** | `number` |  _Optional_ | How many days ahead to show. Min: `1`, max: `365`. Defaults to `7`
 **`limit`** | `number` |  _Optional_ | Maximum number of events to show. Defaults to `10`
 **`hideAllDay`** | `boolean` |  _Optional_ | If `true`, all-day events are omitted
+**`showLocation`** | `boolean` |  _Optional_ | If `true`, shows each event's location under its title
+**`showDescription`** | `boolean` |  _Optional_ | If `true`, shows each event's description under its title
 **`startDate`** | `string` |  _Optional_ | Show events from this date instead of today, e.g. `2026-09-03`
 
 #### Example

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -9,6 +9,7 @@ Dashy has support for displaying dynamic content in the form of widgets. There a
   - [Weather](#weather)
   - [Weather Forecast](#weather-forecast)
   - [RSS Feed](#rss-feed)
+  - [Calendar](#calendar)
   - [Image](#image)
   - [Public IP Address](#public-ip)
   - [IP Blacklist Checker](#ip-blacklist)
@@ -260,6 +261,80 @@ Display news and updates from any RSS-enabled service.
 - **Auth**: 🟠 Optional
 - **Price**: 🟠 Free Plan (up to 10,000 requests / day)
 - **Privacy**: _See [Rss2Json Privacy Policy](https://rss2json.com/privacy-policy)_
+
+---
+
+### Calendar
+
+Shows upcoming events from any calendar that publishes an iCalendar (`.ics`) feed. Works with Nextcloud, Google, Proton, iCloud, Outlook, Radicale,  Baïkal, etc.
+
+Note that this needs to be proxied through Dashy, since calendar providers don't send CORS headers.
+`webcal://` links are accepted, same as `https://`.
+Recurring events, exceptions and moved occurrences are all expanded, and times are converted to your browser's timezone.
+
+#### Options
+
+**Field** | **Type** | **Required** | **Description**
+--- | --- | --- | ---
+**`calendarUrl`** | `string` or `array` |  Required | The URL of your ICS feed. Pass an array to combine several, each either a URL or an object with `url`, plus optional `name` and `color`
+**`days`** | `number` |  _Optional_ | How many days ahead to show. Min: `1`, max: `365`. Defaults to `7`
+**`limit`** | `number` |  _Optional_ | Maximum number of events to show. Defaults to `10`
+**`hideAllDay`** | `boolean` |  _Optional_ | If `true`, all-day events are omitted
+**`startDate`** | `string` |  _Optional_ | Show events from this date instead of today, e.g. `2026-09-03`
+
+#### Example
+
+```yaml
+- type: calendar
+  options:
+    calendarUrl: https://nextcloud.example.com/remote.php/dav/public-calendars/AbCdEf123?export
+    days: 14
+```
+
+Combining calendars, and colour-coding them:
+
+```yaml
+- type: calendar
+  options:
+    limit: 15
+    calendarUrl:
+      - url: https://calendar.google.com/calendar/ical/xxxx/private-xxxx/basic.ics
+        name: Personal
+        color: '#5cabca'
+      - url: webcal://p12-calendars.icloud.com/published/2/xxxx
+        name: Family
+        color: '#e8j54a'
+```
+
+#### Getting your feed URL
+
+**Provider** | **Where to find it**
+--- | ---
+Nextcloud | Calendar → **⋯** → _Copy subscription link_, then append `?export`. Or, for a private calendar, use `https://user:app-password@host/remote.php/dav/calendars/user/calendar-name?export`
+Google | Settings → _Settings for my calendars_ → **Integrate calendar** → _Secret address in iCal format_
+Proton | Settings → Calendars → _Share with anyone_. Requires a paid plan, and the link must be set to **Full view**
+iCloud | Right-click the calendar → _Share Calendar_ → **Public Calendar**
+Outlook | Settings → Calendar → _Shared calendars_ → **Publish a calendar**, choosing the ICS link
+
+#### Keeping your URL private
+
+A calendar URL is a password in disguise: anyone who has it can read your calendar. Since widget options are sent to the browser, don't put a secret feed URL directly in your config if other people can view your dashboard. Instead, set it as an environment variable prefixed with `DASHY_`, and reference the name:
+
+```yaml
+- type: calendar
+  options:
+    calendarUrl: DASHY_MY_CALENDAR
+```
+
+The proxy substitutes the real value server-side, so the URL never reaches the browser.
+
+#### Info
+
+- **CORS**: 🔴 Proxied
+- **Auth**: 🟠 Optional (a secret or authenticated feed URL, where the calendar isn't public)
+- **Price**: 🟢 Free
+- **Host**: Self-Hosted or Managed
+- **Privacy**: _No third-party service is used; Dashy fetches your feed directly_
 
 ---
 

--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -448,6 +448,13 @@
       "show-less": "Show Less",
       "open-link": "Continue Reading"
     },
+    "calendar": {
+      "all-day": "All day",
+      "no-events": "Nothing coming up",
+      "today": "Today",
+      "tomorrow": "Tomorrow",
+      "untitled": "Untitled event"
+    },
     "github-profile": {
       "repos": "Repos",
       "followers": "Followers",

--- a/src/components/Widgets/Calendar.vue
+++ b/src/components/Widgets/Calendar.vue
@@ -14,9 +14,12 @@
       v-tooltip="eventTooltip(event)"
     >
       <span class="event-time" :class="{ 'all-day': event.allDay }">{{ event.time }}</span>
-      <span class="event-title">
-        <span class="calendar-dot" v-if="event.color" :style="{ background: event.color }"></span>
-        {{ event.summary }}
+      <span class="event-body">
+        <span class="event-title">
+          <span class="calendar-dot" v-if="event.color" :style="{ background: event.color }"></span>
+          {{ event.summary }}
+        </span>
+        <span class="event-meta" v-if="event.meta">{{ event.meta }}</span>
       </span>
     </component>
   </div>
@@ -26,7 +29,7 @@
 <script>
 import WidgetMixin from '@/mixins/WidgetMixin';
 import { parseIcs } from '@/utils/IcsParser';
-import { sanitize } from '@/utils/MiscHelpers';
+import { sanitize, truncateStr } from '@/utils/MiscHelpers';
 import { sanitizeText, sanitizeUrl } from '@/utils/Sanitizer';
 
 export default {
@@ -46,7 +49,7 @@ export default {
       const list = Array.isArray(input) ? input : [input];
       return list
         .map((entry) => (typeof entry === 'string' ? { url: entry } : entry))
-        .filter((entry) => entry && entry.url)
+        .filter((entry) => entry && typeof entry.url === 'string')
         .map((entry) => ({
           ...entry,
           url: this.parseAsEnvVar(entry.url).replace(/^webcal:\/\//i, 'https://'),
@@ -64,14 +67,14 @@ export default {
     hideAllDay() {
       return !!this.options.hideAllDay;
     },
-    /* The window to fetch events for, starting now unless told otherwise */
+  },
+  methods: {
+    /* The window to show events for. A method, so refreshes move it along with the clock */
     range() {
       const requested = this.options.startDate ? new Date(this.options.startDate).getTime() : NaN;
       const start = Number.isNaN(requested) ? Date.now() : requested;
       return { start, end: start + this.daysAhead * 86400000 };
     },
-  },
-  methods: {
     fetchData() {
       if (!this.calendars.length) {
         this.error('Missing calendarUrl, see the docs for supported formats');
@@ -83,11 +86,12 @@ export default {
       }
       const requests = this.calendars.map((calendar) => this.makeRequest(calendar.url));
       Promise.allSettled(requests).then((outcomes) => {
+        const range = this.range();
         const events = [];
         let readable = 0;
         outcomes.forEach((outcome, index) => {
           if (outcome.status !== 'fulfilled') return;
-          if (this.readFeed(outcome.value, this.calendars[index], events)) readable += 1;
+          if (this.readFeed(outcome.value, this.calendars[index], events, range)) readable += 1;
         });
         // Leave the widget empty if nothing could be read, so only the error shows
         if (!readable) return;
@@ -96,15 +100,15 @@ export default {
       });
     },
     /* Parse a single feed, appending its events to the combined list */
-    readFeed(data, calendar, events) {
-      let parsed;
+    readFeed(data, calendar, events, range) {
+      let feed;
       try {
-        parsed = parseIcs(data, this.range);
+        feed = parseIcs(data, range);
       } catch (error) {
         this.error(`Unable to parse calendar${calendar.name ? ` '${calendar.name}'` : ''}`, error);
         return false;
       }
-      parsed.forEach((event) => {
+      feed.events.forEach((event) => {
         if (this.hideAllDay && event.allDay) return;
         events.push({
           ...event,
@@ -112,7 +116,7 @@ export default {
           // Feeds often put markup in the description, but never in the other fields
           description: sanitizeText(event.description),
           url: sanitizeUrl(event.url) || '',
-          source: calendar.name || '',
+          source: calendar.name || feed.name,
           color: calendar.color || '',
         });
       });
@@ -124,13 +128,24 @@ export default {
       events.forEach((event) => {
         const label = this.dayLabel(event);
         const current = groups[groups.length - 1];
-        const time = event.allDay
-          ? this.$t('widgets.calendar.all-day') : this.formatTime(event.start);
-        const formatted = { ...event, time };
-        if (current && current.label === label) current.events.push(formatted);
-        else groups.push({ label, events: [formatted] });
+        const row = { ...event, time: this.eventTime(event), meta: this.eventMeta(event) };
+        if (current && current.label === label) current.events.push(row);
+        else groups.push({ label, events: [row] });
       });
       return groups;
+    },
+    eventTime(event) {
+      if (event.allDay) return this.$t('widgets.calendar.all-day');
+      return this.formatTime(event.start);
+    },
+    /* Location and description, when the user has asked to see them inline */
+    eventMeta(event) {
+      const meta = [];
+      if (this.options.showLocation && event.location) meta.push(event.location);
+      if (this.options.showDescription && event.description) {
+        meta.push(truncateStr(event.description.replace(/\s+/g, ' '), 100));
+      }
+      return meta.join(' · ');
     },
     /* All-day events are anchored to UTC, so must be read back in UTC */
     eventDate(event) {
@@ -144,7 +159,8 @@ export default {
       today.setHours(0, 0, 0, 0);
       const date = this.eventDate(event);
       const daysAway = Math.round((date - today) / 86400000);
-      if (daysAway === 0) return this.$t('widgets.calendar.today');
+      // Anything already underway belongs under today, not the day it began
+      if (daysAway <= 0) return this.$t('widgets.calendar.today');
       if (daysAway === 1) return this.$t('widgets.calendar.tomorrow');
       return date.toLocaleDateString(navigator.language, {
         weekday: 'short', day: 'numeric', month: 'short',
@@ -157,7 +173,8 @@ export default {
     },
     eventTooltip(event) {
       const lines = [];
-      if (event.source) lines.push(`<b>${sanitize(event.source)}</b>`);
+      // Only worth naming the calendar when there is more than one to tell apart
+      if (event.source && this.calendars.length > 1) lines.push(`<b>${sanitize(event.source)}</b>`);
       if (!event.allDay && event.end > event.start) {
         lines.push(`${event.time} - ${this.formatTime(event.end)}`);
       }
@@ -203,10 +220,18 @@ export default {
       opacity: var(--dimming-factor);
       &.all-day { font-size: 0.75rem; }
     }
-    .event-title {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+    .event-body {
+      min-width: 0;
+      .event-title, .event-meta {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .event-meta {
+        font-size: 0.75rem;
+        opacity: var(--dimming-factor);
+      }
     }
     .calendar-dot {
       display: inline-block;

--- a/src/components/Widgets/Calendar.vue
+++ b/src/components/Widgets/Calendar.vue
@@ -1,0 +1,230 @@
+<template>
+<div class="calendar-wrapper">
+  <p class="no-events" v-if="days && !days.length">{{ $t('widgets.calendar.no-events') }}</p>
+  <div class="day-group" v-for="day in days" :key="day.label">
+    <p class="day-label">{{ day.label }}</p>
+    <component
+      :is="event.url ? 'a' : 'div'"
+      class="event-row"
+      v-for="(event, index) in day.events"
+      :key="index"
+      :href="event.url || undefined"
+      target="_blank"
+      rel="noopener noreferrer"
+      v-tooltip="eventTooltip(event)"
+    >
+      <span class="event-time" :class="{ 'all-day': event.allDay }">{{ event.time }}</span>
+      <span class="event-title">
+        <span class="calendar-dot" v-if="event.color" :style="{ background: event.color }"></span>
+        {{ event.summary }}
+      </span>
+    </component>
+  </div>
+</div>
+</template>
+
+<script>
+import WidgetMixin from '@/mixins/WidgetMixin';
+import { parseIcs } from '@/utils/IcsParser';
+import { sanitize } from '@/utils/MiscHelpers';
+import { sanitizeText, sanitizeUrl } from '@/utils/Sanitizer';
+
+export default {
+  mixins: [WidgetMixin],
+  components: {},
+  data() {
+    return {
+      days: null,
+      overrideProxyChoice: true,
+    };
+  },
+  computed: {
+    /* User's feed(s), normalised to a list of { url, name, color } */
+    calendars() {
+      const input = this.options.calendarUrl;
+      if (!input) return [];
+      const list = Array.isArray(input) ? input : [input];
+      return list
+        .map((entry) => (typeof entry === 'string' ? { url: entry } : entry))
+        .filter((entry) => entry && entry.url)
+        .map((entry) => ({
+          ...entry,
+          url: this.parseAsEnvVar(entry.url).replace(/^webcal:\/\//i, 'https://'),
+        }));
+    },
+    /* Number of days ahead to show events for */
+    daysAhead() {
+      const usersChoice = this.options.days;
+      if (usersChoice > 0 && usersChoice <= 365) return usersChoice;
+      return 7;
+    },
+    limit() {
+      return this.options.limit || 10;
+    },
+    hideAllDay() {
+      return !!this.options.hideAllDay;
+    },
+    /* The window to fetch events for, starting now unless told otherwise */
+    range() {
+      const requested = this.options.startDate ? new Date(this.options.startDate).getTime() : NaN;
+      const start = Number.isNaN(requested) ? Date.now() : requested;
+      return { start, end: start + this.daysAhead * 86400000 };
+    },
+  },
+  methods: {
+    fetchData() {
+      if (!this.calendars.length) {
+        this.error('Missing calendarUrl, see the docs for supported formats');
+        this.finishLoading();
+        return;
+      }
+      if (this.options.startDate && Number.isNaN(new Date(this.options.startDate).getTime())) {
+        this.error('Invalid startDate, expected a date like 2026-09-03');
+      }
+      const requests = this.calendars.map((calendar) => this.makeRequest(calendar.url));
+      Promise.allSettled(requests).then((outcomes) => {
+        const events = [];
+        let readable = 0;
+        outcomes.forEach((outcome, index) => {
+          if (outcome.status !== 'fulfilled') return;
+          if (this.readFeed(outcome.value, this.calendars[index], events)) readable += 1;
+        });
+        // Leave the widget empty if nothing could be read, so only the error shows
+        if (!readable) return;
+        events.sort((first, second) => first.start - second.start);
+        this.days = this.groupByDay(events.slice(0, this.limit));
+      });
+    },
+    /* Parse a single feed, appending its events to the combined list */
+    readFeed(data, calendar, events) {
+      let parsed;
+      try {
+        parsed = parseIcs(data, this.range);
+      } catch (error) {
+        this.error(`Unable to parse calendar${calendar.name ? ` '${calendar.name}'` : ''}`, error);
+        return false;
+      }
+      parsed.forEach((event) => {
+        if (this.hideAllDay && event.allDay) return;
+        events.push({
+          ...event,
+          summary: event.summary || this.$t('widgets.calendar.untitled'),
+          // Feeds often put markup in the description, but never in the other fields
+          description: sanitizeText(event.description),
+          url: sanitizeUrl(event.url) || '',
+          source: calendar.name || '',
+          color: calendar.color || '',
+        });
+      });
+      return true;
+    },
+    /* Bucket events under a heading for the day they fall on */
+    groupByDay(events) {
+      const groups = [];
+      events.forEach((event) => {
+        const label = this.dayLabel(event);
+        const current = groups[groups.length - 1];
+        const time = event.allDay
+          ? this.$t('widgets.calendar.all-day') : this.formatTime(event.start);
+        const formatted = { ...event, time };
+        if (current && current.label === label) current.events.push(formatted);
+        else groups.push({ label, events: [formatted] });
+      });
+      return groups;
+    },
+    /* All-day events are anchored to UTC, so must be read back in UTC */
+    eventDate(event) {
+      const date = new Date(event.start);
+      return event.allDay
+        ? new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+        : new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    },
+    dayLabel(event) {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const date = this.eventDate(event);
+      const daysAway = Math.round((date - today) / 86400000);
+      if (daysAway === 0) return this.$t('widgets.calendar.today');
+      if (daysAway === 1) return this.$t('widgets.calendar.tomorrow');
+      return date.toLocaleDateString(navigator.language, {
+        weekday: 'short', day: 'numeric', month: 'short',
+      });
+    },
+    formatTime(timestamp) {
+      return new Date(timestamp).toLocaleTimeString(navigator.language, {
+        hour: '2-digit', minute: '2-digit',
+      });
+    },
+    eventTooltip(event) {
+      const lines = [];
+      if (event.source) lines.push(`<b>${sanitize(event.source)}</b>`);
+      if (!event.allDay && event.end > event.start) {
+        lines.push(`${event.time} - ${this.formatTime(event.end)}`);
+      }
+      if (event.location) lines.push(sanitize(event.location));
+      if (event.description) lines.push(sanitize(event.description.slice(0, 200)));
+      if (!lines.length) return { content: '' };
+      return { content: lines.join('<br>'), html: true, popperClass: 'calendar-event-tt' };
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+.calendar-wrapper {
+  padding: 0.25rem 0;
+  color: var(--widget-text-color);
+  p.no-events {
+    margin: 0.5rem 0;
+    text-align: center;
+    opacity: var(--dimming-factor);
+  }
+  .day-group {
+    &:not(:last-child) { margin-bottom: 0.5rem; }
+    p.day-label {
+      margin: 0 0 0.15rem;
+      font-size: 0.8rem;
+      font-weight: bold;
+      text-transform: uppercase;
+      opacity: var(--dimming-factor);
+      border-bottom: 1px dashed var(--widget-text-color);
+    }
+  }
+  .event-row {
+    display: grid;
+    grid-template-columns: 4.2rem 1fr;
+    gap: 0.4rem;
+    padding: 0.15rem 0;
+    font-size: 0.9rem;
+    text-decoration: none;
+    color: var(--widget-text-color);
+    .event-time {
+      font-variant-numeric: tabular-nums;
+      opacity: var(--dimming-factor);
+      &.all-day { font-size: 0.75rem; }
+    }
+    .event-title {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .calendar-dot {
+      display: inline-block;
+      width: 0.5rem;
+      height: 0.5rem;
+      margin-right: 0.25rem;
+      border-radius: 50%;
+    }
+    &[href]:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+  }
+}
+</style>
+
+<style lang="scss">
+.calendar-event-tt {
+  max-width: 20rem;
+}
+</style>

--- a/src/components/Widgets/WidgetBase.vue
+++ b/src/components/Widgets/WidgetBase.vue
@@ -58,6 +58,7 @@ const COMPAT = {
   anonaddy: 'AnonAddy',
   apod: 'Apod',
   'blacklist-check': 'BlacklistCheck',
+  calendar: 'Calendar',
   chucknorris: 'ChuckNorris',
   clock: 'Clock',
   'code-stats': 'CodeStats',

--- a/src/utils/IcsParser.js
+++ b/src/utils/IcsParser.js
@@ -7,8 +7,9 @@
 const DAYS = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
 const FREQS = ['DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'];
 const DAY_MS = 86400000;
+// Longest each period can be, so skipping ahead always lands early, never past an occurrence
 const PERIOD_MS = {
-  DAILY: DAY_MS, WEEKLY: 7 * DAY_MS, MONTHLY: 28 * DAY_MS, YEARLY: 365 * DAY_MS,
+  DAILY: DAY_MS, WEEKLY: 7 * DAY_MS, MONTHLY: 31 * DAY_MS, YEARLY: 366 * DAY_MS,
 };
 const MAX_PERIODS = 5000;
 const LOCAL_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -115,6 +116,8 @@ const parseRule = (value) => {
   return rule;
 };
 
+const numbers = (value) => (value ? value.split(',').map(Number) : null);
+
 const startOfPeriod = (ms, freq, weekStart) => {
   const date = new Date(ms);
   date.setUTCHours(0, 0, 0, 0);
@@ -145,8 +148,9 @@ const daysMatchingByDay = (byDay, monthStart, monthLength) => {
       if (new Date(ms).getUTCDay() === weekday) matches.push(ms);
     }
     if (!nth) found.push(...matches);
-    else if (matches[nth > 0 ? nth - 1 : matches.length + nth]) {
-      found.push(matches[nth > 0 ? nth - 1 : matches.length + nth]);
+    else {
+      const nthMatch = matches[nth > 0 ? nth - 1 : matches.length + nth];
+      if (nthMatch) found.push(nthMatch);
     }
   });
   return found;
@@ -197,14 +201,13 @@ const expandRule = (rule, start, range) => {
   const interval = parseInt(rule.INTERVAL, 10) || 1;
   const count = parseInt(rule.COUNT, 10) || 0;
   const until = rule.UNTIL ? toEpoch(parseDate(rule.UNTIL)) : null;
-  const byMonth = rule.BYMONTH ? rule.BYMONTH.split(',').map(Number) : null;
   const parsed = {
     byDay: rule.BYDAY ? rule.BYDAY.split(',') : null,
-    byMonthDay: rule.BYMONTHDAY ? rule.BYMONTHDAY.split(',').map(Number) : null,
-    byMonth,
+    byMonthDay: numbers(rule.BYMONTHDAY),
+    byMonth: numbers(rule.BYMONTH),
   };
-  const bySetPos = rule.BYSETPOS ? rule.BYSETPOS.split(',').map(Number) : null;
-  const weekStart = Math.max(DAYS.indexOf(rule.WKST), 0);
+  const bySetPos = numbers(rule.BYSETPOS);
+  const weekStart = DAYS.includes(rule.WKST) ? DAYS.indexOf(rule.WKST) : 1;
   const timeOfDay = ((start.wall % DAY_MS) + DAY_MS) % DAY_MS;
 
   let cursor = startOfPeriod(start.wall, freq, weekStart);
@@ -217,8 +220,8 @@ const expandRule = (rule, start, range) => {
   const found = [];
   for (let period = 0; period < MAX_PERIODS && cursor <= range.end; period += 1) {
     let days = daysInPeriod(cursor, freq, parsed, start.wall);
-    if (byMonth && freq !== 'YEARLY') {
-      days = days.filter((ms) => byMonth.includes(new Date(ms).getUTCMonth() + 1));
+    if (parsed.byMonth && freq !== 'YEARLY') {
+      days = days.filter((ms) => parsed.byMonth.includes(new Date(ms).getUTCMonth() + 1));
     }
     let candidates = days.map((ms) => ms + timeOfDay).sort((a, b) => a - b);
     if (bySetPos) {
@@ -226,8 +229,7 @@ const expandRule = (rule, start, range) => {
         .map((pos) => candidates[pos > 0 ? pos - 1 : candidates.length + pos])
         .filter((ms) => ms !== undefined);
     }
-    for (let i = 0; i < candidates.length; i += 1) {
-      const wall = candidates[i];
+    for (const wall of candidates) {
       if (wall >= start.wall) {
         if (until !== null && toEpoch({ ...start, wall }) > until) return found;
         found.push(wall);
@@ -239,9 +241,10 @@ const expandRule = (rule, start, range) => {
   return found;
 };
 
-/* Read every VEVENT, skipping nested components such as VALARM */
-const collectEvents = (text) => {
+/* Read the calendar's name and every VEVENT, skipping nested parts such as VALARM */
+const readCalendar = (text) => {
   const events = [];
+  let calendarName = '';
   let event = null;
   let nested = 0;
   unfold(text).forEach((raw) => {
@@ -258,7 +261,11 @@ const collectEvents = (text) => {
       else if (value === 'VEVENT' && event) { events.push(event); event = null; }
       return;
     }
-    if (!event || nested) return;
+    if (!event) {
+      if (name === 'X-WR-CALNAME') calendarName = unescapeText(value);
+      return;
+    }
+    if (nested) return;
     if (TEXT_FIELDS[name]) event[TEXT_FIELDS[name]] = unescapeText(value);
     else if (name === 'DTSTART') event.start = parseDate(value, params);
     else if (name === 'DTEND') event.end = parseDate(value, params);
@@ -273,7 +280,7 @@ const collectEvents = (text) => {
       });
     }
   });
-  return events;
+  return { name: calendarName, events };
 };
 
 /* Turn one occurrence into the flat shape the widget renders */
@@ -297,16 +304,16 @@ const buildOccurrence = (event, wall) => {
 const isCancelled = (event) => event.status === 'CANCELLED';
 
 /**
- * Parse an ICS document into occurrences starting within `range`.
+ * Parse an ICS document into the occurrences falling within `range`.
  * @param {string} text - Raw iCalendar document
  * @param {{ start: number, end: number }} range - Window, as epoch milliseconds
- * @returns {Array} Occurrences, ordered by start time
+ * @returns {{ name: string, events: Array }} Feed name, and occurrences ordered by start time
  */
 export const parseIcs = (text, range) => {
   if (!text || typeof text !== 'string' || !text.includes('BEGIN:VCALENDAR')) {
     throw new Error('Not a valid iCalendar feed');
   }
-  const events = collectEvents(text);
+  const { name, events } = readCalendar(text);
   const overrides = new Map();
   events.forEach((event) => {
     if (event.recurrenceId && event.uid) {
@@ -314,7 +321,9 @@ export const parseIcs = (text, range) => {
     }
   });
 
-  const inRange = (occurrence) => occurrence.start >= range.start && occurrence.start <= range.end;
+  /* Anything overlapping the window, so events stay listed while they are still running */
+  const inRange = ({ start, end }) => start <= range.end
+    && (start >= range.start || end > range.start);
   const occurrences = [];
 
   events.forEach((event) => {
@@ -335,7 +344,5 @@ export const parseIcs = (text, range) => {
     if (inRange(occurrence)) occurrences.push(occurrence);
   });
 
-  return occurrences.sort((a, b) => a.start - b.start);
+  return { name, events: occurrences.sort((a, b) => a.start - b.start) };
 };
-
-export default parseIcs;

--- a/src/utils/IcsParser.js
+++ b/src/utils/IcsParser.js
@@ -1,0 +1,341 @@
+/**
+ * Attempt at a minimal iCal parser, following RFC 5545
+ * Returning a time-ordered list of events from requested start date
+ * Used for the calendar widget
+ */
+
+const DAYS = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+const FREQS = ['DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'];
+const DAY_MS = 86400000;
+const PERIOD_MS = {
+  DAILY: DAY_MS, WEEKLY: 7 * DAY_MS, MONTHLY: 28 * DAY_MS, YEARLY: 365 * DAY_MS,
+};
+const MAX_PERIODS = 5000;
+const LOCAL_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+const TEXT_FIELDS = {
+  UID: 'uid',
+  SUMMARY: 'summary',
+  DESCRIPTION: 'description',
+  LOCATION: 'location',
+  URL: 'url',
+  STATUS: 'status',
+};
+
+/* Undo RFC 5545 line folding, and split into logical lines */
+const unfold = (text) => text
+  .replace(/^\uFEFF/, '')
+  .replace(/\r\n|\r/g, '\n')
+  .replace(/\n[ \t]/g, '')
+  .split('\n');
+
+/* Split `NAME;PARAM=VALUE:value` into its parts, ignoring colons inside quotes */
+const parseLine = (line) => {
+  let quoted = false;
+  for (let i = 0; i < line.length; i += 1) {
+    if (line[i] === '"') quoted = !quoted;
+    else if (line[i] === ':' && !quoted) {
+      const [name, ...rest] = line.slice(0, i).split(';');
+      const params = {};
+      rest.forEach((param) => {
+        const eq = param.indexOf('=');
+        if (eq > 0) params[param.slice(0, eq).toUpperCase()] = param.slice(eq + 1).replace(/"/g, '');
+      });
+      return { name: name.toUpperCase(), params, value: line.slice(i + 1) };
+    }
+  }
+  return null;
+};
+
+const unescapeText = (value) => value.replace(/\\n/gi, '\n').replace(/\\(.)/g, '$1');
+
+/* Named zones we can't resolve (such as Windows TZIDs) fall back to the local zone */
+const zones = new Map();
+const resolveZone = (tz) => {
+  if (!tz) return LOCAL_ZONE;
+  if (!zones.has(tz)) {
+    try {
+      Intl.DateTimeFormat('en-GB', { timeZone: tz });
+      zones.set(tz, tz);
+    } catch {
+      zones.set(tz, LOCAL_ZONE);
+    }
+  }
+  return zones.get(tz);
+};
+
+/* How far the given zone is from UTC, at the given moment */
+const offsetAt = (ms, zone) => {
+  const parts = {};
+  Intl.DateTimeFormat('en-GB', {
+    timeZone: zone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).formatToParts(ms).forEach(({ type, value }) => { parts[type] = value; });
+  return Date.UTC(parts.year, parts.month - 1, parts.day, parts.hour, parts.minute, parts.second) - ms;
+};
+
+/* Parse a date or date-time. `wall` holds the clock face, as if it were UTC */
+const parseDate = (value, params = {}) => {
+  const match = /^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2})(Z)?)?$/.exec(value.trim());
+  if (!match) return null;
+  const [, year, month, day, hour, minute, second, utc] = match;
+  return {
+    wall: Date.UTC(year, month - 1, day, hour || 0, minute || 0, second || 0),
+    zone: utc ? 'UTC' : params.TZID || null,
+    allDay: !hour || params.VALUE === 'DATE',
+  };
+};
+
+/* Resolve a wall-clock time in its own zone to a real timestamp */
+const toEpoch = ({ wall, zone, allDay }) => {
+  if (allDay || zone === 'UTC') return wall;
+  const resolved = resolveZone(zone);
+  return wall - offsetAt(wall - offsetAt(wall, resolved), resolved);
+};
+
+const parseDuration = (value) => {
+  const [, w, d, h, m, s] = /^P(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/
+    .exec(value.trim()) || [];
+  return ((+w || 0) * 604800 + (+d || 0) * 86400 + (+h || 0) * 3600
+    + (+m || 0) * 60 + (+s || 0)) * 1000;
+};
+
+const parseRule = (value) => {
+  const rule = {};
+  value.split(';').forEach((part) => {
+    const [key, val] = part.split('=');
+    if (val) rule[key.toUpperCase()] = val;
+  });
+  return rule;
+};
+
+const startOfPeriod = (ms, freq, weekStart) => {
+  const date = new Date(ms);
+  date.setUTCHours(0, 0, 0, 0);
+  if (freq === 'WEEKLY') date.setUTCDate(date.getUTCDate() - ((date.getUTCDay() - weekStart + 7) % 7));
+  if (freq === 'MONTHLY') date.setUTCDate(1);
+  if (freq === 'YEARLY') date.setUTCMonth(0, 1);
+  return date.getTime();
+};
+
+const addPeriods = (ms, freq, amount) => {
+  const date = new Date(ms);
+  if (freq === 'DAILY') date.setUTCDate(date.getUTCDate() + amount);
+  if (freq === 'WEEKLY') date.setUTCDate(date.getUTCDate() + amount * 7);
+  if (freq === 'MONTHLY') date.setUTCMonth(date.getUTCMonth() + amount);
+  if (freq === 'YEARLY') date.setUTCFullYear(date.getUTCFullYear() + amount);
+  return date.getTime();
+};
+
+/* Days in a month matching BYDAY tokens, honouring ordinals like `3TU` or `-1SU` */
+const daysMatchingByDay = (byDay, monthStart, monthLength) => {
+  const found = [];
+  byDay.forEach((token) => {
+    const nth = parseInt(token, 10) || 0;
+    const weekday = DAYS.indexOf(token.slice(-2));
+    const matches = [];
+    for (let day = 0; day < monthLength; day += 1) {
+      const ms = monthStart + day * DAY_MS;
+      if (new Date(ms).getUTCDay() === weekday) matches.push(ms);
+    }
+    if (!nth) found.push(...matches);
+    else if (matches[nth > 0 ? nth - 1 : matches.length + nth]) {
+      found.push(matches[nth > 0 ? nth - 1 : matches.length + nth]);
+    }
+  });
+  return found;
+};
+
+/* Candidate days within a single period, before time-of-day is applied */
+const daysInPeriod = (cursor, freq, rule, anchor) => {
+  const { byDay, byMonth, byMonthDay } = rule;
+  if (freq === 'DAILY' || freq === 'WEEKLY') {
+    let weekdays = byDay && byDay.map((token) => DAYS.indexOf(token.slice(-2)));
+    // A weekly rule with no BYDAY repeats on whichever day it started
+    if (!weekdays && freq === 'WEEKLY') weekdays = [new Date(anchor).getUTCDay()];
+    const span = freq === 'DAILY' ? 1 : 7;
+    const days = [];
+    for (let day = 0; day < span; day += 1) {
+      const ms = cursor + day * DAY_MS;
+      if (!weekdays || weekdays.includes(new Date(ms).getUTCDay())) days.push(ms);
+    }
+    return days;
+  }
+  const year = new Date(cursor).getUTCFullYear();
+  const months = freq === 'YEARLY'
+    ? (byMonth || [new Date(anchor).getUTCMonth() + 1])
+    : [new Date(cursor).getUTCMonth() + 1];
+  const days = [];
+  months.forEach((month) => {
+    const monthStart = Date.UTC(year, month - 1, 1);
+    const monthLength = new Date(Date.UTC(year, month, 0)).getUTCDate();
+    if (byDay) {
+      days.push(...daysMatchingByDay(byDay, monthStart, monthLength));
+    } else {
+      const wanted = byMonthDay || [new Date(anchor).getUTCDate()];
+      wanted.forEach((day) => {
+        const resolved = day > 0 ? day : monthLength + day + 1;
+        if (resolved >= 1 && resolved <= monthLength) {
+          days.push(monthStart + (resolved - 1) * DAY_MS);
+        }
+      });
+    }
+  });
+  return days;
+};
+
+/* Walk a recurrence rule, collecting occurrence start times as wall values */
+const expandRule = (rule, start, range) => {
+  const freq = rule.FREQ;
+  if (!FREQS.includes(freq)) return [start.wall];
+  const interval = parseInt(rule.INTERVAL, 10) || 1;
+  const count = parseInt(rule.COUNT, 10) || 0;
+  const until = rule.UNTIL ? toEpoch(parseDate(rule.UNTIL)) : null;
+  const byMonth = rule.BYMONTH ? rule.BYMONTH.split(',').map(Number) : null;
+  const parsed = {
+    byDay: rule.BYDAY ? rule.BYDAY.split(',') : null,
+    byMonthDay: rule.BYMONTHDAY ? rule.BYMONTHDAY.split(',').map(Number) : null,
+    byMonth,
+  };
+  const bySetPos = rule.BYSETPOS ? rule.BYSETPOS.split(',').map(Number) : null;
+  const weekStart = Math.max(DAYS.indexOf(rule.WKST), 0);
+  const timeOfDay = ((start.wall % DAY_MS) + DAY_MS) % DAY_MS;
+
+  let cursor = startOfPeriod(start.wall, freq, weekStart);
+  // Skip the periods before our window, unless COUNT means they all matter
+  if (!count && cursor < range.start) {
+    const skip = Math.floor((range.start - cursor) / (PERIOD_MS[freq] * interval)) - 1;
+    if (skip > 0) cursor = addPeriods(cursor, freq, skip * interval);
+  }
+
+  const found = [];
+  for (let period = 0; period < MAX_PERIODS && cursor <= range.end; period += 1) {
+    let days = daysInPeriod(cursor, freq, parsed, start.wall);
+    if (byMonth && freq !== 'YEARLY') {
+      days = days.filter((ms) => byMonth.includes(new Date(ms).getUTCMonth() + 1));
+    }
+    let candidates = days.map((ms) => ms + timeOfDay).sort((a, b) => a - b);
+    if (bySetPos) {
+      candidates = bySetPos
+        .map((pos) => candidates[pos > 0 ? pos - 1 : candidates.length + pos])
+        .filter((ms) => ms !== undefined);
+    }
+    for (let i = 0; i < candidates.length; i += 1) {
+      const wall = candidates[i];
+      if (wall >= start.wall) {
+        if (until !== null && toEpoch({ ...start, wall }) > until) return found;
+        found.push(wall);
+        if (count && found.length >= count) return found;
+      }
+    }
+    cursor = addPeriods(cursor, freq, interval);
+  }
+  return found;
+};
+
+/* Read every VEVENT, skipping nested components such as VALARM */
+const collectEvents = (text) => {
+  const events = [];
+  let event = null;
+  let nested = 0;
+  unfold(text).forEach((raw) => {
+    const line = parseLine(raw);
+    if (!line) return;
+    const { name, params, value } = line;
+    if (name === 'BEGIN') {
+      if (value === 'VEVENT' && !event) event = { exdates: [], rdates: [] };
+      else if (event) nested += 1;
+      return;
+    }
+    if (name === 'END') {
+      if (nested) nested -= 1;
+      else if (value === 'VEVENT' && event) { events.push(event); event = null; }
+      return;
+    }
+    if (!event || nested) return;
+    if (TEXT_FIELDS[name]) event[TEXT_FIELDS[name]] = unescapeText(value);
+    else if (name === 'DTSTART') event.start = parseDate(value, params);
+    else if (name === 'DTEND') event.end = parseDate(value, params);
+    else if (name === 'DURATION') event.duration = parseDuration(value);
+    else if (name === 'RRULE') event.rrule = parseRule(value);
+    else if (name === 'RECURRENCE-ID') event.recurrenceId = parseDate(value, params);
+    else if (name === 'EXDATE' || name === 'RDATE') {
+      const target = name === 'EXDATE' ? event.exdates : event.rdates;
+      value.split(',').forEach((part) => {
+        const date = parseDate(part, params);
+        if (date) target.push(date.wall);
+      });
+    }
+  });
+  return events;
+};
+
+/* Turn one occurrence into the flat shape the widget renders */
+const buildOccurrence = (event, wall) => {
+  const start = toEpoch({ ...event.start, wall });
+  let end = start;
+  if (event.end) end = toEpoch({ ...event.end, wall: wall + (event.end.wall - event.start.wall) });
+  else if (event.duration) end = start + event.duration;
+  return {
+    uid: event.uid,
+    summary: event.summary || '',
+    description: event.description || '',
+    location: event.location || '',
+    url: event.url || '',
+    allDay: event.start.allDay,
+    start,
+    end,
+  };
+};
+
+const isCancelled = (event) => event.status === 'CANCELLED';
+
+/**
+ * Parse an ICS document into occurrences starting within `range`.
+ * @param {string} text - Raw iCalendar document
+ * @param {{ start: number, end: number }} range - Window, as epoch milliseconds
+ * @returns {Array} Occurrences, ordered by start time
+ */
+export const parseIcs = (text, range) => {
+  if (!text || typeof text !== 'string' || !text.includes('BEGIN:VCALENDAR')) {
+    throw new Error('Not a valid iCalendar feed');
+  }
+  const events = collectEvents(text);
+  const overrides = new Map();
+  events.forEach((event) => {
+    if (event.recurrenceId && event.uid) {
+      overrides.set(`${event.uid}|${event.recurrenceId.wall}`, event);
+    }
+  });
+
+  const inRange = (occurrence) => occurrence.start >= range.start && occurrence.start <= range.end;
+  const occurrences = [];
+
+  events.forEach((event) => {
+    if (event.recurrenceId || !event.start || isCancelled(event)) return;
+    const starts = event.rrule ? expandRule(event.rrule, event.start, range) : [event.start.wall];
+    const all = [...new Set([...starts, ...event.rdates])];
+    all.forEach((wall) => {
+      if (event.exdates.includes(wall)) return;
+      if (overrides.has(`${event.uid}|${wall}`)) return;
+      const occurrence = buildOccurrence(event, wall);
+      if (inRange(occurrence)) occurrences.push(occurrence);
+    });
+  });
+
+  overrides.forEach((event) => {
+    if (!event.start || isCancelled(event)) return;
+    const occurrence = buildOccurrence(event, event.start.wall);
+    if (inRange(occurrence)) occurrences.push(occurrence);
+  });
+
+  return occurrences.sort((a, b) => a.start - b.start);
+};
+
+export default parseIcs;

--- a/tests/components/widgets/calendar.test.js
+++ b/tests/components/widgets/calendar.test.js
@@ -1,0 +1,160 @@
+import {
+  describe, it, expect, beforeEach, afterEach, vi,
+} from 'vitest';
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import request from '@/utils/request';
+import Calendar from '@/components/Widgets/Calendar.vue';
+
+vi.mock('@/utils/request', () => ({ default: vi.fn() }));
+vi.mock('@/utils/logging/ErrorHandler', () => ({ default: vi.fn() }));
+
+/* Events are written relative to a frozen clock, so the day labels stay stable */
+const NOW = Date.parse('2026-09-03T08:00:00Z');
+const at = (offsetDays, time) => {
+  const date = new Date(NOW + offsetDays * 86400000);
+  return `${date.toISOString().slice(0, 10).replace(/-/g, '')}T${time}Z`;
+};
+
+const feed = (...events) => [
+  'BEGIN:VCALENDAR',
+  'VERSION:2.0',
+  ...events.map((event) => `BEGIN:VEVENT\r\n${event}\r\nEND:VEVENT`),
+  'END:VCALENDAR',
+].join('\r\n');
+
+const defaultFeed = feed(
+  ['UID:1', `DTSTART:${at(0, '140000')}`, `DTEND:${at(0, '150000')}`, 'SUMMARY:Team sync',
+    'LOCATION:Room 2'].join('\r\n'),
+  ['UID:2', 'DTSTART;VALUE=DATE:20260904', 'DTEND;VALUE=DATE:20260905',
+    'SUMMARY:Company offsite'].join('\r\n'),
+  ['UID:3', `DTSTART:${at(2, '090000')}`, 'SUMMARY:Dentist',
+    'URL:https://example.com/appointment'].join('\r\n'),
+);
+
+const tooltips = [];
+const tooltip = { mounted: (el, binding) => tooltips.push(binding.value.content) };
+
+async function mount(options = {}) {
+  const wrapper = shallowMount(Calendar, {
+    props: { options: { calendarUrl: 'https://example.com/cal.ics', ...options } },
+    global: { directives: { tooltip }, mocks: { $t: (key) => key } },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+const textOf = (wrapper, selector) => wrapper.findAll(selector).map((node) => node.text());
+
+describe('Calendar widget', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(NOW);
+    tooltips.length = 0;
+    request.mockReset();
+    request.mockResolvedValue({ data: defaultFeed });
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('groups events under a heading for each day', async () => {
+    const wrapper = await mount();
+    const labels = textOf(wrapper, '.day-label');
+    expect(labels.slice(0, 2)).toEqual(['widgets.calendar.today', 'widgets.calendar.tomorrow']);
+    expect(labels[2]).toMatch(/Sat.*5|5.*Sep/);
+    expect(textOf(wrapper, '.event-title')).toEqual(['Team sync', 'Company offsite', 'Dentist']);
+  });
+
+  it('labels all-day events, and shows a start time for the rest', async () => {
+    const wrapper = await mount();
+    const times = textOf(wrapper, '.event-time');
+    expect(times[1]).toBe('widgets.calendar.all-day');
+    expect(times[0]).toMatch(/\d{2}:\d{2}/);
+  });
+
+  it('always fetches through the proxy, rewriting webcal links', async () => {
+    await mount({ calendarUrl: 'webcal://example.com/cal.ics' });
+    expect(request).toHaveBeenCalledTimes(1);
+    const [config] = request.mock.calls[0];
+    expect(config.url).toContain('/cors-proxy');
+    expect(config.headers['Target-URL']).toBe('https://example.com/cal.ics');
+  });
+
+  it('merges several calendars, ordered by start time', async () => {
+    request.mockImplementation((config) => Promise.resolve({
+      data: config.headers['Target-URL'].includes('work')
+        ? feed(['UID:w', `DTSTART:${at(0, '110000')}`, 'SUMMARY:Standup'].join('\r\n'))
+        : feed(['UID:h', `DTSTART:${at(0, '093000')}`, 'SUMMARY:Gym'].join('\r\n')),
+    }));
+    const wrapper = await mount({
+      calendarUrl: [
+        { url: 'https://example.com/work.ics', name: 'Work', color: '#ff0000' },
+        { url: 'https://example.com/home.ics', name: 'Home' },
+      ],
+    });
+    expect(textOf(wrapper, '.event-title')).toEqual(['Gym', 'Standup']);
+    expect(wrapper.findAll('.calendar-dot')).toHaveLength(1);
+  });
+
+  it('keeps rendering when only some of the calendars fail', async () => {
+    request
+      .mockRejectedValueOnce(new Error('unreachable'))
+      .mockResolvedValueOnce({ data: defaultFeed });
+    const wrapper = await mount({
+      calendarUrl: ['https://example.com/broken.ics', 'https://example.com/cal.ics'],
+    });
+    expect(textOf(wrapper, '.event-title')).toEqual(['Team sync', 'Company offsite', 'Dentist']);
+  });
+
+  it('respects limit, hideAllDay and days', async () => {
+    const limited = await mount({ limit: 2 });
+    expect(textOf(limited, '.event-title')).toHaveLength(2);
+
+    const timedOnly = await mount({ hideAllDay: true });
+    expect(textOf(timedOnly, '.event-title')).toEqual(['Team sync', 'Dentist']);
+
+    const today = await mount({ days: 1 });
+    expect(textOf(today, '.event-title')).toEqual(['Team sync', 'Company offsite']);
+  });
+
+  it('links events that have a URL, and leaves the others as plain rows', async () => {
+    const wrapper = await mount();
+    const links = wrapper.findAll('a.event-row');
+    expect(links).toHaveLength(1);
+    expect(links[0].attributes('href')).toBe('https://example.com/appointment');
+  });
+
+  it('drops unsafe event URLs', async () => {
+    request.mockResolvedValue({
+      data: feed(['UID:1', `DTSTART:${at(0, '140000')}`, 'SUMMARY:Dodgy',
+        // eslint-disable-next-line no-script-url
+        'URL:javascript:alert(1)'].join('\r\n')),
+    });
+    const wrapper = await mount();
+    expect(wrapper.findAll('a.event-row')).toHaveLength(0);
+  });
+
+  it('shows the location and calendar name in the tooltip', async () => {
+    await mount({ calendarUrl: [{ url: 'https://example.com/cal.ics', name: 'Work' }] });
+    expect(tooltips[0]).toContain('Work');
+    expect(tooltips[0]).toContain('Room 2');
+  });
+
+  it('reports a helpful message when no calendar is configured', async () => {
+    const wrapper = await mount({ calendarUrl: null });
+    expect(request).not.toHaveBeenCalled();
+    expect(wrapper.emitted().error[0][0]).toContain('Missing calendarUrl');
+  });
+
+  it('reports a message when the feed is not a calendar, without saying it is empty', async () => {
+    request.mockResolvedValue({ data: '<html>Login page</html>' });
+    const wrapper = await mount();
+    expect(wrapper.emitted().error[0][0]).toContain('Unable to parse calendar');
+    expect(wrapper.find('.no-events').exists()).toBe(false);
+  });
+
+  it('says so when there is nothing coming up', async () => {
+    request.mockResolvedValue({ data: feed() });
+    const wrapper = await mount();
+    expect(wrapper.find('.no-events').text()).toBe('widgets.calendar.no-events');
+  });
+});

--- a/tests/components/widgets/calendar.test.js
+++ b/tests/components/widgets/calendar.test.js
@@ -8,27 +8,31 @@ import Calendar from '@/components/Widgets/Calendar.vue';
 vi.mock('@/utils/request', () => ({ default: vi.fn() }));
 vi.mock('@/utils/logging/ErrorHandler', () => ({ default: vi.fn() }));
 
-/* Events are written relative to a frozen clock, so the day labels stay stable */
-const NOW = Date.parse('2026-09-03T08:00:00Z');
-const at = (offsetDays, time) => {
-  const date = new Date(NOW + offsetDays * 86400000);
-  return `${date.toISOString().slice(0, 10).replace(/-/g, '')}T${time}Z`;
+/* Events sit at a local wall-clock time on a frozen local day, so that day
+ * labels and ordering come out the same whatever timezone the tests run in */
+const NOW = new Date('2026-09-03T08:00:00');
+const at = (addDays, hour) => {
+  const date = new Date(NOW);
+  date.setDate(date.getDate() + addDays);
+  date.setHours(hour, 0, 0, 0);
+  return date.toISOString().replace(/[-:]|\.\d{3}/g, '');
 };
 
 const feed = (...events) => [
   'BEGIN:VCALENDAR',
   'VERSION:2.0',
-  ...events.map((event) => `BEGIN:VEVENT\r\n${event}\r\nEND:VEVENT`),
+  ...events.map((lines) => ['BEGIN:VEVENT', ...lines, 'END:VEVENT'].join('\r\n')),
   'END:VCALENDAR',
 ].join('\r\n');
 
 const defaultFeed = feed(
-  ['UID:1', `DTSTART:${at(0, '140000')}`, `DTEND:${at(0, '150000')}`, 'SUMMARY:Team sync',
-    'LOCATION:Room 2'].join('\r\n'),
+  ['UID:1', `DTSTART:${at(0, 10)}`, `DTEND:${at(0, 11)}`,
+    'SUMMARY:Standup, where nobody stands', 'LOCATION:The broom cupboard',
+    'DESCRIPTION:Bring your own excuses'],
   ['UID:2', 'DTSTART;VALUE=DATE:20260904', 'DTEND;VALUE=DATE:20260905',
-    'SUMMARY:Company offsite'].join('\r\n'),
-  ['UID:3', `DTSTART:${at(2, '090000')}`, 'SUMMARY:Dentist',
-    'URL:https://example.com/appointment'].join('\r\n'),
+    'SUMMARY:Offsite trust falls'],
+  ['UID:3', `DTSTART:${at(2, 9)}`, 'SUMMARY:Dentist, reluctantly',
+    'URL:https://example.com/appointment'],
 );
 
 const tooltips = [];
@@ -44,6 +48,7 @@ async function mount(options = {}) {
 }
 
 const textOf = (wrapper, selector) => wrapper.findAll(selector).map((node) => node.text());
+const titles = (wrapper) => textOf(wrapper, '.event-title');
 
 describe('Calendar widget', () => {
   beforeEach(() => {
@@ -59,14 +64,14 @@ describe('Calendar widget', () => {
   it('groups events under a heading for each day', async () => {
     const wrapper = await mount();
     const labels = textOf(wrapper, '.day-label');
+    expect(labels).toHaveLength(3);
     expect(labels.slice(0, 2)).toEqual(['widgets.calendar.today', 'widgets.calendar.tomorrow']);
-    expect(labels[2]).toMatch(/Sat.*5|5.*Sep/);
-    expect(textOf(wrapper, '.event-title')).toEqual(['Team sync', 'Company offsite', 'Dentist']);
+    expect(titles(wrapper))
+      .toEqual(['Standup, where nobody stands', 'Offsite trust falls', 'Dentist, reluctantly']);
   });
 
   it('labels all-day events, and shows a start time for the rest', async () => {
-    const wrapper = await mount();
-    const times = textOf(wrapper, '.event-time');
+    const times = textOf(await mount(), '.event-time');
     expect(times[1]).toBe('widgets.calendar.all-day');
     expect(times[0]).toMatch(/\d{2}:\d{2}/);
   });
@@ -82,8 +87,8 @@ describe('Calendar widget', () => {
   it('merges several calendars, ordered by start time', async () => {
     request.mockImplementation((config) => Promise.resolve({
       data: config.headers['Target-URL'].includes('work')
-        ? feed(['UID:w', `DTSTART:${at(0, '110000')}`, 'SUMMARY:Standup'].join('\r\n'))
-        : feed(['UID:h', `DTSTART:${at(0, '093000')}`, 'SUMMARY:Gym'].join('\r\n')),
+        ? feed(['UID:w', `DTSTART:${at(0, 11)}`, 'SUMMARY:Explain the outage'])
+        : feed(['UID:h', `DTSTART:${at(0, 9)}`, 'SUMMARY:Gym (aspirational)']),
     }));
     const wrapper = await mount({
       calendarUrl: [
@@ -91,7 +96,7 @@ describe('Calendar widget', () => {
         { url: 'https://example.com/home.ics', name: 'Home' },
       ],
     });
-    expect(textOf(wrapper, '.event-title')).toEqual(['Gym', 'Standup']);
+    expect(titles(wrapper)).toEqual(['Gym (aspirational)', 'Explain the outage']);
     expect(wrapper.findAll('.calendar-dot')).toHaveLength(1);
   });
 
@@ -102,41 +107,78 @@ describe('Calendar widget', () => {
     const wrapper = await mount({
       calendarUrl: ['https://example.com/broken.ics', 'https://example.com/cal.ics'],
     });
-    expect(textOf(wrapper, '.event-title')).toEqual(['Team sync', 'Company offsite', 'Dentist']);
+    expect(titles(wrapper)).toHaveLength(3);
   });
 
   it('respects limit, hideAllDay and days', async () => {
-    const limited = await mount({ limit: 2 });
-    expect(textOf(limited, '.event-title')).toHaveLength(2);
+    expect(titles(await mount({ limit: 2 }))).toHaveLength(2);
 
-    const timedOnly = await mount({ hideAllDay: true });
-    expect(textOf(timedOnly, '.event-title')).toEqual(['Team sync', 'Dentist']);
+    expect(titles(await mount({ hideAllDay: true })))
+      .toEqual(['Standup, where nobody stands', 'Dentist, reluctantly']);
 
-    const today = await mount({ days: 1 });
-    expect(textOf(today, '.event-title')).toEqual(['Team sync', 'Company offsite']);
+    const today = titles(await mount({ days: 1 }));
+    expect(today).toContain('Standup, where nobody stands');
+    expect(today).not.toContain('Dentist, reluctantly');
   });
 
   it('links events that have a URL, and leaves the others as plain rows', async () => {
-    const wrapper = await mount();
-    const links = wrapper.findAll('a.event-row');
+    const links = (await mount()).findAll('a.event-row');
     expect(links).toHaveLength(1);
     expect(links[0].attributes('href')).toBe('https://example.com/appointment');
   });
 
   it('drops unsafe event URLs', async () => {
     request.mockResolvedValue({
-      data: feed(['UID:1', `DTSTART:${at(0, '140000')}`, 'SUMMARY:Dodgy',
+      data: feed(['UID:1', `DTSTART:${at(0, 10)}`, 'SUMMARY:Totally legitimate prize',
         // eslint-disable-next-line no-script-url
-        'URL:javascript:alert(1)'].join('\r\n')),
+        'URL:javascript:alert(1)']),
     });
-    const wrapper = await mount();
-    expect(wrapper.findAll('a.event-row')).toHaveLength(0);
+    expect((await mount()).findAll('a.event-row')).toHaveLength(0);
   });
 
-  it('shows the location and calendar name in the tooltip', async () => {
-    await mount({ calendarUrl: [{ url: 'https://example.com/cal.ics', name: 'Work' }] });
+  it('shows the location in the tooltip, and names the calendar only when there are several', async () => {
+    await mount();
+    expect(tooltips[0]).toContain('The broom cupboard');
+    expect(tooltips[0]).not.toContain('Work');
+
+    tooltips.length = 0;
+    await mount({
+      calendarUrl: [
+        { url: 'https://example.com/work.ics', name: 'Work' },
+        { url: 'https://example.com/home.ics' },
+      ],
+    });
     expect(tooltips[0]).toContain('Work');
-    expect(tooltips[0]).toContain('Room 2');
+  });
+
+  it('falls back to the feed\'s own name when the calendar has not been named', async () => {
+    request.mockResolvedValue({
+      data: ['BEGIN:VCALENDAR', 'X-WR-CALNAME:Bin collections',
+        `BEGIN:VEVENT\r\nUID:1\r\nDTSTART:${at(0, 10)}\r\nSUMMARY:Green bin\r\nEND:VEVENT`,
+        'END:VCALENDAR'].join('\r\n'),
+    });
+    await mount({ calendarUrl: ['https://example.com/a.ics', 'https://example.com/b.ics'] });
+    expect(tooltips[0]).toContain('Bin collections');
+  });
+
+  it('shows location and description inline, only when asked', async () => {
+    expect(textOf(await mount(), '.event-meta')).toEqual([]);
+
+    expect(textOf(await mount({ showLocation: true }), '.event-meta')[0])
+      .toBe('The broom cupboard');
+    expect(textOf(await mount({ showDescription: true }), '.event-meta')[0])
+      .toBe('Bring your own excuses');
+    expect(textOf(await mount({ showLocation: true, showDescription: true }), '.event-meta')[0])
+      .toBe('The broom cupboard · Bring your own excuses');
+  });
+
+  it('keeps showing an event that is underway, under today', async () => {
+    request.mockResolvedValue({
+      data: feed(['UID:1', `DTSTART:${at(0, 7)}`, `DTEND:${at(0, 18)}`, 'SUMMARY:All-day hackathon']),
+    });
+    const wrapper = await mount();
+    expect(titles(wrapper)).toEqual(['All-day hackathon']);
+    expect(textOf(wrapper, '.day-label')).toEqual(['widgets.calendar.today']);
   });
 
   it('reports a helpful message when no calendar is configured', async () => {
@@ -146,7 +188,7 @@ describe('Calendar widget', () => {
   });
 
   it('reports a message when the feed is not a calendar, without saying it is empty', async () => {
-    request.mockResolvedValue({ data: '<html>Login page</html>' });
+    request.mockResolvedValue({ data: '<html>Please log in</html>' });
     const wrapper = await mount();
     expect(wrapper.emitted().error[0][0]).toContain('Unable to parse calendar');
     expect(wrapper.find('.no-events').exists()).toBe(false);
@@ -154,7 +196,6 @@ describe('Calendar widget', () => {
 
   it('says so when there is nothing coming up', async () => {
     request.mockResolvedValue({ data: feed() });
-    const wrapper = await mount();
-    expect(wrapper.find('.no-events').text()).toBe('widgets.calendar.no-events');
+    expect((await mount()).find('.no-events').text()).toBe('widgets.calendar.no-events');
   });
 });

--- a/tests/unit/ics-parser.test.js
+++ b/tests/unit/ics-parser.test.js
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import { parseIcs } from '@/utils/IcsParser';
+
+/* Wrap VEVENT bodies in a minimal calendar */
+const calendar = (...events) => [
+  'BEGIN:VCALENDAR',
+  'VERSION:2.0',
+  ...events.map((event) => `BEGIN:VEVENT\r\n${event}\r\nEND:VEVENT`),
+  'END:VCALENDAR',
+].join('\r\n');
+
+const between = (from, to) => ({
+  start: Date.parse(`${from}T00:00:00Z`),
+  end: Date.parse(`${to}T00:00:00Z`),
+});
+
+const starts = (events) => events.map((event) => new Date(event.start).toISOString());
+const days = (events) => events.map((event) => new Date(event.start).toISOString().slice(0, 10));
+
+describe('IcsParser', () => {
+  it('rejects anything that is not a calendar', () => {
+    expect(() => parseIcs('<html>nope</html>', between('2026-01-01', '2026-12-31'))).toThrow();
+    expect(() => parseIcs('', between('2026-01-01', '2026-12-31'))).toThrow();
+  });
+
+  it('unfolds wrapped lines and unescapes text', () => {
+    const ics = calendar([
+      'UID:1',
+      'DTSTART:20260904T090000Z',
+      'SUMMARY:Quarterly planning\\, budget review',
+      'DESCRIPTION:First line\\nSecond line',
+      'LOCATION:Room A\\; upstairs\\, near the very long corridor that keeps',
+      '  going',
+    ].join('\r\n'));
+    const [event] = parseIcs(ics, between('2026-09-01', '2026-09-30'));
+    expect(event.summary).toBe('Quarterly planning, budget review');
+    expect(event.description).toBe('First line\nSecond line');
+    expect(event.location).toBe('Room A; upstairs, near the very long corridor that keeps going');
+  });
+
+  it('anchors all-day events to UTC, so the date never drifts', () => {
+    const ics = calendar([
+      'UID:1',
+      'DTSTART;VALUE=DATE:20261225',
+      'DTEND;VALUE=DATE:20261226',
+      'SUMMARY:Christmas Day',
+    ].join('\r\n'));
+    const [event] = parseIcs(ics, between('2026-12-01', '2026-12-31'));
+    expect(event.allDay).toBe(true);
+    expect(new Date(event.start).toISOString()).toBe('2026-12-25T00:00:00.000Z');
+  });
+
+  it('reads UTC times, and end times from either DTEND or DURATION', () => {
+    const ics = calendar(
+      ['UID:1', 'DTSTART:20260904T090000Z', 'DTEND:20260904T103000Z', 'SUMMARY:With end'].join('\r\n'),
+      ['UID:2', 'DTSTART:20260904T140000Z', 'DURATION:PT45M', 'SUMMARY:With duration'].join('\r\n'),
+    );
+    const events = parseIcs(ics, between('2026-09-01', '2026-09-30'));
+    expect(events[0].end - events[0].start).toBe(90 * 60 * 1000);
+    expect(events[1].end - events[1].start).toBe(45 * 60 * 1000);
+  });
+
+  it('holds a recurring meeting at the same local time across a DST change', () => {
+    const ics = calendar([
+      'UID:1',
+      'DTSTART;TZID=America/New_York:20261028T090000',
+      'DTEND;TZID=America/New_York:20261028T100000',
+      'RRULE:FREQ=WEEKLY;BYDAY=WE',
+      'SUMMARY:Weekly sync',
+    ].join('\r\n'));
+    const events = parseIcs(ics, between('2026-10-27', '2026-11-05'));
+    // New York is UTC-4 on 28 Oct, but UTC-5 on 4 Nov
+    expect(starts(events)).toEqual(['2026-10-28T13:00:00.000Z', '2026-11-04T14:00:00.000Z']);
+  });
+
+  it('expands a fortnightly rule, honouring INTERVAL', () => {
+    const ics = calendar([
+      'UID:1',
+      'DTSTART:20260907T100000Z',
+      'RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO',
+      'SUMMARY:Fortnightly',
+    ].join('\r\n'));
+    expect(days(parseIcs(ics, between('2026-09-01', '2026-10-20'))))
+      .toEqual(['2026-09-07', '2026-09-21', '2026-10-05', '2026-10-19']);
+  });
+
+  it('expands ordinal BYDAY, such as the third Tuesday of the month', () => {
+    const ics = calendar([
+      'UID:1',
+      'DTSTART:20260120T110000Z',
+      'RRULE:FREQ=MONTHLY;BYDAY=3TU',
+      'SUMMARY:Third Tuesday',
+    ].join('\r\n'));
+    expect(days(parseIcs(ics, between('2026-01-01', '2026-04-01'))))
+      .toEqual(['2026-01-20', '2026-02-17', '2026-03-17']);
+  });
+
+  it('expands negative BYMONTHDAY, such as the last day of the month', () => {
+    const ics = calendar([
+      'UID:1',
+      'DTSTART:20260131T080000Z',
+      'RRULE:FREQ=MONTHLY;BYMONTHDAY=-1',
+      'SUMMARY:Month end',
+    ].join('\r\n'));
+    expect(days(parseIcs(ics, between('2026-01-01', '2026-04-01'))))
+      .toEqual(['2026-01-31', '2026-02-28', '2026-03-31']);
+  });
+
+  it('applies BYSETPOS, such as the last weekday of the month', () => {
+    const ics = calendar([
+      'UID:1',
+      'DTSTART:20260130T170000Z',
+      'RRULE:FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1',
+      'SUMMARY:Last weekday',
+    ].join('\r\n'));
+    expect(days(parseIcs(ics, between('2026-01-01', '2026-03-01'))))
+      .toEqual(['2026-01-30', '2026-02-27']);
+  });
+
+  it('stops a rule at COUNT or UNTIL', () => {
+    const counted = calendar(['UID:1', 'DTSTART:20260907T090000Z',
+      'RRULE:FREQ=DAILY;COUNT=3', 'SUMMARY:Counted'].join('\r\n'));
+    expect(days(parseIcs(counted, between('2026-09-01', '2026-10-01'))))
+      .toEqual(['2026-09-07', '2026-09-08', '2026-09-09']);
+
+    const dated = calendar(['UID:1', 'DTSTART:20260907T090000Z',
+      'RRULE:FREQ=DAILY;UNTIL=20260909T090000Z', 'SUMMARY:Until'].join('\r\n'));
+    expect(days(parseIcs(dated, between('2026-09-01', '2026-10-01'))))
+      .toEqual(['2026-09-07', '2026-09-08', '2026-09-09']);
+  });
+
+  it('skips EXDATEs and adds RDATEs', () => {
+    const ics = calendar([
+      'UID:1',
+      'DTSTART:20260907T090000Z',
+      'RRULE:FREQ=DAILY;COUNT=3',
+      'EXDATE:20260908T090000Z',
+      'RDATE:20260912T090000Z',
+      'SUMMARY:Standup',
+    ].join('\r\n'));
+    expect(days(parseIcs(ics, between('2026-09-01', '2026-10-01'))))
+      .toEqual(['2026-09-07', '2026-09-09', '2026-09-12']);
+  });
+
+  it('replaces a single occurrence with its RECURRENCE-ID override', () => {
+    const ics = calendar(
+      ['UID:1', 'DTSTART:20260907T090000Z', 'RRULE:FREQ=DAILY;COUNT=3',
+        'SUMMARY:Standup'].join('\r\n'),
+      ['UID:1', 'RECURRENCE-ID:20260908T090000Z', 'DTSTART:20260908T160000Z',
+        'SUMMARY:Standup (moved)'].join('\r\n'),
+    );
+    const events = parseIcs(ics, between('2026-09-01', '2026-10-01'));
+    expect(starts(events)).toEqual([
+      '2026-09-07T09:00:00.000Z', '2026-09-08T16:00:00.000Z', '2026-09-09T09:00:00.000Z',
+    ]);
+    expect(events[1].summary).toBe('Standup (moved)');
+  });
+
+  it('ignores cancelled events and nested components', () => {
+    const ics = calendar(
+      ['UID:1', 'DTSTART:20260904T090000Z', 'SUMMARY:Cancelled', 'STATUS:CANCELLED'].join('\r\n'),
+      ['UID:2', 'DTSTART:20260904T100000Z', 'SUMMARY:Real', 'BEGIN:VALARM',
+        'TRIGGER:-PT10M', 'SUMMARY:Reminder', 'END:VALARM'].join('\r\n'),
+    );
+    const events = parseIcs(ics, between('2026-09-01', '2026-09-30'));
+    expect(events.map((event) => event.summary)).toEqual(['Real']);
+  });
+
+  it('only returns events that start within the window', () => {
+    const ics = calendar(
+      ['UID:1', 'DTSTART:20260801T090000Z', 'SUMMARY:Before'].join('\r\n'),
+      ['UID:2', 'DTSTART:20260915T090000Z', 'SUMMARY:During'].join('\r\n'),
+      ['UID:3', 'DTSTART:20261101T090000Z', 'SUMMARY:After'].join('\r\n'),
+    );
+    const events = parseIcs(ics, between('2026-09-01', '2026-10-01'));
+    expect(events.map((event) => event.summary)).toEqual(['During']);
+  });
+
+  it('falls back to local time for timezones it cannot resolve', () => {
+    const ics = calendar([
+      'UID:1',
+      'DTSTART;TZID=GMT Standard Time:20260904T090000',
+      'SUMMARY:Outlook style',
+    ].join('\r\n'));
+    const [event] = parseIcs(ics, between('2026-09-01', '2026-09-30'));
+    expect(new Date(event.start).getHours()).toBe(9);
+  });
+});

--- a/tests/unit/ics-parser.test.js
+++ b/tests/unit/ics-parser.test.js
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { parseIcs } from '@/utils/IcsParser';
 
-/* Wrap VEVENT bodies in a minimal calendar */
+/* Wrap one or more VEVENTs, each given as a list of lines, in a minimal calendar */
 const calendar = (...events) => [
   'BEGIN:VCALENDAR',
   'VERSION:2.0',
-  ...events.map((event) => `BEGIN:VEVENT\r\n${event}\r\nEND:VEVENT`),
+  ...events.map((lines) => ['BEGIN:VEVENT', ...lines, 'END:VEVENT'].join('\r\n')),
   'END:VCALENDAR',
 ].join('\r\n');
 
@@ -14,28 +14,33 @@ const between = (from, to) => ({
   end: Date.parse(`${to}T00:00:00Z`),
 });
 
+/* parseIcs returns the feed name alongside its events; most tests only want the events */
+const parse = (ics, range) => parseIcs(ics, range).events;
+
 const starts = (events) => events.map((event) => new Date(event.start).toISOString());
 const days = (events) => events.map((event) => new Date(event.start).toISOString().slice(0, 10));
+const titles = (events) => events.map((event) => event.summary);
 
 describe('IcsParser', () => {
-  it('rejects anything that is not a calendar', () => {
-    expect(() => parseIcs('<html>nope</html>', between('2026-01-01', '2026-12-31'))).toThrow();
-    expect(() => parseIcs('', between('2026-01-01', '2026-12-31'))).toThrow();
+  it('throws on a page that is not a calendar, rather than reporting it as empty', () => {
+    expect(() => parseIcs('<html>Please log in</html>', between('2026-01-01', '2026-12-31')))
+      .toThrow();
   });
 
   it('unfolds wrapped lines and unescapes text', () => {
     const ics = calendar([
       'UID:1',
       'DTSTART:20260904T090000Z',
-      'SUMMARY:Quarterly planning\\, budget review',
-      'DESCRIPTION:First line\\nSecond line',
-      'LOCATION:Room A\\; upstairs\\, near the very long corridor that keeps',
-      '  going',
-    ].join('\r\n'));
-    const [event] = parseIcs(ics, between('2026-09-01', '2026-09-30'));
-    expect(event.summary).toBe('Quarterly planning, budget review');
-    expect(event.description).toBe('First line\nSecond line');
-    expect(event.location).toBe('Room A; upstairs, near the very long corridor that keeps going');
+      'SUMMARY:Tabs vs spaces\\, the reckoning',
+      'DESCRIPTION:Bring snacks\\nAnd a helmet',
+      'LOCATION:The broom cupboard\\; second floor\\, past the humming server that',
+      '  nobody will admit to owning',
+    ]);
+    const [event] = parse(ics, between('2026-09-01', '2026-09-30'));
+    expect(event.summary).toBe('Tabs vs spaces, the reckoning');
+    expect(event.description).toBe('Bring snacks\nAnd a helmet');
+    expect(event.location)
+      .toBe('The broom cupboard; second floor, past the humming server that nobody will admit to owning');
   });
 
   it('anchors all-day events to UTC, so the date never drifts', () => {
@@ -44,20 +49,20 @@ describe('IcsParser', () => {
       'DTSTART;VALUE=DATE:20261225',
       'DTEND;VALUE=DATE:20261226',
       'SUMMARY:Christmas Day',
-    ].join('\r\n'));
-    const [event] = parseIcs(ics, between('2026-12-01', '2026-12-31'));
+    ]);
+    const [event] = parse(ics, between('2026-12-01', '2026-12-31'));
     expect(event.allDay).toBe(true);
-    expect(new Date(event.start).toISOString()).toBe('2026-12-25T00:00:00.000Z');
+    expect(starts([event])).toEqual(['2026-12-25T00:00:00.000Z']);
   });
 
-  it('reads UTC times, and end times from either DTEND or DURATION', () => {
+  it('reads end times from either DTEND or DURATION', () => {
     const ics = calendar(
-      ['UID:1', 'DTSTART:20260904T090000Z', 'DTEND:20260904T103000Z', 'SUMMARY:With end'].join('\r\n'),
-      ['UID:2', 'DTSTART:20260904T140000Z', 'DURATION:PT45M', 'SUMMARY:With duration'].join('\r\n'),
+      ['UID:1', 'DTSTART:20260904T090000Z', 'DTEND:20260904T103000Z', 'SUMMARY:Long lunch'],
+      ['UID:2', 'DTSTART:20260904T140000Z', 'DURATION:PT45M', 'SUMMARY:Quick chat'],
     );
-    const events = parseIcs(ics, between('2026-09-01', '2026-09-30'));
-    expect(events[0].end - events[0].start).toBe(90 * 60 * 1000);
-    expect(events[1].end - events[1].start).toBe(45 * 60 * 1000);
+    const [lunch, chat] = parse(ics, between('2026-09-01', '2026-09-30'));
+    expect(lunch.end - lunch.start).toBe(90 * 60 * 1000);
+    expect(chat.end - chat.start).toBe(45 * 60 * 1000);
   });
 
   it('holds a recurring meeting at the same local time across a DST change', () => {
@@ -66,11 +71,11 @@ describe('IcsParser', () => {
       'DTSTART;TZID=America/New_York:20261028T090000',
       'DTEND;TZID=America/New_York:20261028T100000',
       'RRULE:FREQ=WEEKLY;BYDAY=WE',
-      'SUMMARY:Weekly sync',
-    ].join('\r\n'));
-    const events = parseIcs(ics, between('2026-10-27', '2026-11-05'));
+      'SUMMARY:Weekly blameless post-mortem (mostly blame)',
+    ]);
     // New York is UTC-4 on 28 Oct, but UTC-5 on 4 Nov
-    expect(starts(events)).toEqual(['2026-10-28T13:00:00.000Z', '2026-11-04T14:00:00.000Z']);
+    expect(starts(parse(ics, between('2026-10-27', '2026-11-05'))))
+      .toEqual(['2026-10-28T13:00:00.000Z', '2026-11-04T14:00:00.000Z']);
   });
 
   it('expands a fortnightly rule, honouring INTERVAL', () => {
@@ -78,9 +83,9 @@ describe('IcsParser', () => {
       'UID:1',
       'DTSTART:20260907T100000Z',
       'RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO',
-      'SUMMARY:Fortnightly',
-    ].join('\r\n'));
-    expect(days(parseIcs(ics, between('2026-09-01', '2026-10-20'))))
+      'SUMMARY:Bin day (the good bin)',
+    ]);
+    expect(days(parse(ics, between('2026-09-01', '2026-10-20'))))
       .toEqual(['2026-09-07', '2026-09-21', '2026-10-05', '2026-10-19']);
   });
 
@@ -89,9 +94,9 @@ describe('IcsParser', () => {
       'UID:1',
       'DTSTART:20260120T110000Z',
       'RRULE:FREQ=MONTHLY;BYDAY=3TU',
-      'SUMMARY:Third Tuesday',
-    ].join('\r\n'));
-    expect(days(parseIcs(ics, between('2026-01-01', '2026-04-01'))))
+      'SUMMARY:Board game night, someone always flips the table',
+    ]);
+    expect(days(parse(ics, between('2026-01-01', '2026-04-01'))))
       .toEqual(['2026-01-20', '2026-02-17', '2026-03-17']);
   });
 
@@ -100,10 +105,21 @@ describe('IcsParser', () => {
       'UID:1',
       'DTSTART:20260131T080000Z',
       'RRULE:FREQ=MONTHLY;BYMONTHDAY=-1',
-      'SUMMARY:Month end',
-    ].join('\r\n'));
-    expect(days(parseIcs(ics, between('2026-01-01', '2026-04-01'))))
+      'SUMMARY:Remember what the invoices were for',
+    ]);
+    expect(days(parse(ics, between('2026-01-01', '2026-04-01'))))
       .toEqual(['2026-01-31', '2026-02-28', '2026-03-31']);
+  });
+
+  it('still finds occurrences of a rule that started years ago', () => {
+    const ics = calendar([
+      'UID:1',
+      'DTSTART:20160805T170000Z',
+      'RRULE:FREQ=MONTHLY;BYDAY=1WE',
+      'SUMMARY:All-hands, unchanged since 2016',
+    ]);
+    expect(days(parse(ics, between('2026-09-03', '2026-12-03'))))
+      .toEqual(['2026-10-07', '2026-11-04', '2026-12-02']);
   });
 
   it('applies BYSETPOS, such as the last weekday of the month', () => {
@@ -111,21 +127,24 @@ describe('IcsParser', () => {
       'UID:1',
       'DTSTART:20260130T170000Z',
       'RRULE:FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1',
-      'SUMMARY:Last weekday',
-    ].join('\r\n'));
-    expect(days(parseIcs(ics, between('2026-01-01', '2026-03-01'))))
+      'SUMMARY:Friday deploy, against all advice',
+    ]);
+    expect(days(parse(ics, between('2026-01-01', '2026-03-01'))))
       .toEqual(['2026-01-30', '2026-02-27']);
   });
 
   it('stops a rule at COUNT or UNTIL', () => {
-    const counted = calendar(['UID:1', 'DTSTART:20260907T090000Z',
-      'RRULE:FREQ=DAILY;COUNT=3', 'SUMMARY:Counted'].join('\r\n'));
-    expect(days(parseIcs(counted, between('2026-09-01', '2026-10-01'))))
+    const counted = calendar([
+      'UID:1', 'DTSTART:20260907T090000Z', 'RRULE:FREQ=DAILY;COUNT=3', 'SUMMARY:Three day juice cleanse',
+    ]);
+    expect(days(parse(counted, between('2026-09-01', '2026-10-01'))))
       .toEqual(['2026-09-07', '2026-09-08', '2026-09-09']);
 
-    const dated = calendar(['UID:1', 'DTSTART:20260907T090000Z',
-      'RRULE:FREQ=DAILY;UNTIL=20260909T090000Z', 'SUMMARY:Until'].join('\r\n'));
-    expect(days(parseIcs(dated, between('2026-09-01', '2026-10-01'))))
+    const dated = calendar([
+      'UID:1', 'DTSTART:20260907T090000Z', 'RRULE:FREQ=DAILY;UNTIL=20260909T090000Z',
+      'SUMMARY:Feed the neighbour\'s cat',
+    ]);
+    expect(days(parse(dated, between('2026-09-01', '2026-10-01'))))
       .toEqual(['2026-09-07', '2026-09-08', '2026-09-09']);
   });
 
@@ -136,53 +155,69 @@ describe('IcsParser', () => {
       'RRULE:FREQ=DAILY;COUNT=3',
       'EXDATE:20260908T090000Z',
       'RDATE:20260912T090000Z',
-      'SUMMARY:Standup',
-    ].join('\r\n'));
-    expect(days(parseIcs(ics, between('2026-09-01', '2026-10-01'))))
+      'SUMMARY:Standup, where nobody stands',
+    ]);
+    expect(days(parse(ics, between('2026-09-01', '2026-10-01'))))
       .toEqual(['2026-09-07', '2026-09-09', '2026-09-12']);
   });
 
   it('replaces a single occurrence with its RECURRENCE-ID override', () => {
     const ics = calendar(
-      ['UID:1', 'DTSTART:20260907T090000Z', 'RRULE:FREQ=DAILY;COUNT=3',
-        'SUMMARY:Standup'].join('\r\n'),
+      ['UID:1', 'DTSTART:20260907T090000Z', 'RRULE:FREQ=DAILY;COUNT=3', 'SUMMARY:Standup'],
       ['UID:1', 'RECURRENCE-ID:20260908T090000Z', 'DTSTART:20260908T160000Z',
-        'SUMMARY:Standup (moved)'].join('\r\n'),
+        'SUMMARY:Standup, moved so Dave can go to the dentist'],
     );
-    const events = parseIcs(ics, between('2026-09-01', '2026-10-01'));
+    const events = parse(ics, between('2026-09-01', '2026-10-01'));
     expect(starts(events)).toEqual([
       '2026-09-07T09:00:00.000Z', '2026-09-08T16:00:00.000Z', '2026-09-09T09:00:00.000Z',
     ]);
-    expect(events[1].summary).toBe('Standup (moved)');
+    expect(events[1].summary).toContain('moved');
   });
 
   it('ignores cancelled events and nested components', () => {
     const ics = calendar(
-      ['UID:1', 'DTSTART:20260904T090000Z', 'SUMMARY:Cancelled', 'STATUS:CANCELLED'].join('\r\n'),
-      ['UID:2', 'DTSTART:20260904T100000Z', 'SUMMARY:Real', 'BEGIN:VALARM',
-        'TRIGGER:-PT10M', 'SUMMARY:Reminder', 'END:VALARM'].join('\r\n'),
+      ['UID:1', 'DTSTART:20260904T090000Z', 'SUMMARY:Mandatory fun', 'STATUS:CANCELLED'],
+      ['UID:2', 'DTSTART:20260904T100000Z', 'SUMMARY:Actually happening',
+        'BEGIN:VALARM', 'TRIGGER:-PT10M', 'SUMMARY:Nag', 'END:VALARM'],
     );
-    const events = parseIcs(ics, between('2026-09-01', '2026-09-30'));
-    expect(events.map((event) => event.summary)).toEqual(['Real']);
+    expect(titles(parse(ics, between('2026-09-01', '2026-09-30'))))
+      .toEqual(['Actually happening']);
   });
 
-  it('only returns events that start within the window', () => {
+  it('only returns events overlapping the window', () => {
     const ics = calendar(
-      ['UID:1', 'DTSTART:20260801T090000Z', 'SUMMARY:Before'].join('\r\n'),
-      ['UID:2', 'DTSTART:20260915T090000Z', 'SUMMARY:During'].join('\r\n'),
-      ['UID:3', 'DTSTART:20261101T090000Z', 'SUMMARY:After'].join('\r\n'),
+      ['UID:1', 'DTSTART:20260801T090000Z', 'SUMMARY:Last month\'s regrets'],
+      ['UID:2', 'DTSTART:20260915T090000Z', 'SUMMARY:This week\'s chaos'],
+      ['UID:3', 'DTSTART:20261101T090000Z', 'SUMMARY:Next quarter\'s problem'],
     );
-    const events = parseIcs(ics, between('2026-09-01', '2026-10-01'));
-    expect(events.map((event) => event.summary)).toEqual(['During']);
+    expect(titles(parse(ics, between('2026-09-01', '2026-10-01'))))
+      .toEqual(['This week\'s chaos']);
+  });
+
+  it('keeps an event that began before the window but has not finished', () => {
+    const ics = calendar(
+      ['UID:1', 'DTSTART:20260831T090000Z', 'DTEND:20260901T170000Z', 'SUMMARY:Hackathon, hour 30'],
+      ['UID:2', 'DTSTART:20260831T090000Z', 'DTEND:20260831T170000Z', 'SUMMARY:Yesterday, finished'],
+      ['UID:3', 'DTSTART:20260830T090000Z', 'SUMMARY:No end time, so long gone'],
+    );
+    expect(titles(parse(ics, between('2026-09-01', '2026-10-01'))))
+      .toEqual(['Hackathon, hour 30']);
+  });
+
+  it('reads the feed name, for labelling a calendar the user has not named', () => {
+    const named = `BEGIN:VCALENDAR\r\nX-WR-CALNAME:Bins\\, and when to move them\r\nEND:VCALENDAR`;
+    expect(parseIcs(named, between('2026-09-01', '2026-10-01')).name)
+      .toBe('Bins, and when to move them');
+    expect(parseIcs(calendar(), between('2026-09-01', '2026-10-01')).name).toBe('');
   });
 
   it('falls back to local time for timezones it cannot resolve', () => {
     const ics = calendar([
       'UID:1',
       'DTSTART;TZID=GMT Standard Time:20260904T090000',
-      'SUMMARY:Outlook style',
-    ].join('\r\n'));
-    const [event] = parseIcs(ics, between('2026-09-01', '2026-09-30'));
+      'SUMMARY:Meeting booked by someone using Outlook',
+    ]);
+    const [event] = parse(ics, between('2026-09-01', '2026-09-30'));
     expect(new Date(event.start).getHours()).toBe(9);
   });
 });


### PR DESCRIPTION
### Category
Feature

### Overview

Implements calendar widget, to display feed of events from an ical feed.

### Issue Number
Fixes #1201
Fixes #1903

### Details

Works with Nextcloud, Google, Proton, iCloud, Outlook, Radicale,  Baïkal, etc. And any calendar which can surface an ical feed. Supports both `webcal://` and normal https route. Always needs to be proxied.

Allows for combining multiple calendars onto one feed, and color coding them. Supports all-day events, and can normalize date/time to local. 

Example:

```yaml
- type: calendar
  options:
    limit: 15
    calendarUrl:
      - url: https://calendar.google.com/calendar/ical/xxxx/private-xxxx/basic.ics
        name: Personal
        color: '#5cabca'
      - url: webcal://p12-calendars.icloud.com/published/2/xxxx
        name: Family
        color: '#e8j54a'
```

Or

```yaml
- type: calendar
  useProxy: true
  options:
    calendarUrl: https://www.footballcalculator.co.uk/calendar?team=West+Ham
    limit: 5
```

<img width="400" alt="Image" src="https://github.com/user-attachments/assets/07236947-3c93-482b-b5e6-d72f5ea01c61" />