### PR TITLE
Performance improvment for status check, and saftey of ping check

### DIFF
--- a/services/endpoints/ping-check.js
+++ b/services/endpoints/ping-check.js
@@ -6,6 +6,17 @@
 const ping = require('pingman');
 const net = require('net');
 
+// Upper bounds for user-supplied params, matching the documented pingCheck limits
+const MAX_COUNT = 5;
+const MAX_TIMEOUT = MAX_COUNT * 1000;
+
+/* Bounds a numeric param, falling back to the default when absent or out of range */
+const boundedParam = (value, fallback, max) => {
+  const num = Math.floor(Number(value));
+  if (!Number.isFinite(num) || num < 1) return fallback;
+  return Math.min(num, max);
+};
+
 /* Returned if the URL params are not present or correct */
 const immediateError = (render, error) => {
   render(JSON.stringify({
@@ -22,8 +33,8 @@ module.exports = (paramStr, render) => {
     // Get the url to check from query params
     const params = new URLSearchParams(paramStr.slice(paramStr.indexOf('?') + 1));
     const host = params.get('host') || '';
-    const count = Number(params.get('count')) || 2;
-    const timeout = Number(params.get('timeout')) || 2000;
+    const count = boundedParam(params.get('count'), 2, MAX_COUNT);
+    const timeout = boundedParam(params.get('timeout'), 2000, MAX_TIMEOUT);
     if (!host || typeof host !== 'string') {
       immediateError(render, 'Invalid host given for ping check.');
       return;

--- a/services/endpoints/ping-check.js
+++ b/services/endpoints/ping-check.js
@@ -6,9 +6,8 @@
 const ping = require('pingman');
 const net = require('net');
 
-// Upper bounds for user-supplied params, matching the documented pingCheck limits
+// Max ICMP packets per check, matching the documented pingCheckCount limit
 const MAX_COUNT = 5;
-const MAX_TIMEOUT = MAX_COUNT * 1000;
 
 /* Bounds a numeric param, falling back to the default when absent or out of range */
 const boundedParam = (value, fallback, max) => {
@@ -34,7 +33,7 @@ module.exports = (paramStr, render) => {
     const params = new URLSearchParams(paramStr.slice(paramStr.indexOf('?') + 1));
     const host = params.get('host') || '';
     const count = boundedParam(params.get('count'), 2, MAX_COUNT);
-    const timeout = boundedParam(params.get('timeout'), 2000, MAX_TIMEOUT);
+    const timeout = boundedParam(params.get('timeout'), 2000, count * 1000);
     if (!host || typeof host !== 'string') {
       immediateError(render, 'Invalid host given for ping check.');
       return;
@@ -42,7 +41,7 @@ module.exports = (paramStr, render) => {
     (async () => {
       try {
         const configuration = {
-          timeout: Math.round(timeout/1000),
+          timeout: Math.max(1, Math.round(timeout / 1000)),
           numberOfEchos: count,
           IPV4: net.isIPv4(host),
           IPV6: net.isIPv6(host),

--- a/services/endpoints/status-check.js
+++ b/services/endpoints/status-check.js
@@ -40,6 +40,7 @@ const makeRequest = (url, options, render) => {
     headers,
     maxRedirects,
     timeout: 10000,
+    ignoreResponseBody: true,
     httpsAgent: { rejectUnauthorized: !enableInsecure },
     validateUrl: validateTargetUrl,
   })

--- a/services/utils/request.js
+++ b/services/utils/request.js
@@ -100,6 +100,7 @@ function request(config) {
     maxRedirects = 5,
     timeout = 0,
     maxResponseSize = 0,
+    ignoreResponseBody = false,
     httpsAgent,
     validateUrl,
   } = config;
@@ -175,6 +176,39 @@ function request(config) {
           return;
         }
 
+        // Resolves (or rejects) the promise, from an already-complete response body
+        const finish = (raw) => {
+          let responseData;
+          try { responseData = JSON.parse(raw); } catch (_) { responseData = raw; }
+
+          const response = {
+            data: responseData,
+            status: res.statusCode,
+            statusText: res.statusMessage,
+            headers: res.headers,
+          };
+          // Expose raw request for socket access (non-enumerable, circular refs break stringify)
+          Object.defineProperty(response, 'request', {
+            value: req,
+            enumerable: false,
+          });
+
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            resolve(response);
+          } else {
+            reject(new RequestError(
+              `Request failed with status ${res.statusCode}`,
+              { response, code: res.statusCode },
+            ));
+          }
+        };
+        // If body not needed, can finish early with just status code
+        if (ignoreResponseBody) {
+          finish('');
+          req.destroy();
+          return;
+        }
+
         // Decompress response based on Content-Encoding (matching axios behavior)
         let stream = res;
         const encoding = (res.headers['content-encoding'] || '').toLowerCase();
@@ -209,33 +243,7 @@ function request(config) {
         });
         stream.on('end', () => {
           if (aborted) return;
-          const raw = Buffer.concat(chunks).toString('utf8');
-          let responseData;
-          try { responseData = JSON.parse(raw); } catch (_) { responseData = raw; }
-
-          const response = {
-            data: responseData,
-            status: res.statusCode,
-            statusText: res.statusMessage,
-            headers: res.headers,
-          };
-          // Expose the raw request object for socket access (status-check.js
-          // needs this). Defined as non-enumerable so JSON.stringify() skips
-          // it — the http.ClientRequest has circular socket references that
-          // would otherwise crash any endpoint forwarding the response.
-          Object.defineProperty(response, 'request', {
-            value: req,
-            enumerable: false,
-          });
-
-          if (res.statusCode >= 200 && res.statusCode < 300) {
-            resolve(response);
-          } else {
-            reject(new RequestError(
-              `Request failed with status ${res.statusCode}`,
-              { response, code: res.statusCode },
-            ));
-          }
+          finish(Buffer.concat(chunks).toString('utf8'));
         });
       });
 


### PR DESCRIPTION
### Category
Bugfix / Performance

### Overview
2 small perf fixes:
1. Adds bounds to the ping check for redirects and time
2. Disregard the response body for status checks (only status code + headers needed)

### Issue Number
No open issue, but this was reported by @ry2811 
